### PR TITLE
[ignition] create LV per service

### DIFF
--- a/artifacts_new.go
+++ b/artifacts_new.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.13.1.1", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.13.2.1", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.11.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "20190201.1", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "1.1.0.1", Private: false},

--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -51,6 +51,10 @@ systemd:
     mask: true
   - name: systemd-timesyncd.service
     mask: true
+  - name: rkt-metadata.service
+    mask: true
+  - name: rkt-metadata.socket
+    mask: true
   - name: chronyd.service
     enabled: true
   - name: serf.service

--- a/ignitions/common/files/etc/fstab
+++ b/ignitions/common/files/etc/fstab
@@ -1,1 +1,3 @@
-LABEL=var /var ext4 x-systemd.device-timeout=300 0 0
+LABEL=containerd /var/lib/containerd ext4 x-systemd.device-timeout=300 0 0
+LABEL=docker     /var/lib/docker     ext4 x-systemd.device-timeout=300 0 0
+LABEL=rkt        /var/lib/rkt        ext4 x-systemd.device-timeout=300 0 0

--- a/ignitions/common/files/etc/fstab
+++ b/ignitions/common/files/etc/fstab
@@ -1,3 +1,4 @@
-LABEL=containerd /var/lib/containerd ext4 x-systemd.device-timeout=300 0 0
-LABEL=docker     /var/lib/docker     ext4 x-systemd.device-timeout=300 0 0
-LABEL=rkt        /var/lib/rkt        ext4 x-systemd.device-timeout=300 0 0
+LABEL=containerd /var/lib/containerd ext4 x-systemd.device-timeout=600 0 0
+LABEL=docker     /var/lib/docker     ext4 x-systemd.device-timeout=600 0 0
+LABEL=kubelet    /var/lib/kubelet    ext4 x-systemd.device-timeout=600 0 0
+LABEL=rkt        /var/lib/rkt        ext4 x-systemd.device-timeout=600 0 0

--- a/ignitions/common/files/etc/systemd/system/containerd.service.d/10-wait-mount.conf
+++ b/ignitions/common/files/etc/systemd/system/containerd.service.d/10-wait-mount.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=var-lib-containerd.mount
+After=var-lib-containerd.mount

--- a/ignitions/common/files/etc/systemd/system/docker.service.d/10-wait-mount.conf
+++ b/ignitions/common/files/etc/systemd/system/docker.service.d/10-wait-mount.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=var-lib-docker.mount
+After=var-lib-docker.mount

--- a/ignitions/common/files/etc/systemd/system/docker.service.d/10-wait-mount.conf
+++ b/ignitions/common/files/etc/systemd/system/docker.service.d/10-wait-mount.conf
@@ -1,3 +1,3 @@
 [Unit]
-Requires=var-lib-docker.mount
-After=var-lib-docker.mount
+Requires=var-lib-docker.mount var-lib-kubelet.mount
+After=var-lib-docker.mount var-lib-kubelet.mount

--- a/ignitions/common/files/etc/systemd/system/docker.service.d/99-run-after-time-sync.conf
+++ b/ignitions/common/files/etc/systemd/system/docker.service.d/99-run-after-time-sync.conf
@@ -1,3 +1,3 @@
 [Unit]
-After=time-sync.target setup-var.service
-Requires=time-sync.target setup-var.service
+After=time-sync.target
+Requires=time-sync.target

--- a/ignitions/common/files/etc/systemd/system/docker.socket.d/99-run-after-time-sync.conf
+++ b/ignitions/common/files/etc/systemd/system/docker.socket.d/99-run-after-time-sync.conf
@@ -1,4 +1,4 @@
 [Unit]
-After=time-sync.target setup-var.service
-Requires=time-sync.target setup-var.service
+After=time-sync.target
+Requires=time-sync.target
 DefaultDependencies=no

--- a/ignitions/common/files/etc/systemd/system/rkt-gc.timer.d/10-wait-mount.conf
+++ b/ignitions/common/files/etc/systemd/system/rkt-gc.timer.d/10-wait-mount.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=var-lib-rkt.mount
+After=var-lib-rkt.mount

--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -1,8 +1,24 @@
 #!/bin/sh -eu
 
 VG=vg1
-LV=var
-MOUNTDEV=/dev/disk/by-label/var
+LVLIST="containerd docker rkt"
+CONTAINERD_SIZE=10g
+DOCKER_SIZE=10g
+RKT_SIZE=10g
+
+lvsize() {
+    case $1 in
+    containerd)
+        echo $CONTAINERD_SIZE
+        ;;
+    docker)
+        echo $DOCKER_SIZE
+        ;;
+    rkt)
+        echo $RKT_SIZE
+        ;;
+    esac
+}
 
 prepare_lv() {
     vgchange -a ay
@@ -16,38 +32,46 @@ prepare_lv() {
     lvchange $VG -a ay
     sleep 1
 
-    if ! lvs $VG/$LV >/dev/null 2>&1; then
-        lvcreate -y -n $LV -L $SIZE $VG
+    for lv in $LVLIST; do
+        if ! lvs $VG/$lv >/dev/null 2>&1; then
+            lvcreate -y -n $lv -L $(lvsize $lv) $VG
+        fi
         sync
-    fi
+        sleep 1
+    done
 }
 
 if ls /dev/mapper/crypt-virtio-pci-* >/dev/null 2>&1; then
+    # for qemu
     PVS=$(ls /dev/mapper/crypt-virtio-pci-*)
-    SIZE=30g
     prepare_lv
-    DEV=/dev/$VG/$LV
 elif ls /dev/mapper/crypt-pci-*-nvme-1 >/dev/null 2>&1; then
+    # for compute node
     PVS=$(ls /dev/mapper/crypt-pci-*-nvme-1)
-    SIZE=1t
+    CONTAINERD_SIZE=1t
+    DOCKER_SIZE=50g
     prepare_lv
-    DEV=/dev/$VG/$LV
 else
-    DEV=$(ls /dev/mapper/crypt-pci-*-ata-1)
+    # for storage node
+    PVS=$(ls /dev/mapper/crypt-pci-*-ata-1)
+    CONTAINERD_SIZE=50g
+    DOCKER_SIZE=50g
+    prepare_lv
 fi
 
-sleep 1
+for label in $LVLIST; do
+    DEVICE=/dev/$VG/$label
+    while true; do
+        if [ -e $DEVICE ]; then
+            break
+        fi
+        echo "waiting for $DEVICE to appear..."
+        sleep 1
+    done
 
-if [ ! -L "${MOUNTDEV}" ]; then
-    mkfs.ext4 -L var "${DEV}"
-    sleep 1
-fi
-
-# wait for /var mount
-while true; do
-    dev=$(awk '{ if( $2 == "/var" ) { print "ok" } }' /proc/mounts)
-    if [ "$dev" = ok ]; then
-        exit 0
+    if [ $label != "$(lsblk -n -o LABEL $DEVICE)" ]; then
+        mkfs.ext4 -L $label $DEVICE
     fi
-    sleep 1
 done
+
+sync

--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -1,9 +1,10 @@
 #!/bin/sh -eu
 
 VG=vg1
-LVLIST="containerd docker rkt"
+LVLIST="containerd docker kubelet rkt"
 CONTAINERD_SIZE=10g
 DOCKER_SIZE=10g
+KUBELET_SIZE=10g
 RKT_SIZE=10g
 
 lvsize() {
@@ -13,6 +14,9 @@ lvsize() {
         ;;
     docker)
         echo $DOCKER_SIZE
+        ;;
+    kubelet)
+        echo $KUBELET_SIZE
         ;;
     rkt)
         echo $RKT_SIZE
@@ -50,6 +54,7 @@ elif ls /dev/mapper/crypt-pci-*-nvme-1 >/dev/null 2>&1; then
     PVS=$(ls /dev/mapper/crypt-pci-*-nvme-1)
     CONTAINERD_SIZE=1t
     DOCKER_SIZE=50g
+    KUBELET_SIZE=100g
     prepare_lv
 else
     # for storage node

--- a/ignitions/common/systemd/setup-chrony.service
+++ b/ignitions/common/systemd/setup-chrony.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Setup chrony container
 ConditionPathExists=!/etc/chrony.conf
-After=setup-var.service
-Before=setup-network.service
 Wants=setup-network.service
-Requires=setup-var.service
+Requires=var-lib-rkt.mount
+Before=setup-network.service
+After=var-lib-rkt.mount
 
 [Service]
 Type=oneshot

--- a/ignitions/common/systemd/setup-network.service
+++ b/ignitions/common/systemd/setup-network.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Setup network
 ConditionPathExists=!/etc/bird
-After=setup-var.service neco-dhcp-online.target
 Wants=neco-dhcp-online.target
-Requires=setup-var.service
+Requires=var-lib-rkt.mount
+After=var-lib-rkt.mount neco-dhcp-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
In order to specify precise dependencies on persistent volumes,
we switch to prepare a logical volume for each service including
containerd, docker, and rkt.

In addition, `/var/lib/kubelet` is also persisted for kubelet.
Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage