### PR TITLE
[ignition] make robust for temporary service failure

### DIFF
--- a/ignitions/common/systemd/exec-setup-hw.service
+++ b/ignitions/common/systemd/exec-setup-hw.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Run setup-hw tool
-Requires=setup-hw.service setup-bmc-user.service
+Wants=setup-hw.service
+Requires=setup-bmc-user.service
 After=setup-hw.service setup-bmc-user.service
 
 [Service]

--- a/ignitions/common/systemd/serf.service
+++ b/ignitions/common/systemd/serf.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Serf container on docker
-Wants=neco.target
-Requires=setup-serf.service docker.socket docker.service exec-setup-hw.service
-After=neco.target setup-serf.service docker.socket docker.service exec-setup-hw.service
+Wants=neco.target exec-setup-hw.service
+After=neco.target  exec-setup-hw.service
+Requires=setup-serf.service docker.socket
+After=setup-serf.service docker.socket
 After=cke-images.service coil-image.service squid-image.service
 ConditionPathExists=/etc/serf/serf.json
 
@@ -11,8 +12,9 @@ Type=simple
 Restart=always
 RestartSec=10s
 TimeoutStartSec=0
-ExecStartPre=-/usr/bin/docker kill serf
-ExecStartPre=-/usr/bin/docker rm serf
+ExecStartPre=/bin/systemctl is-active -q exec-setup-hw.service
+ExecStartPre=/bin/sh -c "/usr/bin/docker kill serf || true"
+ExecStartPre=/bin/sh -c "/usr/bin/docker rm serf || true"
 ExecStartPre=/opt/bin/load-image {{ MyURL }}/api/v1/assets/%%serf%img%% %%serf%full%%
 ExecStart=/usr/bin/docker run \
   --name serf \

--- a/ignitions/common/systemd/setup-hw.service
+++ b/ignitions/common/systemd/setup-hw.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=setup-hw container
-Requires=docker.socket docker.service
-After=docker.socket docker.service
+Requires=docker.socket
+After=docker.socket
 
 [Service]
 Type=simple
@@ -9,8 +9,8 @@ Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=0
 OOMScoreAdjust=-1000
-ExecStartPre=-/usr/bin/docker kill setup-hw
-ExecStartPre=-/usr/bin/docker rm setup-hw
+ExecStartPre=/bin/sh -c "/usr/bin/docker kill setup-hw || true"
+ExecStartPre=/bin/sh -c "/usr/bin/docker rm setup-hw || true"
 ExecStartPre=/opt/bin/load-image {{ MyURL }}/api/v1/assets/%%setup-hw%img%% %%setup-hw%full%%
 ExecStart=/usr/bin/docker run \
   --name setup-hw \


### PR DESCRIPTION
systemd `Requires=` dependency is too strong when a dependency
service may sometimes fail but then restart successfully.

Ref: https://github.com/systemd/systemd/issues/1312

Instead of `Requires=`, `ExecStartPre=/bin/systemctl is-active -q`
can be used for such cases.