### PR TITLE
[Bug fix] upgrade unbound

### DIFF
--- a/dctest/coil.go
+++ b/dctest/coil.go
@@ -32,7 +32,7 @@ func TestCoilSetup() {
 		execSafeAt(boot0, "sed", "s,%%COIL_IMAGE%%,$(neco image coil),",
 			"/usr/share/neco/coil-deploy.yml", "|", "kubectl", "create", "-f", "-")
 
-		By("waiting for coil-node DaemonSet and coil-controllers Deployement")
+		By("waiting for coil-node DaemonSet and coil-controllers Deployment")
 		checkCoilNodeDaemonSet()
 		checkCoilControllersDeployment()
 
@@ -87,7 +87,7 @@ func TestCoilSetup() {
 // TestCoil tests Coil
 func TestCoil() {
 	It("should be available", func() {
-		By("checking coil-node DaemonSet and coil-controllers Deployement")
+		By("checking coil-node DaemonSet and coil-controllers Deployment")
 		checkCoilNodeDaemonSet()
 		checkCoilControllersDeployment()
 

--- a/dctest/squid.go
+++ b/dctest/squid.go
@@ -15,6 +15,7 @@ func TestSquidSetup() {
 		By("creating k8s resources")
 		execSafeAt(boot0, "sed", "-e", "s,%%SQUID_IMAGE%%,$(neco image squid),",
 			"-e", "'s,cache_mem .*,cache_mem 200 MB,'",
+			"-e", "s,%%UNBOUND_IMAGE%%,$(ckecli images | grep quay.io/cybozu/unbound),",
 			"/usr/share/neco/squid.yml", "|", "kubectl", "create", "-f", "-")
 	})
 }

--- a/dctest/upgrade.go
+++ b/dctest/upgrade.go
@@ -117,7 +117,7 @@ func checkVersionInDaemonSet(namespace, dsName, imageName, desiredVersion string
 		}
 	}
 	if actual == "" {
-		return fmt.Errorf("DeamonSet %s does not contain %s", dsName, imageName)
+		return fmt.Errorf("DaemonSet %s does not contain %s", dsName, imageName)
 	}
 	if actual != desiredVersion {
 		return fmt.Errorf("%s %s is not updated. desired version is %s, but actual version is %s",
@@ -154,13 +154,17 @@ func checkVersionInDeployment(namespace, deploymentName, imageName, desiredVersi
 				deploymentName, imageName, desiredVersion, actual)
 		}
 	}
-	if actual := deploy.Status.AvailableReplicas; actual != *deploy.Spec.Replicas {
-		return fmt.Errorf("%s's %s is not updated completely. desired replicas is %d, but actual available is %d",
-			deploymentName, imageName, deploy.Spec.Replicas, actual)
+	desired := int32(1)
+	if deploy.Spec.Replicas != nil {
+		desired = *deploy.Spec.Replicas
 	}
-	if actual := deploy.Status.UpdatedReplicas; actual != *deploy.Spec.Replicas {
+	if actual := deploy.Status.AvailableReplicas; actual != desired {
+		return fmt.Errorf("%s's %s is not updated completely. desired replicas is %d, but actual available is %d",
+			deploymentName, imageName, desired, actual)
+	}
+	if actual := deploy.Status.UpdatedReplicas; actual != desired {
 		return fmt.Errorf("%s's %s is not updated completely. desired replicas is %d, but actual updated is %d",
-			deploymentName, imageName, deploy.Spec.Replicas, actual)
+			deploymentName, imageName, desired, actual)
 	}
 
 	return nil

--- a/dctest/upgrade.go
+++ b/dctest/upgrade.go
@@ -56,7 +56,7 @@ func TestUpgrade() {
 		stdout, stderr, err := execAt(boot0, "ckecli", "images")
 		Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
 
-		for _, img := range strings.Split(string(stdout), "\n") {
+		for _, img := range strings.Split(strings.TrimSpace(string(stdout)), "\n") {
 			split := strings.Split(img[len("quay.io/cybozu/"):], ":")
 			imageName := split[0]
 			version := split[1]
@@ -110,7 +110,7 @@ func checkVersionInDaemonSet(namespace, dsName, imageName, desiredVersion string
 	if err != nil {
 		return err
 	}
-	actual := ds.GetObjectMeta().GetAnnotations()["cke.cybozu.com/image"][len("quay.io/cybozu/:"+imageName):]
+	actual := ds.GetObjectMeta().GetAnnotations()["cke.cybozu.com/image"][len("quay.io/cybozu/"+imageName+":"):]
 	if actual != desiredVersion {
 		return fmt.Errorf("%s %s is not updated. desired version is %s, but actual version is %s",
 			dsName, imageName, desiredVersion, actual)
@@ -136,7 +136,7 @@ func checkVersionInDeployment(namespace, deploymentName, imageName, desiredVersi
 		if !strings.HasPrefix(c.Image, "quay.io/cybozu/"+imageName) {
 			continue
 		}
-		if actual := c.Image[len("quay.io/cybozu/"+imageName):]; actual != desiredVersion {
+		if actual := c.Image[len("quay.io/cybozu/"+imageName+":"):]; actual != desiredVersion {
 			return fmt.Errorf("%s's %s is not updated. desired version is %s, but actual version is %s",
 				deploymentName, imageName, desiredVersion, actual)
 		}

--- a/dctest/upgrade.go
+++ b/dctest/upgrade.go
@@ -2,12 +2,16 @@ package dctest
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/cybozu-go/neco"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 // TestUpgrade test neco debian package upgrade scenario
@@ -48,4 +52,98 @@ func TestUpgrade() {
 			execSafeAt(h, "systemctl", "-q", "is-active", "node-exporter.service")
 		}
 	})
+	It("should install desired version", func() {
+		stdout, stderr, err := execAt(boot0, "ckecli", "images")
+		Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)
+
+		for _, img := range strings.Split(string(stdout), "\n") {
+			split := strings.Split(img[len("quay.io/cybozu/"):], ":")
+			imageName := split[0]
+			version := split[1]
+
+			// TODO: check all images
+			if imageName != "unbound" && imageName != "coredns" {
+				continue
+			}
+			err := checkRunningDesiredVersion(imageName, version)
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+	})
+}
+
+func checkRunningDesiredVersion(imageName string, desiredVersion string) error {
+	switch imageName {
+	case "unbound":
+		// node-dns
+		err := checkVersionInDaemonSet("kube-system", "node-dns", imageName, desiredVersion)
+		if err != nil {
+			return err
+		}
+		// internet full resolver
+		err = checkVersionInDeployment("internet-egress", "unbound", imageName, desiredVersion)
+		if err != nil {
+			return err
+		}
+		// unbound in squid pod
+		err = checkVersionInDeployment("internet-egress", "squid", imageName, desiredVersion)
+		if err != nil {
+			return err
+		}
+	case "coredns":
+		err := checkVersionInDeployment("kube-system", "cluster-dns", imageName, desiredVersion)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("checker function for %s is not implemented", imageName)
+	}
+	return nil
+}
+
+func checkVersionInDaemonSet(namespace, dsName, imageName, desiredVersion string) error {
+	stdout, _, err := execAt(boot0, "kubectl", "get", "ds", "-n", namespace, dsName, "-o", "json")
+	if err != nil {
+		return err
+	}
+	ds := new(appsv1.DaemonSet)
+	err = json.Unmarshal(stdout, ds)
+	if err != nil {
+		return err
+	}
+	actual := ds.GetObjectMeta().GetAnnotations()["cke.cybozu.com/image"][len("quay.io/cybozu/:"+imageName):]
+	if actual != desiredVersion {
+		return fmt.Errorf("%s %s is not updated. desired version is %s, but actual version is %s",
+			dsName, imageName, desiredVersion, actual)
+	}
+	if ds.Status.DesiredNumberScheduled != ds.Status.NumberAvailable {
+		return fmt.Errorf("%s %s is not updated completely. desired number scheduled is %d, but actual available is %d",
+			dsName, imageName, ds.Status.DesiredNumberScheduled, ds.Status.NumberAvailable)
+	}
+	return nil
+}
+
+func checkVersionInDeployment(namespace, deploymentName, imageName, desiredVersion string) error {
+	stdout, _, err := execAt(boot0, "kubectl", "get", "deployment", "-n", namespace, deploymentName, "-o", "json")
+	if err != nil {
+		return err
+	}
+	deploy := new(appsv1.Deployment)
+	err = json.Unmarshal(stdout, deploy)
+	if err != nil {
+		return err
+	}
+	for _, c := range deploy.Spec.Template.Spec.Containers {
+		if !strings.HasPrefix(c.Image, "quay.io/cybozu/"+imageName) {
+			continue
+		}
+		if actual := c.Image[len("quay.io/cybozu/"+imageName):]; actual != desiredVersion {
+			return fmt.Errorf("%s's %s is not updated. desired version is %s, but actual version is %s",
+				deploymentName, imageName, desiredVersion, actual)
+		}
+	}
+	if actual := deploy.Status.AvailableReplicas; actual != *deploy.Spec.Replicas {
+		return fmt.Errorf("%s's %s is not updated completely. desired replicas is %d, but actual available is %d",
+			deploymentName, imageName, deploy.Spec.Replicas, actual)
+	}
+	return nil
 }

--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -51,6 +51,9 @@ spec:
           effect: NoSchedule
         - key: CriticalAddonsOnly
           operator: Exists
+      dnsConfig:
+        nameservers:
+          - 127.0.0.1
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -93,6 +96,46 @@ spec:
             periodSeconds: 1
             initialDelaySeconds: 10
             failureThreshold: 6
+        - name: unbound
+          image: "%%UNBOUND_IMAGE%%"
+          imagePullPolicy: IfNotPresent
+          args:
+            - -c
+            - /etc/unbound/unbound.conf
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/unbound
+              readOnly: true
+            - name: temporary-volume
+              mountPath: /tmp
+          ports:
+            - containerPort: 53
+              name: dns
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          livenessProbe:
+            tcpSocket:
+              port: 53
+              host: 127.0.0.1
+            periodSeconds: 1
+            initialDelaySeconds: 1
+            failureThreshold: 6
       volumes:
         - name: cache
           emptyDir: {}
@@ -102,6 +145,16 @@ spec:
             items:
               - key: squid.conf
                 path: squid.conf
+        - name: config-volume
+          configMap:
+            name: unbound
+            items:
+              - key: unbound.conf
+                path: unbound.conf
+              - key: root.hints
+                path: root.hints
+        - name: temporary-volume
+          emptyDir: {}
 ---
 kind: Service
 apiVersion: v1

--- a/ignitions/common/files/etc/systemd/system/docker.service.d/90-proxy.conf
+++ b/ignitions/common/files/etc/systemd/system/docker.service.d/90-proxy.conf
@@ -1,3 +1,3 @@
 [Service]
-Environment="HTTP_PROXY=http://squid.internet-egress.svc.cluster.local:3128"
-Environment="HTTPS_PROXY=http://squid.internet-egress.svc.cluster.local:3128"
+Environment="HTTP_PROXY=http://127.0.0.1:30128"
+Environment="HTTPS_PROXY=http://127.0.0.1:30128"

--- a/ignitions/common/files/etc/systemd/system/docker.service.d/90-proxy.conf
+++ b/ignitions/common/files/etc/systemd/system/docker.service.d/90-proxy.conf
@@ -1,3 +1,3 @@
 [Service]
-Environment="HTTP_PROXY=http://127.0.0.1:30128"
-Environment="HTTPS_PROXY=http://127.0.0.1:30128"
+Environment="HTTP_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
+Environment="HTTPS_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"

--- a/ignitions/common/systemd/k8s-containerd.service
+++ b/ignitions/common/systemd/k8s-containerd.service
@@ -11,8 +11,8 @@ Restart=always
 ExecStartPre=/usr/bin/mkdir -p /var/lib/k8s-containerd
 ExecStartPre=/usr/bin/mkdir -p /run/k8s-containerd
 ExecStart=/opt/sbin/containerd --config /etc/k8s-containerd/config.toml
-Environment="HTTP_PROXY=http://127.0.0.1:30128"
-Environment="HTTPS_PROXY=http://127.0.0.1:30128"
+Environment="HTTP_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
+Environment="HTTPS_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
 
 # (lack of) limits from the upstream docker service unit
 LimitNOFILE=1048576

--- a/ignitions/common/systemd/k8s-containerd.service
+++ b/ignitions/common/systemd/k8s-containerd.service
@@ -11,8 +11,8 @@ Restart=always
 ExecStartPre=/usr/bin/mkdir -p /var/lib/k8s-containerd
 ExecStartPre=/usr/bin/mkdir -p /run/k8s-containerd
 ExecStart=/opt/sbin/containerd --config /etc/k8s-containerd/config.toml
-Environment="HTTP_PROXY=http://squid.internet-egress.svc.cluster.local:3128"
-Environment="HTTPS_PROXY=http://squid.internet-egress.svc.cluster.local:3128"
+Environment="HTTP_PROXY=http://127.0.0.1:30128"
+Environment="HTTPS_PROXY=http://127.0.0.1:30128"
 
 # (lack of) limits from the upstream docker service unit
 LimitNOFILE=1048576


### PR DESCRIPTION
## Problem

Currently, upgrading container images of node-local DNS cache fails because of two reasons:

1. Squid, the HTTP proxy used by docker / containerd to pull images, depends on the node-local DNS.
2. Docker and containerd themselves depend on node-local DNS to resolve squid hostname.

## Solution

- Make container runtimes use NodePort to access node-local DNS cache
- Add unbound container to Squid pod and make squid depends on that container.