### PR TITLE
Replace vmx-enabled base OS with Ubuntu 18.04

### DIFF
--- a/gcp/artifacts.go
+++ b/gcp/artifacts.go
@@ -1,14 +1,14 @@
 package gcp
 
 var artifacts = artifactSet{
-	goVersion:           "1.12.1",
+	goVersion:           "1.12.5",
 	rktVersion:          "1.30.0",
-	etcdVersion:         "3.3.12",
+	etcdVersion:         "3.3.13",
 	placematVersion:     "1.3.5",
 	customUbuntuVersion: "20190312",
-	coreOSVersion:       "2023.4.0",
+	coreOSVersion:       "2079.4.0",
 	ctVersion:           "0.9.0",
-	protobufVersion:     "3.7.0",
+	protobufVersion:     "3.8.0",
 	debPackages: []string{
 		"git",
 		"build-essential",

--- a/gcp/config.go
+++ b/gcp/config.go
@@ -14,8 +14,8 @@ const (
 	// DefaultPreemptible is default value for enabling preemptible
 	// https://cloud.google.com/compute/docs/instances/preemptible
 	defaultPreemptible            = false
-	defaultVmxEnabledImage        = "debian-9-stretch-v20180911"
-	defaultVmxEnabledImageProject = "debian-cloud"
+	defaultVmxEnabledImage        = "ubuntu-1804-bionic-v20190429"
+	defaultVmxEnabledImageProject = "ubuntu-os-cloud"
 )
 
 // Config is configuration for necogcp command and GAE app

--- a/gcp/vmxenabled.go
+++ b/gcp/vmxenabled.go
@@ -143,6 +143,11 @@ func configureDNS(ctx context.Context) error {
 
 	newData := strings.Replace(string(data), "nameserver 127.0.0.53", "nameserver 169.254.169.254", -1)
 
+	err = os.Remove("/etc/resolv.conf")
+	if err != nil {
+		return err
+	}
+
 	return neco.WriteFile("/etc/resolv.conf", newData)
 }
 


### PR DESCRIPTION
We should use the same Linux distribution on the local development environment and host-vm.
We're still using Debian 9 for host-vm. It is a stable version, but most of the package versions are older than Ubuntu 18.04.