### PR TITLE
[dctest] retry "neco bmc setup-hw".

### DIFF
--- a/dctest/machines.go
+++ b/dctest/machines.go
@@ -1,7 +1,8 @@
 package dctest
 
 import (
-	"github.com/cybozu-go/log"
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -24,15 +25,13 @@ func TestMachines() {
 
 	It("should setup boot server hardware", func() {
 		for _, host := range []string{boot0, boot1, boot2} {
-			stdout, stderr, err := execAt(host, "sudo", "neco", "bmc", "setup-hw")
-			if err != nil {
-				log.Error("setup-hw", map[string]interface{}{
-					"host":   host,
-					"stdout": string(stdout),
-					"stderr": string(stderr),
-				})
-				Expect(err).NotTo(HaveOccurred())
-			}
+			Eventually(func() error {
+				stdout, stderr, err := execAt(host, "sudo", "neco", "bmc", "setup-hw")
+				if err != nil {
+					return fmt.Errorf("neco bmc setup-hw failed; err: %s, stdout: %s, stderr: %s", err, stdout, stderr)
+				}
+				return nil
+			}).Should(Succeed())
 		}
 	})
 }

--- a/dctest/machines.go
+++ b/dctest/machines.go
@@ -28,7 +28,7 @@ func TestMachines() {
 			Eventually(func() error {
 				stdout, stderr, err := execAt(host, "sudo", "neco", "bmc", "setup-hw")
 				if err != nil {
-					return fmt.Errorf("neco bmc setup-hw failed; err: %s, stdout: %s, stderr: %s", err, stdout, stderr)
+					return fmt.Errorf("neco bmc setup-hw failed; host: %s, err: %s, stdout: %s, stderr: %s", host, err, stdout, stderr)
 				}
 				return nil
 			}).Should(Succeed())


### PR DESCRIPTION
`neco bmc setup-hw` in dctest/machines.go failed once.
This does not succeed until `rkt run setup-hw` in setup-hw.service fetches and runs a setup-hw container,
so test it in an eventually loop.