### PR TITLE
Bootserver tag

### DIFF
--- a/dctest/auto-config
+++ b/dctest/auto-config
@@ -6,9 +6,9 @@ http_proxy=http://10.0.49.3:3128/
 https_proxy=http://10.0.49.3:3128/
 
 cat > /etc/apt/sources.list <<EOF
-deb http://mirror.math.princeton.edu/pub/ubuntu bionic main restricted universe multiverse
-deb http://mirror.math.princeton.edu/pub/ubuntu bionic-updates main restricted universe multiverse
-deb http://mirror.math.princeton.edu/pub/ubuntu bionic-security main restricted universe multiverse
+deb http://linux.yz.yamagata-u.ac.jp/ubuntu/ bionic main restricted universe multiverse
+deb http://linux.yz.yamagata-u.ac.jp/ubuntu/ bionic-updates main restricted universe multiverse
+deb http://linux.yz.yamagata-u.ac.jp/ubuntu/ bionic-security main restricted universe multiverse
 EOF
 
 env http_proxy=$http_proxy apt-get update -o Acquire::Retries=5

--- a/ignitions/common/files/opt/sbin/setup-serf-conf
+++ b/ignitions/common/files/opt/sbin/setup-serf-conf
@@ -13,7 +13,7 @@ cat >/etc/serf/serf.json <<EOF
         "os-name": "${os_name}",
         "os-version": "${os_version}",
         "serial": "${serial}",
-        "boot-server": false
+        "boot-server": "false"
     },
     "interface": "node0",
     "reconnect_interval": "30s",

--- a/ignitions/common/files/opt/sbin/setup-serf-conf
+++ b/ignitions/common/files/opt/sbin/setup-serf-conf
@@ -12,7 +12,8 @@ cat >/etc/serf/serf.json <<EOF
     "tags": {
         "os-name": "${os_name}",
         "os-version": "${os_version}",
-        "serial": "${serial}"
+        "serial": "${serial}",
+        "boot-server": false
     },
     "interface": "node0",
     "reconnect_interval": "30s",

--- a/progs/serf/conf.go
+++ b/progs/serf/conf.go
@@ -26,7 +26,7 @@ func GenerateConf(w io.Writer, lrns []int, osName, osVersion, serial string) err
 			OsName:     osName,
 			OsVersion:  osVersion,
 			Serial:     serial,
-			BootServer: true,
+			BootServer: "true",
 		},
 		Interface:         "node0",
 		EventHandlers:     []string{"member-join,member-failed,member-leave=" + neco.SerfHandler},

--- a/progs/serf/conf.go
+++ b/progs/serf/conf.go
@@ -23,9 +23,10 @@ func GenerateConf(w io.Writer, lrns []int, osName, osVersion, serial string) err
 
 	data := serfConfig{
 		Tags: tags{
-			OsName:    osName,
-			OsVersion: osVersion,
-			Serial:    serial,
+			OsName:     osName,
+			OsVersion:  osVersion,
+			Serial:     serial,
+			BootServer: true,
 		},
 		Interface:         "node0",
 		EventHandlers:     []string{"member-join,member-failed,member-leave=" + neco.SerfHandler},

--- a/progs/serf/conf_test.go
+++ b/progs/serf/conf_test.go
@@ -24,7 +24,7 @@ func TestGenerateConf(t *testing.T) {
 			OsName:     osName,
 			OsVersion:  osVer,
 			Serial:     serial,
-			BootServer: true,
+			BootServer: "true",
 		},
 		Interface:         "node0",
 		EventHandlers:     []string{"member-join,member-failed,member-leave=" + neco.SerfHandler},

--- a/progs/serf/conf_test.go
+++ b/progs/serf/conf_test.go
@@ -21,9 +21,10 @@ func TestGenerateConf(t *testing.T) {
 	}
 	expected := serfConfig{
 		Tags: tags{
-			OsName:    osName,
-			OsVersion: osVer,
-			Serial:    serial,
+			OsName:     osName,
+			OsVersion:  osVer,
+			Serial:     serial,
+			BootServer: true,
 		},
 		Interface:         "node0",
 		EventHandlers:     []string{"member-join,member-failed,member-leave=" + neco.SerfHandler},

--- a/progs/serf/templates.go
+++ b/progs/serf/templates.go
@@ -3,9 +3,10 @@ package serf
 import "text/template"
 
 type tags struct {
-	OsName    string `json:"os-name"`
-	OsVersion string `json:"os-version"`
-	Serial    string `json:"serial"`
+	OsName     string `json:"os-name"`
+	OsVersion  string `json:"os-version"`
+	Serial     string `json:"serial"`
+	BootServer bool   `json:"boot-server"`
 }
 
 type serfConfig struct {

--- a/progs/serf/templates.go
+++ b/progs/serf/templates.go
@@ -6,7 +6,7 @@ type tags struct {
 	OsName     string `json:"os-name"`
 	OsVersion  string `json:"os-version"`
 	Serial     string `json:"serial"`
-	BootServer bool   `json:"boot-server"`
+	BootServer string `json:"boot-server"`
 }
 
 type serfConfig struct {


### PR DESCRIPTION
To discover boot server from cluster machines, add `boot-server` tag to serf members.