### PR TITLE
Install bash completions for ckecli and sabactl

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -96,6 +96,11 @@ const (
 	WorkerAssetsPath = "/usr/libexec/neco"
 )
 
+// Bash completion
+const (
+	BashCompletionDir = "/etc/bash_completion.d"
+)
+
 // File locations
 var (
 	rackFile    = filepath.Join(NecoDir, "rack")
@@ -123,16 +128,19 @@ var (
 	EtcdpasswdConfFile = filepath.Join(EtcdpasswdDir, "config.yml")
 	EtcdpasswdDropIn   = "/etc/systemd/system/ep-agent.service.d/10-check-certificate.conf"
 
-	SabakanCertFile = filepath.Join(SabakanDir, "etcd.crt")
-	SabakanKeyFile  = filepath.Join(SabakanDir, "etcd.key")
-	SabakanConfFile = filepath.Join(SabakanDir, "config.yml")
+	SabakanCertFile           = filepath.Join(SabakanDir, "etcd.crt")
+	SabakanKeyFile            = filepath.Join(SabakanDir, "etcd.key")
+	SabakanConfFile           = filepath.Join(SabakanDir, "config.yml")
+	SabactlBin                = "/usr/local/bin/sabactl"
+	SabactlBashCompletionFile = filepath.Join(BashCompletionDir, "sabactl")
 
 	SerfConfFile = filepath.Join(SerfDir, "serf.json")
 
-	CKECertFile = filepath.Join(CKEDir, "etcd.crt")
-	CKEKeyFile  = filepath.Join(CKEDir, "etcd.key")
-	CKEConfFile = filepath.Join(CKEDir, "config.yml")
-	CKECLIBin   = "/usr/local/bin/ckecli"
+	CKECertFile              = filepath.Join(CKEDir, "etcd.crt")
+	CKEKeyFile               = filepath.Join(CKEDir, "etcd.key")
+	CKEConfFile              = filepath.Join(CKEDir, "config.yml")
+	CKECLIBin                = "/usr/local/bin/ckecli"
+	CKECLIBashCompletionFile = filepath.Join(BashCompletionDir, "ckecli")
 
 	NecoCertFile = filepath.Join(NecoDir, "etcd.crt")
 	NecoKeyFile  = filepath.Join(NecoDir, "etcd.key")

--- a/dctest/init.go
+++ b/dctest/init.go
@@ -79,6 +79,7 @@ func TestInit() {
 			execSafeAt(host, "test", "-f", neco.SabakanConfFile)
 			execSafeAt(host, "test", "-f", neco.SabakanKeyFile)
 			execSafeAt(host, "test", "-f", neco.SabakanCertFile)
+			execSafeAt(host, "test", "-f", neco.SabactlBashCompletionFile)
 
 			execSafeAt(host, "systemctl", "-q", "is-active", "sabakan.service")
 		}
@@ -104,6 +105,7 @@ func TestInit() {
 			execSafeAt(host, "test", "-f", neco.CKEConfFile)
 			execSafeAt(host, "test", "-f", neco.CKEKeyFile)
 			execSafeAt(host, "test", "-f", neco.CKECertFile)
+			execSafeAt(host, "test", "-f", neco.CKECLIBashCompletionFile)
 
 			execSafeAt(host, "systemctl", "-q", "is-active", "cke.service")
 		}

--- a/dctest/setup.go
+++ b/dctest/setup.go
@@ -69,6 +69,8 @@ func TestSetup() {
 			execSafeAt(h, "test", "-f", neco.EtcdBackupKeyFile)
 			execSafeAt(h, "test", "-f", neco.TimerFile("etcd-backup"))
 			execSafeAt(h, "test", "-f", neco.ServiceFile("etcd-backup"))
+			execSafeAt(h, "test", "-f", neco.SabactlBashCompletionFile)
+			execSafeAt(h, "test", "-f", neco.CKECLIBashCompletionFile)
 		}
 	})
 

--- a/dctest/setup.go
+++ b/dctest/setup.go
@@ -69,8 +69,6 @@ func TestSetup() {
 			execSafeAt(h, "test", "-f", neco.EtcdBackupKeyFile)
 			execSafeAt(h, "test", "-f", neco.TimerFile("etcd-backup"))
 			execSafeAt(h, "test", "-f", neco.ServiceFile("etcd-backup"))
-			execSafeAt(h, "test", "-f", neco.SabactlBashCompletionFile)
-			execSafeAt(h, "test", "-f", neco.CKECLIBashCompletionFile)
 		}
 	})
 

--- a/progs/cke/install.go
+++ b/progs/cke/install.go
@@ -1,7 +1,11 @@
 package cke
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os"
+	"os/exec"
 
 	"github.com/cybozu-go/neco"
 )
@@ -11,4 +15,26 @@ func InstallToolsCKE(ctx context.Context) error {
 	return neco.RunContainer(ctx, "cke",
 		[]neco.Bind{{Name: "host", Source: "/usr/local/bin", Dest: "/host"}},
 		[]string{"--user=0", "--group=0", "--exec=/usr/local/cke/install-tools"})
+}
+
+// InstallBashCompletion installs bash completion for ckecli
+func InstallBashCompletion(ctx context.Context) error {
+	output, err := exec.Command(neco.CKECLIBin, "completion").Output()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(neco.CKECLIBashCompletionFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	bc := bytes.NewReader(output)
+	_, err = io.Copy(f, bc)
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
 }

--- a/progs/cke/install.go
+++ b/progs/cke/install.go
@@ -1,10 +1,8 @@
 package cke
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"os"
+	"io/ioutil"
 	"os/exec"
 
 	"github.com/cybozu-go/neco"
@@ -24,17 +22,5 @@ func InstallBashCompletion(ctx context.Context) error {
 		return err
 	}
 
-	f, err := os.OpenFile(neco.CKECLIBashCompletionFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	bc := bytes.NewReader(output)
-	_, err = io.Copy(f, bc)
-	if err != nil {
-		return err
-	}
-
-	return f.Sync()
+	return ioutil.WriteFile(neco.CKECLIBashCompletionFile, output, 0644)
 }

--- a/progs/sabakan/install.go
+++ b/progs/sabakan/install.go
@@ -1,7 +1,11 @@
 package sabakan
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os"
+	"os/exec"
 
 	"github.com/cybozu-go/neco"
 )
@@ -13,4 +17,26 @@ func InstallTools(ctx context.Context) error {
 			{Name: "host-usr-local-bin", Source: "/usr/local/bin", Dest: "/host/usr/local/bin"},
 		},
 		[]string{"--user=0", "--group=0", "--exec=/usr/local/sabakan/install-tools"})
+}
+
+// InstallBashCompletion installs bash completion for sabactl
+func InstallBashCompletion(ctx context.Context) error {
+	output, err := exec.Command(neco.SabactlBin, "completion").Output()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(neco.SabactlBashCompletionFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	bc := bytes.NewReader(output)
+	_, err = io.Copy(f, bc)
+	if err != nil {
+		return err
+	}
+
+	return f.Sync()
 }

--- a/progs/sabakan/install.go
+++ b/progs/sabakan/install.go
@@ -1,10 +1,8 @@
 package sabakan
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"os"
+	"io/ioutil"
 	"os/exec"
 
 	"github.com/cybozu-go/neco"
@@ -26,17 +24,5 @@ func InstallBashCompletion(ctx context.Context) error {
 		return err
 	}
 
-	f, err := os.OpenFile(neco.SabactlBashCompletionFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	bc := bytes.NewReader(output)
-	_, err = io.Copy(f, bc)
-	if err != nil {
-		return err
-	}
-
-	return f.Sync()
+	return ioutil.WriteFile(neco.SabactlBashCompletionFile, output, 0644)
 }

--- a/worker/cke.go
+++ b/worker/cke.go
@@ -30,11 +30,11 @@ func (o *operator) UpdateCKE(ctx context.Context, req *neco.UpdateRequest) error
 		if err != nil {
 			return err
 		}
-		err = o.storage.RecordContainerTag(ctx, o.mylrn, "cke")
+		err = cke.InstallBashCompletion(ctx)
 		if err != nil {
 			return err
 		}
-		err = cke.InstallBashCompletion(ctx)
+		err = o.storage.RecordContainerTag(ctx, o.mylrn, "cke")
 		if err != nil {
 			return err
 		}

--- a/worker/cke.go
+++ b/worker/cke.go
@@ -34,6 +34,10 @@ func (o *operator) UpdateCKE(ctx context.Context, req *neco.UpdateRequest) error
 		if err != nil {
 			return err
 		}
+		err = cke.InstallBashCompletion(ctx)
+		if err != nil {
+			return err
+		}
 	}
 	_, err = o.replaceCKEFiles(ctx, req.Servers)
 	if err != nil {

--- a/worker/sabakan.go
+++ b/worker/sabakan.go
@@ -31,6 +31,10 @@ func (o *operator) UpdateSabakan(ctx context.Context, req *neco.UpdateRequest) e
 		if err != nil {
 			return err
 		}
+		err = sabakan.InstallBashCompletion(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = o.replaceSabakanFiles(ctx, o.mylrn, req.Servers)

--- a/worker/sabakan.go
+++ b/worker/sabakan.go
@@ -27,11 +27,11 @@ func (o *operator) UpdateSabakan(ctx context.Context, req *neco.UpdateRequest) e
 		if err != nil {
 			return err
 		}
-		err = o.storage.RecordContainerTag(ctx, o.mylrn, "sabakan")
+		err = sabakan.InstallBashCompletion(ctx)
 		if err != nil {
 			return err
 		}
-		err = sabakan.InstallBashCompletion(ctx)
+		err = o.storage.RecordContainerTag(ctx, o.mylrn, "sabakan")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
These commands has subcommand `completion` to dump bash completion.
neco-worker installs them onto /etc/bash_completion.d.