### PR TITLE
[ignitions] set realtime scheduler using Systemd's policy instead of chrony.conf

### DIFF
--- a/ignitions/common/files/opt/sbin/setup-chronyd-conf
+++ b/ignitions/common/files/opt/sbin/setup-chronyd-conf
@@ -46,7 +46,4 @@ smoothtime 400 0.001 leaponly
 
 # mlockall
 lock_all
-
-# set highest scheduling priority
-sched_priority 99
 EOF

--- a/ignitions/common/systemd/chronyd.service
+++ b/ignitions/common/systemd/chronyd.service
@@ -6,6 +6,8 @@ Conflicts=systemd-timesyncd.service ntpd.service
 
 [Service]
 Slice=machine.slice
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=99
 Type=simple
 KillMode=mixed
 Restart=on-failure


### PR DESCRIPTION
If sched_priority is specified in chrony.conf, the following log is output.
```
chrony[7]: 2018-12-27T23:00:12Z sched_setscheduler() failed
```