### PR TITLE
[cke] update cluster template to enable metrics for etcd

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -20,3 +20,5 @@ options:
     container_runtime_endpoint: unix:///var/run/k8s-containerd.sock
     container_log_max_size: 10Mi
     container_log_max_files: 10
+  etcd:
+    extra_args: ["--listen-metrics-urls=http://0.0.0.0:2381"]


### PR DESCRIPTION
etcd managed by CKE normally requires TLS client certificate
for authentication.  To allow prometheus to pull metrics of
etcd w/o client certs, --listen-metrics-urls=http://0.0.0.0:2381
is given as an extra agument for etcd.