### PR TITLE
[ignitions] delay node0 creation

### DIFF
--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -88,5 +88,3 @@ systemd:
 networkd:
   - 01-eth0.network
   - 01-eth1.network
-  - 10-node0.netdev
-  - 10-node0.network

--- a/ignitions/common/files/opt/sbin/setup-local-network
+++ b/ignitions/common/files/opt/sbin/setup-local-network
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 cat >/etc/systemd/network/01-eth0.network <<EOF
 [Match]
@@ -24,6 +24,20 @@ EmitLLDP=nearest-bridge
 [Address]
 Address={{ index .Spec.IPv4 2 }}/{{ (index .Info.Network.IPv4 2).MaskBits }}
 Scope=link
+EOF
+
+cat >/etc/systemd/network/10-node0.netdev <<EOF
+[NetDev]
+Name=node0
+Kind=dummy
+EOF
+
+cat >/etc/systemd/network/10-node0.network <<EOF
+[Match]
+Name=node0
+
+[Network]
+Address={{ index .Spec.IPv4 0 }}/32
 EOF
 
 systemctl restart systemd-networkd.service

--- a/ignitions/common/networkd/10-node0.netdev
+++ b/ignitions/common/networkd/10-node0.netdev
@@ -1,3 +1,0 @@
-[NetDev]
-Name=node0
-Kind=dummy

--- a/ignitions/common/networkd/10-node0.network
+++ b/ignitions/common/networkd/10-node0.network
@@ -1,5 +1,0 @@
-[Match]
-Name=node0
-
-[Network]
-Address={{ index .Spec.IPv4 0 }}/32


### PR DESCRIPTION
The address of node0 interface need to be advertised by BGP.
It is therefore too early to have node0 interface and address
during DHCP phase.

This commit postpones node0 setup just before running BIRD.