### PR TITLE
Update ignitions and ipam.json for sabakan 1.0.1

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -8,7 +8,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "0.27-1"},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.9-4"},
 		{Name: "omsa", Repository: "quay.io/cybozu/omsa", Tag: "18.11.01-1"},
-		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.0.0-1"},
+		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.0.1-1"},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.8.1-4"},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "0.11.0-4"},
 		{Name: "hyperkube", Repository: "quay.io/cybozu/hyperkube", Tag: "1.12.3-2"},

--- a/artifacts.go
+++ b/artifacts.go
@@ -8,7 +8,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "0.27-1"},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.9-4"},
 		{Name: "omsa", Repository: "quay.io/cybozu/omsa", Tag: "18.11.01-1"},
-		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "0.31-1"},
+		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.0.0-1"},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.8.1-4"},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "0.11.0-4"},
 		{Name: "hyperkube", Repository: "quay.io/cybozu/hyperkube", Tag: "1.12.3-2"},

--- a/artifacts_new.go
+++ b/artifacts_new.go
@@ -8,7 +8,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "0.28-1"},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.10-1"},
 		{Name: "omsa", Repository: "quay.io/cybozu/omsa", Tag: "18.11.01-1"},
-		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.0.0-1"},
+		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.0.1-1"},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.8.1-5"},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.0.0-1"},
 		{Name: "hyperkube", Repository: "quay.io/cybozu/hyperkube", Tag: "1.13.0-1"},

--- a/artifacts_new.go
+++ b/artifacts_new.go
@@ -8,7 +8,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "0.28-1"},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.10-1"},
 		{Name: "omsa", Repository: "quay.io/cybozu/omsa", Tag: "18.11.01-1"},
-		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "0.31-1"},
+		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.0.0-1"},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.8.1-5"},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.0.0-1"},
 		{Name: "hyperkube", Repository: "quay.io/cybozu/hyperkube", Tag: "1.13.0-1"},

--- a/etc/ipam.json
+++ b/etc/ipam.json
@@ -8,5 +8,6 @@
    "bmc-ipv4-pool": "10.72.16.0/20",
    "bmc-ipv4-offset": "0.0.1.0",
    "bmc-ipv4-range-size": 5,
-   "bmc-ipv4-range-mask": 20
+   "bmc-ipv4-range-mask": 20,
+   "bmc-ipv4-gateway-offset": 1
 }

--- a/ignitions/common/files/etc/hostname
+++ b/ignitions/common/files/etc/hostname
@@ -1,1 +1,1 @@
-rack{{ .Rack }}-{{ .Role }}{{ .IndexInRack }}
+rack{{ .Spec.Rack }}-{{ .Spec.Role }}{{ .Spec.IndexInRack }}

--- a/ignitions/common/files/etc/neco/rack
+++ b/ignitions/common/files/etc/neco/rack
@@ -1,1 +1,1 @@
-{{ .Rack }}
+{{ .Spec.Rack }}

--- a/ignitions/common/files/opt/sbin/setup-hw
+++ b/ignitions/common/files/opt/sbin/setup-hw
@@ -2,7 +2,7 @@
 
 if systemd-detect-virt -v >/dev/null; then
     # notify BMC address to placemat
-    echo {{ .BMC.IPv4 }} > /dev/virtio-ports/placemat
+    echo {{ .Spec.BMC.IPv4 }} > /dev/virtio-ports/placemat
     echo >&2 "Setup succeeded"
     exit 0
 fi
@@ -33,7 +33,7 @@ if test_scheduled_jobqueue; then
 fi
 
 rkt enter --app=omsa $uuid setup-hw \
-    --rac-name rack{{ .Rack }}-{{ .Role }}{{ .IndexInRack }}-idrac
+    --rac-name rack{{ .Spec.Rack }}-{{ .Spec.Role }}{{ .Spec.IndexInRack }}-idrac
 
 if test_scheduled_jobqueue; then
     echo >&2 "Setup succeeded, machine will reboot"

--- a/ignitions/common/files/opt/sbin/setup-local-network
+++ b/ignitions/common/files/opt/sbin/setup-local-network
@@ -16,7 +16,7 @@ LLDP=true
 EmitLLDP=nearest-bridge
 
 [Address]
-Address={{ index .IPv4 1 }}/26
+Address={{ index .Spec.IPv4 1 }}/26
 Scope=link
 EOF
 
@@ -29,7 +29,7 @@ LLDP=true
 EmitLLDP=nearest-bridge
 
 [Address]
-Address={{ index .IPv4 2 }}/26
+Address={{ index .Spec.IPv4 2 }}/26
 Scope=link
 EOF
 

--- a/ignitions/common/files/opt/sbin/setup-omsa
+++ b/ignitions/common/files/opt/sbin/setup-omsa
@@ -3,5 +3,5 @@
 # setup config
 mkdir -p /etc/neco
 curl -sfSL -o /tmp/omsa.json {{ MyURL }}/api/v1/assets/omsa.json
-jq '. | .bmc_address = "{{ .BMC.IPv4 }}"' /tmp/omsa.json >/etc/neco/omsa.json
+jq '. | .bmc_address = "{{ .Spec.BMC.IPv4 }}"' /tmp/omsa.json >/etc/neco/omsa.json
 rm -f /tmp/omsa.json

--- a/ignitions/common/networkd/10-node0.network
+++ b/ignitions/common/networkd/10-node0.network
@@ -2,4 +2,4 @@
 Name=node0
 
 [Network]
-Address={{ index .IPv4 0 }}/32
+Address={{ index .Spec.IPv4 0 }}/32

--- a/progs/etcd/templates.go
+++ b/progs/etcd/templates.go
@@ -1,6 +1,6 @@
 package etcd
 
-import "html/template"
+import "text/template"
 
 var confTmpl = template.Must(template.New("etcd.conf.yml").
 	Parse(`# This is the configuration file for the etcd server.

--- a/progs/sabakan/template.go
+++ b/progs/sabakan/template.go
@@ -1,6 +1,6 @@
 package sabakan
 
-import "html/template"
+import "text/template"
 
 var serviceTmpl = template.Must(template.New("sabakan.service").Parse(`[Unit]
 Description=Sabakan container on rkt

--- a/progs/serf/templates.go
+++ b/progs/serf/templates.go
@@ -1,6 +1,6 @@
 package serf
 
-import "html/template"
+import "text/template"
 
 type tags struct {
 	OsName    string `json:"os-name"`

--- a/progs/vault/templates.go
+++ b/progs/vault/templates.go
@@ -1,6 +1,6 @@
 package vault
 
-import "html/template"
+import "text/template"
 
 var confTmpl = template.Must(template.New("vault.hcl").
 	Parse(`# vault configuration file

--- a/setup/etcd_backup.go
+++ b/setup/etcd_backup.go
@@ -3,9 +3,9 @@ package setup
 import (
 	"bytes"
 	"context"
-	"html/template"
 	"io/ioutil"
 	"os"
+	"text/template"
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"


### PR DESCRIPTION
Because sabakan 1.0.0 breaks backward compatibility for ignition
template syntax and ipam.json, they need to be updated.