### PR TITLE
Support GitHub access token for checking GitHub release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ jobs:
           command: |
             echo "$QUAY_PASSWORD" > secrets
       - run:
+          name: Store neco-updater-token
+          command: |
+            echo "$NECO_UPDATER_TOKEN" > neco-updater-token
+      - run:
           name: Watch console on boot-0
           command: |
             ./bin/watch_boot0
@@ -119,6 +123,10 @@ jobs:
           command: |
             if [ ! -f .diff ]; then exit 0; fi
             echo "$QUAY_PASSWORD" > secrets
+      - run:
+          name: Store neco-updater-token
+          command: |
+            echo "$NECO_UPDATER_TOKEN" > neco-updater-token
       - run:
           name: Watch console on boot-0
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ jobs:
           command: |
             echo "$QUAY_PASSWORD" > secrets
       - run:
-          name: Store neco-updater-token
+          name: Store github-token
           command: |
-            echo "$NECO_UPDATER_TOKEN" > neco-updater-token
+            echo "$NECO_GITHUB_TOKEN" > github-token
       - run:
           name: Watch console on boot-0
           command: |
@@ -124,9 +124,9 @@ jobs:
             if [ ! -f .diff ]; then exit 0; fi
             echo "$QUAY_PASSWORD" > secrets
       - run:
-          name: Store neco-updater-token
+          name: Store github-token
           command: |
-            echo "$NECO_UPDATER_TOKEN" > neco-updater-token
+            echo "$NECO_GITHUB_TOKEN" > github-token
       - run:
           name: Watch console on boot-0
           command: |

--- a/bin/run-dctest.sh
+++ b/bin/run-dctest.sh
@@ -46,6 +46,7 @@ git checkout -qf ${CIRCLE_SHA1}
 
 cd dctest
 cp /home/cybozu/secrets .
+cp /home/cybozu/neco-updater-token .
 cp /assets/cybozu-ubuntu-18.04-server-cloudimg-amd64.img .
 export GO111MODULE=on
 make setup
@@ -54,5 +55,6 @@ EOF
 chmod +x run.sh
 
 $GCLOUD compute scp --zone=${ZONE} secrets cybozu@${INSTANCE_NAME}:
+$GCLOUD compute scp --zone=${ZONE} neco-updater-token cybozu@${INSTANCE_NAME}:
 $GCLOUD compute scp --zone=${ZONE} run.sh cybozu@${INSTANCE_NAME}:
 $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command='sudo /home/cybozu/run.sh'

--- a/bin/run-dctest.sh
+++ b/bin/run-dctest.sh
@@ -46,7 +46,7 @@ git checkout -qf ${CIRCLE_SHA1}
 
 cd dctest
 cp /home/cybozu/secrets .
-cp /home/cybozu/neco-updater-token .
+cp /home/cybozu/github-token .
 cp /assets/cybozu-ubuntu-18.04-server-cloudimg-amd64.img .
 export GO111MODULE=on
 make setup
@@ -55,6 +55,6 @@ EOF
 chmod +x run.sh
 
 $GCLOUD compute scp --zone=${ZONE} secrets cybozu@${INSTANCE_NAME}:
-$GCLOUD compute scp --zone=${ZONE} neco-updater-token cybozu@${INSTANCE_NAME}:
+$GCLOUD compute scp --zone=${ZONE} github-token cybozu@${INSTANCE_NAME}:
 $GCLOUD compute scp --zone=${ZONE} run.sh cybozu@${INSTANCE_NAME}:
 $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command='sudo /home/cybozu/run.sh'

--- a/dctest/machines.go
+++ b/dctest/machines.go
@@ -15,7 +15,11 @@ func TestMachines() {
 	It("should put BMC/IPMI settings", func() {
 		execSafeAt(boot0, "neco", "bmc", "config", "set", "bmc-user", "/mnt/bmc-user.json")
 		execSafeAt(boot0, "neco", "bmc", "config", "set", "ipmi-user", "cybozu")
+		ipmiUser := execSafeAt(boot0, "neco", "bmc", "config", "get", "ipmi-user")
+		Expect(string(ipmiUser)).To(Equal("cybozu"))
 		execSafeAt(boot0, "neco", "bmc", "config", "set", "ipmi-password", "cybozu")
+		ipmiPassword := execSafeAt(boot0, "neco", "bmc", "config", "get", "ipmi-password")
+		Expect(string(ipmiPassword)).To(Equal("cybozu"))
 	})
 
 	It("should setup boot server hardware", func() {

--- a/dctest/machines.go
+++ b/dctest/machines.go
@@ -16,10 +16,10 @@ func TestMachines() {
 		execSafeAt(boot0, "neco", "bmc", "config", "set", "bmc-user", "/mnt/bmc-user.json")
 		execSafeAt(boot0, "neco", "bmc", "config", "set", "ipmi-user", "cybozu")
 		ipmiUser := execSafeAt(boot0, "neco", "bmc", "config", "get", "ipmi-user")
-		Expect(string(ipmiUser)).To(Equal("cybozu"))
+		Expect(string(ipmiUser)).To(Equal("cybozu\n"))
 		execSafeAt(boot0, "neco", "bmc", "config", "set", "ipmi-password", "cybozu")
 		ipmiPassword := execSafeAt(boot0, "neco", "bmc", "config", "get", "ipmi-password")
-		Expect(string(ipmiPassword)).To(Equal("cybozu"))
+		Expect(string(ipmiPassword)).To(Equal("cybozu\n"))
 	})
 
 	It("should setup boot server hardware", func() {

--- a/dctest/upgrade.go
+++ b/dctest/upgrade.go
@@ -1,8 +1,11 @@
 package dctest
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -15,6 +18,24 @@ import (
 // TestUpgrade test neco debian package upgrade scenario
 func TestUpgrade() {
 	It("should update neco package", func() {
+		By("setting github-token if a token exists", func() {
+			data, err := ioutil.ReadFile("../neco-updater-token")
+			switch {
+			case err == nil:
+				By("setting github-token")
+
+				token := string(bytes.TrimSpace(data))
+				_, _, err = execAt(boot0, "neco", "config", "set", "github-token", token)
+				Expect(err).NotTo(HaveOccurred())
+				stdout, _, err := execAt(boot0, "neco", "config", "get", "github-token")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(stdout)).To(Equal(token))
+			case os.IsNotExist(err):
+			default:
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
 		By("Changing env for test")
 		_, _, err := execAt(boot0, "neco", "config", "set", "env", "test")
 		Expect(err).ShouldNot(HaveOccurred())

--- a/dctest/upgrade.go
+++ b/dctest/upgrade.go
@@ -18,7 +18,7 @@ import (
 // TestUpgrade test neco debian package upgrade scenario
 func TestUpgrade() {
 	It("should update neco package", func() {
-		data, err := ioutil.ReadFile("../neco-updater-token")
+		data, err := ioutil.ReadFile("../github-token")
 		switch {
 		case err == nil:
 			By("setting github-token")

--- a/dctest/upgrade.go
+++ b/dctest/upgrade.go
@@ -18,26 +18,24 @@ import (
 // TestUpgrade test neco debian package upgrade scenario
 func TestUpgrade() {
 	It("should update neco package", func() {
-		By("setting github-token if a token exists", func() {
-			data, err := ioutil.ReadFile("../neco-updater-token")
-			switch {
-			case err == nil:
-				By("setting github-token")
+		data, err := ioutil.ReadFile("../neco-updater-token")
+		switch {
+		case err == nil:
+			By("setting github-token")
 
-				token := string(bytes.TrimSpace(data))
-				_, _, err = execAt(boot0, "neco", "config", "set", "github-token", token)
-				Expect(err).NotTo(HaveOccurred())
-				stdout, _, err := execAt(boot0, "neco", "config", "get", "github-token")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(string(stdout)).To(Equal(token))
-			case os.IsNotExist(err):
-			default:
-				Expect(err).NotTo(HaveOccurred())
-			}
-		})
+			token := string(bytes.TrimSpace(data))
+			_, _, err = execAt(boot0, "neco", "config", "set", "github-token", token)
+			Expect(err).NotTo(HaveOccurred())
+			stdout, _, err := execAt(boot0, "neco", "config", "get", "github-token")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(stdout)).To(Equal(token + "\n"))
+		case os.IsNotExist(err):
+		default:
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 		By("Changing env for test")
-		_, _, err := execAt(boot0, "neco", "config", "set", "env", "test")
+		_, _, err = execAt(boot0, "neco", "config", "set", "env", "test")
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("Wait for systemd unit files to be updated")

--- a/docs/dctest.md
+++ b/docs/dctest.md
@@ -38,7 +38,7 @@ Options
 dctest runs `neco config set quay-username` and `neco config set quay-password` automatically when `secrets` file exists.
 To upload private container images for sabakan, put quay.io password in `dctest/secrets`.
 
-## `neco-updater-token` file
+## `github-token` file
 
-`neco-updater` watches GitHub release without authentication by default. It would receive rate limits of the GitHub API.
-dctest runs `neco config set github-token` automatically when `neco-updater-token` file exists.
+`neco-updater` watches GitHub release without authentication by default. `neco-worker` also watches it to download debian packages.
+It would receive rate limits of the GitHub API. dctest runs `neco config set github-token` automatically when `github-token` file exists.

--- a/docs/dctest.md
+++ b/docs/dctest.md
@@ -37,3 +37,8 @@ Options
 `neco sabakan-upload` supports uploading private container images where are in quay.io.
 dctest runs `neco config set quay-username` and `neco config set quay-password` automatically when `secrets` file exists.
 To upload private container images for sabakan, put quay.io password in `dctest/secrets`.
+
+## `neco-updater-token` file
+
+`neco-updater` watches GitHub release without authentication by default. It would receive rate limits of the GitHub API.
+dctest runs `neco config set github-token` automatically when `neco-updater-token` file exists.

--- a/docs/etcd.md
+++ b/docs/etcd.md
@@ -136,6 +136,10 @@ Polling interval for checking new neco release in nanoseconds.
 
 Timeout from workers in nanoseconds.
 
+## `<prefix>/config/github-token`
+
+GitHub personal access token.
+
 ## `<prefix>/vault-unseal-key`
 
 Vault unseal key for unsealing automatically.

--- a/docs/neco-updater.md
+++ b/docs/neco-updater.md
@@ -19,5 +19,5 @@ process is completed or stopped. This URL keeps on memory to prevent
 etcd connection refused.
 
 It also periodically checks GitHub release of this repository.
-To prevent rate limits for GitHub, It is highly recommended that
+To prevent rate limits for GitHub, it is highly recommended that
 set personal access token by `neco config set github-token TOKEN`.

--- a/docs/neco-updater.md
+++ b/docs/neco-updater.md
@@ -16,5 +16,6 @@ Option     | Default value          | Description
 
 `neco-updater` will notify status to webhook URL when update
 process is completed or stopped. This URL keeps on memory to prevent
-etcd connection refused.
+etcd connection refused. To prevent rate limits for GitHub, It recommends
+to set personal access token by `neco config set github-token TOKEN`.
 

--- a/docs/neco-updater.md
+++ b/docs/neco-updater.md
@@ -16,6 +16,8 @@ Option     | Default value          | Description
 
 `neco-updater` will notify status to webhook URL when update
 process is completed or stopped. This URL keeps on memory to prevent
-etcd connection refused. To prevent rate limits for GitHub, It recommends
-to set personal access token by `neco config set github-token TOKEN`.
+etcd connection refused.
 
+It also periodically checks GitHub release of this repository.
+To prevent rate limits for GitHub, It is highly recommended that
+set personal access token by `neco config set github-token TOKEN`.

--- a/docs/neco-worker.md
+++ b/docs/neco-worker.md
@@ -26,6 +26,6 @@ Updating programs
 When there is a new version of neco, it updates itself by installing
 the new debian package, then start automatic update process.
 
-It also checks latest GitHub release of debian package such as `etcdpasswd`.
-To prevent rate limits for GitHub, It is highly recommended that
+It also checks latest GitHub release of debian package such as `etcdpasswd` and `neco`.
+To prevent GitHub rate limits, It is highly recommended that
 set personal access token by `neco config set github-token TOKEN`.

--- a/docs/neco-worker.md
+++ b/docs/neco-worker.md
@@ -27,5 +27,5 @@ When there is a new version of neco, it updates itself by installing
 the new debian package, then start automatic update process.
 
 It also checks latest GitHub release of debian package such as `etcdpasswd` and `neco`.
-To prevent GitHub rate limits, It is highly recommended that
+To prevent GitHub rate limits, it is highly recommended that
 set personal access token by `neco config set github-token TOKEN`.

--- a/docs/neco-worker.md
+++ b/docs/neco-worker.md
@@ -26,3 +26,6 @@ Updating programs
 When there is a new version of neco, it updates itself by installing
 the new debian package, then start automatic update process.
 
+It also checks latest GitHub release of debian package such as `etcdpasswd`.
+To prevent rate limits for GitHub, It is highly recommended that
+set personal access token by `neco config set github-token TOKEN`.

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -208,8 +208,8 @@ The default value is `60m`.
 
 ### `github-token`
 
-Set GitHub personal access token for checking GitHub release with authenticated user.
-It will be used by `neco-updater`.
+Set GitHub personal access token for using GitHub API with authenticated user.
+It will be used by `neco-updater` and `neco-worker`.
 
 Use case
 --------

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -206,6 +206,11 @@ The value will be parsed by [`time.ParseDuration`][ParseDuration].
 
 The default value is `60m`.
 
+### `github-token`
+
+Set GitHub personal access token for checking GitHub release with authenticated user.
+It will be used by `neco-updater`.
+
 Use case
 --------
 

--- a/ext/http.go
+++ b/ext/http.go
@@ -74,11 +74,11 @@ func ProxyHTTPClientWithGitHubToken(ctx context.Context, st storage.Storage) (*h
 	}
 
 	token, err := st.GetGitHubToken(ctx)
+	if err == storage.ErrNotFound {
+		return hc, nil
+	}
 	if err != nil {
 		return nil, err
-	}
-	if len(token) == 0 {
-		return hc, nil
 	}
 
 	// Set personal access token

--- a/ext/http.go
+++ b/ext/http.go
@@ -77,7 +77,7 @@ func ProxyHTTPClientWithGitHubToken(ctx context.Context, st storage.Storage) (*h
 	if err != nil {
 		return nil, err
 	}
-	if len(token) != 0 {
+	if len(token) == 0 {
 		return hc, nil
 	}
 

--- a/ext/http.go
+++ b/ext/http.go
@@ -65,9 +65,9 @@ func LocalHTTPClient() *http.Client {
 	}
 }
 
-// ProxyHTTPClientWithGitHubToken returns a *http.Client to access Internet with GitHub personal access token.
+// GitHubHTTPClient returns a *http.Client to access Internet with GitHub personal access token.
 // It returns *http.Client of ProxyHTTPClient() when token does not exist.
-func ProxyHTTPClientWithGitHubToken(ctx context.Context, st storage.Storage) (*http.Client, error) {
+func GitHubHTTPClient(ctx context.Context, st storage.Storage) (*http.Client, error) {
 	hc, err := ProxyHTTPClient(ctx, st)
 	if err != nil {
 		return nil, err

--- a/ext/http.go
+++ b/ext/http.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cybozu-go/neco/storage"
+	"golang.org/x/oauth2"
 )
 
 // ProxyHTTPClient returns a *http.Client to access Internet.
@@ -62,4 +63,28 @@ func LocalHTTPClient() *http.Client {
 		Transport: transport,
 		Timeout:   10 * time.Minute,
 	}
+}
+
+// ProxyHTTPClientWithGitHubToken returns a *http.Client to access Internet with GitHub personal access token.
+// It returns *http.Client of ProxyHTTPClient() when token does not exist.
+func ProxyHTTPClientWithGitHubToken(ctx context.Context, st storage.Storage) (*http.Client, error) {
+	hc, err := ProxyHTTPClient(ctx, st)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := st.GetGitHubToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(token) != 0 {
+		return hc, nil
+	}
+
+	// Set personal access token
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	// Add proxy http client to oauth2 generated http.Client
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, hc)
+	// Create access token and proxy configuration included *http.Client
+	return oauth2.NewClient(ctx, ts), nil
 }

--- a/pkg/neco/cmd/bmc_config_get_ipmipassword.go
+++ b/pkg/neco/cmd/bmc_config_get_ipmipassword.go
@@ -15,7 +15,7 @@ var bmcConfigGetIPMIPasswordCmd = &cobra.Command{
 	Use:   "ipmi-password",
 	Short: "show the current IPMI password",
 	Long:  `Show the current IPMI password.`,
-	Args:  cobra.ExactArgs(0),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		etcd, err := neco.EtcdClient()
 		if err != nil {

--- a/pkg/neco/cmd/bmc_config_get_ipmipassword.go
+++ b/pkg/neco/cmd/bmc_config_get_ipmipassword.go
@@ -15,7 +15,7 @@ var bmcConfigGetIPMIPasswordCmd = &cobra.Command{
 	Use:   "ipmi-password",
 	Short: "show the current IPMI password",
 	Long:  `Show the current IPMI password.`,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		etcd, err := neco.EtcdClient()
 		if err != nil {

--- a/pkg/neco/cmd/bmc_config_get_ipmiuser.go
+++ b/pkg/neco/cmd/bmc_config_get_ipmiuser.go
@@ -15,7 +15,7 @@ var bmcConfigGetIPMIUserCmd = &cobra.Command{
 	Use:   "ipmi-user",
 	Short: "show the current IPMI username",
 	Long:  `show the current IPMI username.`,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		etcd, err := neco.EtcdClient()
 		if err != nil {

--- a/pkg/neco/cmd/config_get.go
+++ b/pkg/neco/cmd/config_get.go
@@ -25,7 +25,7 @@ Possible keys are:
     quay-username         - Username to authenticate to quay.io.
     check-update-interval - Polling interval for checking new neco release.
     worker-timeout        - Timeout value to wait for workers.
-    github-token          - GitHub OAuth2 access token for checking GitHub release.`,
+    github-token          - GitHub personal access token for checking GitHub release.`,
 
 	Args: cobra.ExactArgs(1),
 	ValidArgs: []string{

--- a/pkg/neco/cmd/config_get.go
+++ b/pkg/neco/cmd/config_get.go
@@ -24,7 +24,8 @@ Possible keys are:
     proxy                 - HTTP proxy server URL to access Internet.
     quay-username         - Username to authenticate to quay.io.
     check-update-interval - Polling interval for checking new neco release.
-    worker-timeout        - Timeout value to wait for workers.`,
+    worker-timeout        - Timeout value to wait for workers.
+    github-token          - GitHub OAuth2 access token for checking GitHub release.`,
 
 	Args: cobra.ExactArgs(1),
 	ValidArgs: []string{
@@ -34,6 +35,7 @@ Possible keys are:
 		"quay-username",
 		"check-update-interval",
 		"worker-timeout",
+		"github-token",
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		etcd, err := neco.EtcdClient()
@@ -81,6 +83,12 @@ Possible keys are:
 					return err
 				}
 				fmt.Println(timeout.String())
+			case "github-token":
+				token, err := st.GetGitHubToken(ctx)
+				if err != nil {
+					return err
+				}
+				fmt.Println(token)
 			default:
 				return errors.New("unknown key: " + key)
 			}

--- a/pkg/neco/cmd/config_set.go
+++ b/pkg/neco/cmd/config_set.go
@@ -28,7 +28,8 @@ Possible keys are:
     quay-username         - Username to authenticate to quay.io from QUAY_USER.  This does not take VALUE.
     quay-password         - Password to authenticate to quay.io from QUAY_PASSWORD.  This does not take VALUE.
     check-update-interval - Polling interval for checking new neco release.
-    worker-timeout        - Timeout value to wait for workers.`,
+    worker-timeout        - Timeout value to wait for workers.
+    github-token          - GitHub OAuth2 access token for checking GitHub release.`,
 
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
@@ -54,6 +55,7 @@ Possible keys are:
 		"quay-password",
 		"check-update-interval",
 		"worker-timeout",
+		"github-token",
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		etcd, err := neco.EtcdClient()
@@ -112,6 +114,9 @@ Possible keys are:
 					return err
 				}
 				return st.PutWorkerTimeout(ctx, duration)
+			case "github-token":
+				value = args[1]
+				return st.PutGitHubToken(ctx, value)
 			}
 			return errors.New("unknown key: " + key)
 		})

--- a/pkg/neco/cmd/config_set.go
+++ b/pkg/neco/cmd/config_set.go
@@ -29,7 +29,7 @@ Possible keys are:
     quay-password         - Password to authenticate to quay.io from QUAY_PASSWORD.  This does not take VALUE.
     check-update-interval - Polling interval for checking new neco release.
     worker-timeout        - Timeout value to wait for workers.
-    github-token          - GitHub OAuth2 access token for checking GitHub release.`,
+    github-token          - GitHub personal access token for checking GitHub release.`,
 
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {

--- a/storage/config.go
+++ b/storage/config.go
@@ -114,3 +114,21 @@ func (s Storage) GetWorkerTimeout(ctx context.Context) (time.Duration, error) {
 	}
 	return time.Duration(i), nil
 }
+
+// PutGitHubToken stores github-token config to storage.
+func (s Storage) PutGitHubToken(ctx context.Context, token string) error {
+	return s.put(ctx, KeyGitHubToken, token)
+}
+
+// GetGitHubToken returns github-token from storage
+// If not found, this returns empty string.
+func (s Storage) GetGitHubToken(ctx context.Context) (string, error) {
+	token, err := s.get(ctx, KeyGitHubToken)
+	if err == ErrNotFound {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}

--- a/storage/config.go
+++ b/storage/config.go
@@ -121,14 +121,6 @@ func (s Storage) PutGitHubToken(ctx context.Context, token string) error {
 }
 
 // GetGitHubToken returns github-token from storage
-// If not found, this returns empty string.
 func (s Storage) GetGitHubToken(ctx context.Context) (string, error) {
-	token, err := s.get(ctx, KeyGitHubToken)
-	if err == ErrNotFound {
-		return "", nil
-	}
-	if err != nil {
-		return "", err
-	}
-	return token, nil
+	return s.get(ctx, KeyGitHubToken)
 }

--- a/storage/keys.go
+++ b/storage/keys.go
@@ -26,6 +26,7 @@ const (
 	KeyEnv                 = "config/env"
 	KeyCheckUpdateInterval = "config/check-update-interval"
 	KeyWorkerTimeout       = "config/worker-timeout"
+	KeyGitHubToken         = "config/github-token"
 	KeyVaultUnsealKey      = "vault-unseal-key"
 	KeyVaultRootToken      = "vault-root-token"
 	KeyFinishPrefix        = "finish/"

--- a/updater/release_checker.go
+++ b/updater/release_checker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cybozu-go/neco"
 	"github.com/cybozu-go/neco/ext"
 	"github.com/cybozu-go/neco/storage"
+	"golang.org/x/oauth2"
 )
 
 // ReleaseChecker checks newer GitHub releases by polling
@@ -34,6 +35,17 @@ func (c *ReleaseChecker) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	token, err := c.storage.GetGitHubToken(ctx)
+	if err != nil {
+		return err
+	}
+	if len(token) != 0 {
+		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+		oc := oauth2.NewClient(ctx, ts)
+		ctx = context.WithValue(ctx, oc, hc)
+	}
+
 	github := &ReleaseClient{neco.GitHubRepoOwner, neco.GitHubRepoName, hc}
 
 	env, err := c.storage.GetEnvConfig(ctx)

--- a/updater/release_checker.go
+++ b/updater/release_checker.go
@@ -30,12 +30,12 @@ func NewReleaseChecker(st storage.Storage, leaderKey string) ReleaseChecker {
 
 // Run periodically checks the new release of neco package at GitHub.
 func (c *ReleaseChecker) Run(ctx context.Context) error {
-	hc, err := ext.ProxyHTTPClientWithGitHubToken(ctx, c.storage)
+	ghc, err := ext.GitHubHTTPClient(ctx, c.storage)
 	if err != nil {
 		return err
 	}
 
-	github := &ReleaseClient{neco.GitHubRepoOwner, neco.GitHubRepoName, hc}
+	github := &ReleaseClient{neco.GitHubRepoOwner, neco.GitHubRepoName, ghc}
 
 	env, err := c.storage.GetEnvConfig(ctx)
 	if err != nil {

--- a/updater/release_checker.go
+++ b/updater/release_checker.go
@@ -3,11 +3,11 @@ package updater
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
-	"github.com/cybozu-go/neco/ext"
 	"github.com/cybozu-go/neco/storage"
 )
 
@@ -15,27 +15,24 @@ import (
 type ReleaseChecker struct {
 	storage   storage.Storage
 	leaderKey string
+	ghClient  *http.Client
 
 	check   func(context.Context) (string, error)
 	current string
 }
 
 // NewReleaseChecker returns a new ReleaseChecker
-func NewReleaseChecker(st storage.Storage, leaderKey string) ReleaseChecker {
+func NewReleaseChecker(st storage.Storage, leaderKey string, ghc *http.Client) ReleaseChecker {
 	return ReleaseChecker{
 		storage:   st,
 		leaderKey: leaderKey,
+		ghClient:  ghc,
 	}
 }
 
 // Run periodically checks the new release of neco package at GitHub.
 func (c *ReleaseChecker) Run(ctx context.Context) error {
-	ghc, err := ext.GitHubHTTPClient(ctx, c.storage)
-	if err != nil {
-		return err
-	}
-
-	github := &ReleaseClient{neco.GitHubRepoOwner, neco.GitHubRepoName, ghc}
+	github := &ReleaseClient{neco.GitHubRepoOwner, neco.GitHubRepoName, c.ghClient}
 
 	env, err := c.storage.GetEnvConfig(ctx)
 	if err != nil {

--- a/updater/release_checker.go
+++ b/updater/release_checker.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cybozu-go/neco"
 	"github.com/cybozu-go/neco/ext"
 	"github.com/cybozu-go/neco/storage"
-	"golang.org/x/oauth2"
 )
 
 // ReleaseChecker checks newer GitHub releases by polling
@@ -31,19 +30,9 @@ func NewReleaseChecker(st storage.Storage, leaderKey string) ReleaseChecker {
 
 // Run periodically checks the new release of neco package at GitHub.
 func (c *ReleaseChecker) Run(ctx context.Context) error {
-	hc, err := ext.ProxyHTTPClient(ctx, c.storage)
+	hc, err := ext.ProxyHTTPClientWithGitHubToken(ctx, c.storage)
 	if err != nil {
 		return err
-	}
-
-	token, err := c.storage.GetGitHubToken(ctx)
-	if err != nil {
-		return err
-	}
-	if len(token) != 0 {
-		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-		oc := oauth2.NewClient(ctx, ts)
-		ctx = context.WithValue(ctx, oc, hc)
 	}
 
 	github := &ReleaseClient{neco.GitHubRepoOwner, neco.GitHubRepoName, hc}

--- a/updater/server.go
+++ b/updater/server.go
@@ -62,7 +62,12 @@ RETRY:
 	env.Go(func(ctx context.Context) error {
 		return s.runLoop(ctx, leaderKey)
 	})
-	checker := NewReleaseChecker(s.storage, leaderKey)
+
+	ghc, err := ext.GitHubHTTPClient(ctx, s.storage)
+	if err != nil {
+		return err
+	}
+	checker := NewReleaseChecker(s.storage, leaderKey, ghc)
 	env.Go(checker.Run)
 	env.Stop()
 	err = env.Wait()

--- a/worker/deb.go
+++ b/worker/deb.go
@@ -13,8 +13,10 @@ import (
 )
 
 // InstallDebianPackage installs a debian package
-func InstallDebianPackage(ctx context.Context, client *http.Client, pkg *neco.DebianPackage, background bool) error {
-	gh := neco.NewGitHubClient(client)
+// client uses for downloading a debian package.
+// ghClient uses for getting download URL by GitHub API.
+func InstallDebianPackage(ctx context.Context, client *http.Client, ghClient *http.Client, pkg *neco.DebianPackage, background bool) error {
+	gh := neco.NewGitHubClient(ghClient)
 
 	releases, err := listGithubReleases(ctx, gh, pkg)
 	if err != nil {

--- a/worker/deb_test.go
+++ b/worker/deb_test.go
@@ -16,7 +16,7 @@ func TestInstallDebianPackage(t *testing.T) {
 		Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v0.5",
 	}
 
-	err := InstallDebianPackage(context.Background(), http.DefaultClient, pkg, true)
+	err := InstallDebianPackage(context.Background(), http.DefaultClient, http.DefaultClient, pkg, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
-	"github.com/cybozu-go/neco/ext"
 	"github.com/cybozu-go/neco/progs/etcdpasswd"
 )
 
@@ -38,11 +37,7 @@ func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest
 		if err != nil {
 			return err
 		}
-		ghc, err := ext.GitHubHTTPClient(ctx, o.storage)
-		if err != nil {
-			return err
-		}
-		err = InstallDebianPackage(ctx, o.proxyClient, ghc, &deb, false)
+		err = InstallDebianPackage(ctx, o.proxyClient, o.ghClient, &deb, false)
 		if err != nil {
 			return err
 		}

--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/neco/ext"
 	"github.com/cybozu-go/neco/progs/etcdpasswd"
 )
 
@@ -37,7 +38,11 @@ func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest
 		if err != nil {
 			return err
 		}
-		err = InstallDebianPackage(ctx, o.proxyClient, &deb, false)
+		hc, err := ext.ProxyHTTPClientWithGitHubToken(ctx, o.storage)
+		if err != nil {
+			return err
+		}
+		err = InstallDebianPackage(ctx, hc, &deb, false)
 		if err != nil {
 			return err
 		}

--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -38,11 +38,11 @@ func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest
 		if err != nil {
 			return err
 		}
-		hc, err := ext.ProxyHTTPClientWithGitHubToken(ctx, o.storage)
+		ghc, err := ext.GitHubHTTPClient(ctx, o.storage)
 		if err != nil {
 			return err
 		}
-		err = InstallDebianPackage(ctx, hc, &deb, false)
+		err = InstallDebianPackage(ctx, o.proxyClient, ghc, &deb, false)
 		if err != nil {
 			return err
 		}

--- a/worker/operator.go
+++ b/worker/operator.go
@@ -35,6 +35,7 @@ type operator struct {
 	mylrn       int
 	ec          *clientv3.Client
 	storage     storage.Storage
+	ghClient    *http.Client
 	proxyClient *http.Client
 	localClient *http.Client
 
@@ -49,11 +50,16 @@ func NewOperator(ctx context.Context, ec *clientv3.Client, mylrn int) (Operator,
 	if err != nil {
 		return nil, err
 	}
+	ghClient, err := ext.GitHubHTTPClient(ctx, st)
+	if err != nil {
+		return nil, err
+	}
 
 	return &operator{
 		mylrn:       mylrn,
 		ec:          ec,
 		storage:     st,
+		ghClient:    ghClient,
 		proxyClient: proxyClient,
 		localClient: localClient,
 	}, nil
@@ -77,11 +83,7 @@ func (o *operator) UpdateNeco(ctx context.Context, req *neco.UpdateRequest) erro
 	if env == neco.TestEnv {
 		return installLocalPackage(ctx, deb)
 	}
-	ghc, err := ext.GitHubHTTPClient(ctx, o.storage)
-	if err != nil {
-		return err
-	}
-	return InstallDebianPackage(ctx, o.proxyClient, ghc, deb, true)
+	return InstallDebianPackage(ctx, o.proxyClient, o.ghClient, deb, true)
 }
 
 func (o *operator) FinalStep() int {

--- a/worker/operator.go
+++ b/worker/operator.go
@@ -77,11 +77,11 @@ func (o *operator) UpdateNeco(ctx context.Context, req *neco.UpdateRequest) erro
 	if env == neco.TestEnv {
 		return installLocalPackage(ctx, deb)
 	}
-	hc, err := ext.ProxyHTTPClientWithGitHubToken(ctx, o.storage)
+	ghc, err := ext.GitHubHTTPClient(ctx, o.storage)
 	if err != nil {
 		return err
 	}
-	return InstallDebianPackage(ctx, hc, deb, true)
+	return InstallDebianPackage(ctx, o.proxyClient, ghc, deb, true)
 }
 
 func (o *operator) FinalStep() int {

--- a/worker/operator.go
+++ b/worker/operator.go
@@ -77,7 +77,11 @@ func (o *operator) UpdateNeco(ctx context.Context, req *neco.UpdateRequest) erro
 	if env == neco.TestEnv {
 		return installLocalPackage(ctx, deb)
 	}
-	return InstallDebianPackage(ctx, o.proxyClient, deb, true)
+	hc, err := ext.ProxyHTTPClientWithGitHubToken(ctx, o.storage)
+	if err != nil {
+		return err
+	}
+	return InstallDebianPackage(ctx, hc, deb, true)
 }
 
 func (o *operator) FinalStep() int {


### PR DESCRIPTION
Background:
`neco-updater` periodically checks the latest GitHub release of this repository. But rate limit would be received shortly if it is not authenticated.

Expected:
Set token in etcd, then `neco-updater` and `neco-worker` use it when checks release to prevent the GitHub rate limits.

Also fix an argument bug of the `neco bmc config get ipmipassword`.