### PR TITLE
[ignition] enable lvm2-monitor.service

### DIFF
--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -25,6 +25,10 @@ lvsize() {
 }
 
 prepare_lv() {
+    # enable COW volume auto extension
+    lvmconfig --config activation/snapshot_autoextend_threshold=70 \
+      --withsummary --withcomments --withspaces --withversions -f /etc/lvm/lvm.conf
+
     # When lvmetad is used, PVs are not scaned by vgchange.
     # We need to scan PVs manually and send infomation to lvmetad. 
     pvscan --cache -a ay

--- a/ignitions/common/systemd/setup-var.service
+++ b/ignitions/common/systemd/setup-var.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Setup filesystem for /var
-Wants=lvm2-lvmetad.service
+Wants=lvm2-lvmetad.service lvm2-monitor.service
 Requires=sabakan-cryptsetup.service
 After=lvm2-lvmetad.service sabakan-cryptsetup.service
+Before=lvm2-monitor.service
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
This service monitors LVM2 snapshots and automatically
extends COW blocks when it runs low.