### PR TITLE
Update for cke-1.14

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -18,12 +18,9 @@ CRITOOLS_VERSION = 1.13.0
 ARGOCD_VERSION = 0.12.1
 
 ### for kubectl
-K8S_VERSION = 1.13.2
+K8S_VERSION = 1.14.1
 
-### for kustomize
-KUSTOMIZE_VERSION = 2.0.3
-
-all: node_exporter containerd crictl argocd kubectl kustomize
+all: node_exporter containerd crictl argocd kubectl
 
 node_exporter:
 	rm -f $(LIBEXECDIR)/node_exporter
@@ -77,13 +74,6 @@ kubectl:
 	chmod +x $(BINDIR)/kubectl
 	curl -fsSL -o $(DOCDIR)/$@/LICENSE https://raw.githubusercontent.com/kubernetes/kubernetes/v$(K8S_VERSION)/LICENSE
 	curl -fsSL -o $(DOCDIR)/$@/README.md https://raw.githubusercontent.com/kubernetes/kubernetes/v$(K8S_VERSION)/README.md
-
-kustomize:
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/
-	curl -sSLf -o $(BINDIR)/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_linux_amd64
-	chmod +x $(BINDIR)/kustomize
-	curl -fsSL -o $(DOCDIR)/$@/README.md https://raw.githubusercontent.com/kubernetes-sigs/kustomize/v$(KUSTOMIZE_VERSION)/README.md
-	curl -fsSL -o $(DOCDIR)/$@/LICENSE https://raw.githubusercontent.com/kubernetes-sigs/kustomize/v$(KUSTOMIZE_VERSION)/LICENSE
 
 setup:
 	$(SUDO) apt-get update

--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.13.18", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.14.0-rc1", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.12.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.2.0", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.3.0", Private: false},

--- a/etc/coil-deploy.yml
+++ b/etc/coil-deploy.yml
@@ -67,7 +67,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure coil gets scheduled on all nodes.
@@ -182,7 +182,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.


### PR DESCRIPTION
- Update cke version in artifacts.go
- Specify `--ipvs-strict-arp` option for `kube-proxy`
- Replace `beta.kubernetes.io/os` with `kubernetes.io/os`
- Limit process group with `RunAsGroup` in PodSecurityPolicy
- Remove `kustomize` from debian package