### PR TITLE
[ignitions] add config for MetalLB to bird.conf

### DIFF
--- a/ignitions/common/files/etc/bird/bird.conf
+++ b/ignitions/common/files/etc/bird/bird.conf
@@ -18,6 +18,7 @@ protocol kernel {
         export filter {
             if source = RTS_DEVICE then reject;
             if proto = "coil" then reject;
+            if (64698,64699) ~ bgp_community then reject;
             accept;
         };
     };
@@ -52,6 +53,7 @@ template bgp tor {
         # Accept routes regardless of its NEXT_HOP.
         igp table dummytab;
         gateway recursive;
+        next hop self;
         import filter {
             # If this route came from iBGP peers,
             if bgp_next_hop.mask({{ (index .Info.Network.IPv4 1).MaskBits }}) = from.mask({{ (index .Info.Network.IPv4 1).MaskBits }}) then {
@@ -72,4 +74,18 @@ protocol bgp tor1 from tor {
 }
 protocol bgp tor2 from tor {
     neighbor {{ (index .Info.Network.IPv4 2).Gateway }} as {{ add 64600 .Spec.Rack }};
+}
+protocol bgp metallb {
+    local as 64699;
+    neighbor 127.0.0.1 as 64698;
+
+    multihop;
+    passive;
+    ipv4 {
+        import filter {
+            bgp_community.add((64698,64699));
+            accept;
+        };
+        export none;
+    };
 }


### PR DESCRIPTION
MetalLB runs a BGP speaker to advertise virtual IP addresses
on each Kubernetes node.  Since each node already runs bird as
BGP speaker, MetalLB need to communicate with bird instead of
ToR switches.

In Neco, ASN for MetalLB is `64698` and bound to 127.0.0.1.
BIRD advertises routes from MetalLB as its own routes by
using `next hop self` directive.

In addition, MetalLB routes should not be imported to Node
kernel because packets to the virtual IP addresses are handled
by kube-proxy (IPVS).  To distinguish MetalLB routes, they are
marked with BGP community `(64698,64699)`.