### PR TITLE
[necogcp] use correct zone

### DIFF
--- a/gcp/compute.go
+++ b/gcp/compute.go
@@ -116,7 +116,7 @@ func (cc *ComputeClient) CreateHomeDisk(ctx context.Context) error {
 	}
 	gcmdInfo := cc.gCloudComputeDisks()
 	gcmdInfo = append(gcmdInfo, "describe", "home",
-		"--zone",cc.cfg.Common.Zone,
+		"--zone", cc.cfg.Common.Zone,
 		"--format", "json")
 	outBuf := new(bytes.Buffer)
 	c := well.CommandContext(ctx, gcmdInfo[0], gcmdInfo[1:]...)

--- a/gcp/compute.go
+++ b/gcp/compute.go
@@ -115,7 +115,9 @@ func (cc *ComputeClient) CreateHomeDisk(ctx context.Context) error {
 		return nil
 	}
 	gcmdInfo := cc.gCloudComputeDisks()
-	gcmdInfo = append(gcmdInfo, "describe", "home", "--format", "json")
+	gcmdInfo = append(gcmdInfo, "describe", "home",
+		"--zone",cc.cfg.Common.Zone,
+		"--format", "json")
 	outBuf := new(bytes.Buffer)
 	c := well.CommandContext(ctx, gcmdInfo[0], gcmdInfo[1:]...)
 	c.Stdin = os.Stdin
@@ -163,7 +165,9 @@ func (cc *ComputeClient) ResizeHomeDisk(ctx context.Context) error {
 		return nil
 	}
 	gcmdInfo := cc.gCloudComputeDisks()
-	gcmdInfo = append(gcmdInfo, "describe", "home", "--format", "json")
+	gcmdInfo = append(gcmdInfo, "describe", "home",
+		"--zone", cc.cfg.Common.Zone,
+		"--format", "json")
 	outBuf := new(bytes.Buffer)
 	c := well.CommandContext(ctx, gcmdInfo[0], gcmdInfo[1:]...)
 	c.Stdin = os.Stdin


### PR DESCRIPTION
necogcp uses `gcloud compute disks describe home` command to judge
whether home disk exists or not. It doesn't use --zone option and
expect the default zone to be the zone written in the config file.