### PR TITLE
Use different context when updater sends slack notification

### DIFF
--- a/ext/notifier.go
+++ b/ext/notifier.go
@@ -9,21 +9,21 @@ import (
 
 // Notifier notifies the result of update to the outside.
 type Notifier interface {
-	NotifyInfo(ctx context.Context, req neco.UpdateRequest, message string) error
-	NotifySucceeded(ctx context.Context, req neco.UpdateRequest) error
-	NotifyFailure(ctx context.Context, req neco.UpdateRequest, message string) error
+	NotifyInfo(req neco.UpdateRequest, message string) error
+	NotifySucceeded(req neco.UpdateRequest) error
+	NotifyFailure(req neco.UpdateRequest, message string) error
 }
 
 type nopNotifier struct {
 }
 
-func (n nopNotifier) NotifyInfo(ctx context.Context, req neco.UpdateRequest, message string) error {
+func (n nopNotifier) NotifyInfo(req neco.UpdateRequest, message string) error {
 	return nil
 }
-func (n nopNotifier) NotifySucceeded(ctx context.Context, req neco.UpdateRequest) error {
+func (n nopNotifier) NotifySucceeded(req neco.UpdateRequest) error {
 	return nil
 }
-func (n nopNotifier) NotifyFailure(ctx context.Context, req neco.UpdateRequest, message string) error {
+func (n nopNotifier) NotifyFailure(req neco.UpdateRequest, message string) error {
 	return nil
 }
 

--- a/ext/slack.go
+++ b/ext/slack.go
@@ -48,7 +48,6 @@ type Attachment struct {
 	ThumbURL   string            `json:"thumb_url,omitempty"`
 	Footer     string            `json:"footer,omitempty"`
 	FooterIcon string            `json:"footer_icon,omitempty"`
-	Timestamp  time.Time         `json:"ts,omitempty"`
 }
 
 // SlackClient is a slack client
@@ -58,7 +57,7 @@ type SlackClient struct {
 }
 
 // PostWebHook posts a payload to slack
-func (c SlackClient) PostWebHook(ctx context.Context, payload Payload) error {
+func (c SlackClient) PostWebHook(payload Payload) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return err
@@ -67,6 +66,10 @@ func (c SlackClient) PostWebHook(ctx context.Context, payload Payload) error {
 	if err != nil {
 		return err
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -86,7 +89,7 @@ func (c SlackClient) PostWebHook(ctx context.Context, payload Payload) error {
 }
 
 // NotifyInfo notifies to slack that update was started.
-func (c SlackClient) NotifyInfo(ctx context.Context, req neco.UpdateRequest, message string) error {
+func (c SlackClient) NotifyInfo(req neco.UpdateRequest, message string) error {
 	att := Attachment{
 		Color:      ColorInfo,
 		AuthorName: "Boot server updater",
@@ -100,11 +103,11 @@ func (c SlackClient) NotifyInfo(ctx context.Context, req neco.UpdateRequest, mes
 		},
 	}
 	payload := Payload{Attachments: []Attachment{att}}
-	return c.PostWebHook(ctx, payload)
+	return c.PostWebHook(payload)
 }
 
 // NotifySucceeded notifies to slack that update was successful.
-func (c SlackClient) NotifySucceeded(ctx context.Context, req neco.UpdateRequest) error {
+func (c SlackClient) NotifySucceeded(req neco.UpdateRequest) error {
 	att := Attachment{
 		Color:      ColorGood,
 		AuthorName: "Boot server updater",
@@ -117,11 +120,11 @@ func (c SlackClient) NotifySucceeded(ctx context.Context, req neco.UpdateRequest
 		},
 	}
 	payload := Payload{Attachments: []Attachment{att}}
-	return c.PostWebHook(ctx, payload)
+	return c.PostWebHook(payload)
 }
 
 // NotifyFailure notifies to slack that update was failure.
-func (c SlackClient) NotifyFailure(ctx context.Context, req neco.UpdateRequest, message string) error {
+func (c SlackClient) NotifyFailure(req neco.UpdateRequest, message string) error {
 	att := Attachment{
 		Color:      ColorDanger,
 		AuthorName: "Boot server updater",
@@ -135,5 +138,5 @@ func (c SlackClient) NotifyFailure(ctx context.Context, req neco.UpdateRequest, 
 		},
 	}
 	payload := Payload{Attachments: []Attachment{att}}
-	return c.PostWebHook(ctx, payload)
+	return c.PostWebHook(payload)
 }

--- a/ext/slack_test.go
+++ b/ext/slack_test.go
@@ -1,15 +1,12 @@
 package ext
 
 import (
-	"context"
 	"testing"
 	"time"
 )
 
 func testPostWebHook(t *testing.T) {
 	t.Skip()
-
-	ctx := context.Background()
 
 	url := "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXX"
 
@@ -41,7 +38,7 @@ func testPostWebHook(t *testing.T) {
 	}
 
 	c := SlackClient{URL: url}
-	err := c.PostWebHook(ctx, Payload{Attachments: attachments})
+	err := c.PostWebHook(Payload{Attachments: attachments})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/updater/server.go
+++ b/updater/server.go
@@ -122,7 +122,7 @@ func (s Server) runLoop(ctx context.Context, leaderKey string) error {
 			if err != nil {
 				return err
 			}
-			err = s.notifier.NotifyInfo(ctx, req, "start boot servers reconfiguration.")
+			err = s.notifier.NotifyInfo(req, "start boot servers reconfiguration.")
 			if err != nil {
 				log.Warn("failed to notify", map[string]interface{}{log.FnError: err})
 			}
@@ -136,7 +136,7 @@ func (s Server) runLoop(ctx context.Context, leaderKey string) error {
 			if err != nil {
 				return err
 			}
-			err = s.notifier.NotifyInfo(ctx, req, "start updating the new release.")
+			err = s.notifier.NotifyInfo(req, "start updating the new release.")
 			if err != nil {
 				log.Warn("failed to notify", map[string]interface{}{log.FnError: err})
 			}
@@ -180,7 +180,7 @@ func (s Server) waitComplete(ctx context.Context, leaderKey string, ss *storage.
 			"started_at": ss.Request.StartedAt,
 			"timeout":    timeout.String(),
 		})
-		err = s.notifier.NotifyFailure(ctx, *ss.Request, fmt.Sprintf("timeout occurred: %s", timeout.String()))
+		err = s.notifier.NotifyFailure(*ss.Request, fmt.Sprintf("timeout occurred: %s", timeout.String()))
 		if err != nil {
 			log.Warn("failed to notify", map[string]interface{}{log.FnError: err})
 		}
@@ -208,7 +208,7 @@ func (h statusHandler) handleStatus(ctx context.Context, lrn int, st *neco.Updat
 			"lrn":     lrn,
 			"message": st.Message,
 		})
-		err := h.notifier.NotifyFailure(ctx, *h.req, "update request was aborted: "+st.Message)
+		err := h.notifier.NotifyFailure(*h.req, "update request was aborted: "+st.Message)
 		if err != nil {
 			log.Warn("failed to notify", map[string]interface{}{log.FnError: err})
 		}
@@ -226,7 +226,7 @@ func (h statusHandler) handleStatus(ctx context.Context, lrn int, st *neco.Updat
 			"version": h.req.Version,
 			"servers": h.req.Servers,
 		})
-		err := h.notifier.NotifySucceeded(ctx, *h.req)
+		err := h.notifier.NotifySucceeded(*h.req)
 		if err != nil {
 			log.Warn("failed to notify", map[string]interface{}{log.FnError: err})
 		}


### PR DESCRIPTION
neco-updater does not send a notification sometimes when
context is canceled due to updating or restarting.

warning: "failed to notify" error="Post https://hooks.slack.com/services/foo/bar context canceled"

Also omit "ts" field from the slack attachment JSON for removing default
time.Time in the notification message.