### PR TITLE
[etcdpasswd] install sudoers and sshd_config

### DIFF
--- a/dctest/setup.go
+++ b/dctest/setup.go
@@ -84,5 +84,11 @@ func TestSetup() {
 	It("should complete updates", func() {
 		By("Waiting for request to complete")
 		waitRequestComplete()
+
+		By("Installing sshd_config and sudoers")
+		for _, h := range []string{boot0, boot1, boot2} {
+			execSafeAt(h, "grep", "-q", "'^PasswordAuthentication.no$'", "/etc/ssh/sshd_config")
+			execSafeAt(h, "test", "-f", "/etc/sudoers.d/cybozu")
+		}
 	})
 }

--- a/dctest/setup.go
+++ b/dctest/setup.go
@@ -88,7 +88,7 @@ func TestSetup() {
 		By("Installing sshd_config and sudoers")
 		for _, h := range []string{boot0, boot1, boot2} {
 			execSafeAt(h, "grep", "-q", "'^PasswordAuthentication.no$'", "/etc/ssh/sshd_config")
-			execSafeAt(h, "test", "-f", "/etc/sudoers.d/cybozu")
+			execSafeAt(h, "sudo", "test", "-f", "/etc/sudoers.d/cybozu")
 		}
 	})
 }

--- a/progs/etcdpasswd/sshd.go
+++ b/progs/etcdpasswd/sshd.go
@@ -1,0 +1,129 @@
+package etcdpasswd
+
+// SshdConf is the contents for "/etc/ssh/sshd_config" file.
+const SshdConf = `#	$OpenBSD: sshd_config,v 1.101 2017/03/14 07:19:07 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+# Cybozu: NecoTask-220
+PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+# Cybozu: NecoTask-220
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+# Cybozu: NecoTask-220
+PasswordAuthentication no
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+`

--- a/progs/etcdpasswd/sudoers.go
+++ b/progs/etcdpasswd/sudoers.go
@@ -1,0 +1,37 @@
+package etcdpasswd
+
+import "os"
+
+const (
+	sudoers = "%sudo   ALL=(ALL:ALL) NOPASSWD: ALL\n"
+)
+
+// InstallSudoers installs "/etc/sudoers.d/cybozu" file safely.
+func InstallSudoers() error {
+	const dest = "/etc/sudoers.d/cybozu"
+	_, err := os.Stat(dest)
+	if err == nil {
+		return nil
+	}
+
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	f, err := os.OpenFile("/etc/sudoers.d/.cybozu", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0440)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(sudoers)
+	if err != nil {
+		return err
+	}
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(f.Name(), dest)
+}

--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -12,6 +12,16 @@ import (
 )
 
 func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest) error {
+	_, err := replaceFile("/etc/ssh/sshd_config", []byte(etcdpasswd.SshdConf), 0644)
+	if err != nil {
+		return err
+	}
+
+	err = etcdpasswd.InstallSudoers()
+	if err != nil {
+		return err
+	}
+
 	replaced, err := o.replaceEtcdpasswdFiles(ctx, req.Servers)
 	if err != nil {
 		return err


### PR DESCRIPTION
Although etcdpasswd assumes password-less operations, neco did not install
requisite changes for ssh and sudoers.

With this PR, sshd is configured as follows:

* Enable `PubKeyAuthentication`
* Disable `PasswordAuthentication`
* Disregard `.ssh/authorized_keys2`

Users who belong to `sudo` group will not be asked their passwords when using `sudo`.