### PR TITLE
[circleci] merge origin/master instead of master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
             git config --global user.email "neco@cybozu.com"
             git config --global user.name "cybozu-neco"
       - run: git checkout release
-      - run: git merge --no-commit master
+      - run: git merge --no-commit origin/master
       - run: cp /tmp/workspace/artifacts_release.go .
       - run: 
           name: Check diff


### PR DESCRIPTION
Because CircleCI resets `master` at the head of working branch (in this case `release`) while
checking out the code, `git merge master` would have no effect.

`git merge origin/master` works as expected.