### PR TITLE
Bug fix: Do not skip UpdateSabakanContents() when quay.io auth is not set

### DIFF
--- a/worker/sabakan.go
+++ b/worker/sabakan.go
@@ -87,11 +87,7 @@ func (o *operator) UpdateSabakanContents(ctx context.Context, req *neco.UpdateRe
 	}
 
 	auth, err := o.getDockerAuth(ctx, o.storage)
-	if err == storage.ErrNotFound {
-		log.Info("sabakan: skipped uploading contents because Quay auth is not set", nil)
-		return nil
-	}
-	if err != nil {
+	if err != nil && err != storage.ErrNotFound {
 		return err
 	}
 


### PR DESCRIPTION
- This is missing change for #53 to skip uploading private container
images when quay.io auth is not set.
- It had to uploading only public container images by not only `neco
sabakan-upload`, but also `neco-worker`.