### PR TITLE
[neco] Add settings to service files to write logs to console

### DIFF
--- a/ignitions/common/systemd/bird-wait.service
+++ b/ignitions/common/systemd/bird-wait.service
@@ -9,6 +9,9 @@ Wants=network-online.target
 Type=oneshot
 ExecStart=/opt/sbin/bird-wait
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/chrony-wait.service
+++ b/ignitions/common/systemd/chrony-wait.service
@@ -8,6 +8,9 @@ Before=time-sync.target
 Type=oneshot
 ExecStart=/opt/sbin/chrony-wait
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/cke-images.service
+++ b/ignitions/common/systemd/cke-images.service
@@ -21,6 +21,9 @@ ExecStart=/opt/bin/load-containerd-image \
   {{ MyURL }}/api/v1/assets/{{ Metadata "cke:coredns.img" }}   {{ Metadata "cke:coredns.ref" }}
 ExecStart=/opt/bin/load-containerd-image \
   {{ MyURL }}/api/v1/assets/{{ Metadata "cke:unbound.img" }}   {{ Metadata "cke:unbound.ref" }}
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/coil-image.service
+++ b/ignitions/common/systemd/coil-image.service
@@ -8,6 +8,9 @@ After=network-online.target wait-k8s-containerd-socket.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/opt/bin/load-containerd-image {{ MyURL }}/api/v1/assets/{{ Metadata "coil.img" }} {{ Metadata "coil.ref" }}
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/disable-nic-offload.service
+++ b/ignitions/common/systemd/disable-nic-offload.service
@@ -9,6 +9,9 @@ Type=oneshot
 ExecStart=/usr/sbin/ethtool -K eno1 tx off rx off
 ExecStart=/usr/sbin/ethtool -K eno2 tx off rx off
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/disable-transparent-hugepage.service
+++ b/ignitions/common/systemd/disable-transparent-hugepage.service
@@ -8,6 +8,9 @@ AssertPathIsReadWrite=/sys/kernel/mm/transparent_hugepage/enabled
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c 'echo never > /sys/kernel/mm/transparent_hugepage/enabled'
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=basic.target

--- a/ignitions/common/systemd/exec-setup-hw.service
+++ b/ignitions/common/systemd/exec-setup-hw.service
@@ -8,6 +8,9 @@ After=setup-hw.service setup-bmc-user.service
 Type=oneshot
 ExecStart=/opt/sbin/setup-hw
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/neco-wait-dhcp-online.service
+++ b/ignitions/common/systemd/neco-wait-dhcp-online.service
@@ -8,6 +8,9 @@ Before=network-online.target
 Type=oneshot
 ExecStart=/opt/sbin/neco-wait-dhcp-online
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/sabakan-cryptsetup.service
+++ b/ignitions/common/systemd/sabakan-cryptsetup.service
@@ -11,6 +11,9 @@ ExecStart=/usr/bin/curl -sfSL -o /opt/sbin/sabakan-cryptsetup {{ MyURL }}/api/v1
 ExecStart=/bin/chmod a+x /opt/sbin/sabakan-cryptsetup
 ExecStart=/opt/sbin/sabakan-cryptsetup
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/setup-bmc-user.service
+++ b/ignitions/common/systemd/setup-bmc-user.service
@@ -7,3 +7,5 @@ After=network-online.target
 Type=oneshot
 ExecStart=/opt/sbin/setup-bmc-user
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console

--- a/ignitions/common/systemd/setup-k8s-containerd.service
+++ b/ignitions/common/systemd/setup-k8s-containerd.service
@@ -7,6 +7,9 @@ After=data.mount
 Type=oneshot
 ExecStart=/opt/sbin/setup-containerd
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/setup-network.service
+++ b/ignitions/common/systemd/setup-network.service
@@ -7,3 +7,5 @@ After=var-lib-rkt.mount
 Type=oneshot
 ExecStart=/opt/sbin/setup-local-network
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console

--- a/ignitions/common/systemd/setup-node-exporter.service
+++ b/ignitions/common/systemd/setup-node-exporter.service
@@ -7,3 +7,5 @@ After=network-online.target
 Type=oneshot
 ExecStart=/opt/sbin/setup-node-exporter
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console

--- a/ignitions/common/systemd/setup-serf.service
+++ b/ignitions/common/systemd/setup-serf.service
@@ -8,3 +8,5 @@ After=network-online.target
 Type=oneshot
 ExecStart=/opt/sbin/setup-serf-conf
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console

--- a/ignitions/common/systemd/setup-var.service
+++ b/ignitions/common/systemd/setup-var.service
@@ -9,6 +9,9 @@ DefaultDependencies=no
 Type=oneshot
 ExecStart=/opt/sbin/setup-var
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/squid-image.service
+++ b/ignitions/common/systemd/squid-image.service
@@ -8,6 +8,9 @@ After=network-online.target wait-k8s-containerd-socket.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/opt/bin/load-containerd-image {{ MyURL }}/api/v1/assets/{{ Metadata "squid.img" }} {{ Metadata "squid.ref" }}
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ignitions/common/systemd/tune-rt-runtime.service
+++ b/ignitions/common/systemd/tune-rt-runtime.service
@@ -7,3 +7,5 @@ Wants=machine.slice
 Type=oneshot
 ExecStart=/opt/sbin/tune-rt-runtime
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console

--- a/ignitions/common/systemd/wait-k8s-containerd-socket.service
+++ b/ignitions/common/systemd/wait-k8s-containerd-socket.service
@@ -7,6 +7,9 @@ After=k8s-containerd.service
 Type=oneshot
 ExecStart=/opt/bin/wait-k8s-containerd-socket
 RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As all service processes with standard output and standard error are connected to the journal by default, we need to wait until we can use journalctl. By this change, the standard outputs and standard errors are also written to serial console and we do not need to wait anymore.