### PR TITLE
[setup-serf-tags] fix unit definitions

### DIFF
--- a/ignitions/common/systemd/setup-serf-tags.service
+++ b/ignitions/common/systemd/setup-serf-tags.service
@@ -2,6 +2,7 @@
 Description=Set serf tags
 Requires=serf.service
 After=serf.service
+PartOf=setup-serf-tags.timer
 
 [Service]
 Type=oneshot

--- a/ignitions/common/systemd/setup-serf-tags.timer
+++ b/ignitions/common/systemd/setup-serf-tags.timer
@@ -1,12 +1,10 @@
 [Unit]
-Description=Set serf tags
-PartOf=setup-serf-tags.service
+Description=Set serf tags periodically
 Requires=serf.service
 After=serf.service
 
 [Timer]
 OnCalendar=*-*-* *:*:0/20
-Persistent=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* "PartOf" was wrongly declared for the timer unit.
  It should be declared for the service unit.

* "Persistent" is not effective for netboot systems.