### PR TITLE
Update CKE and coil

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,13 +5,13 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.14.8", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.14.11", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.13.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.5", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.4.3", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.8.3.2", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.1.2.1", Private: false},
-		{Name: "coil", Repository: "quay.io/cybozu/coil", Tag: "1.1.2", Private: false},
+		{Name: "coil", Repository: "quay.io/cybozu/coil", Tag: "1.1.4", Private: false},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "3.5.27.1.5", Private: false},
 	},
 	Debs: []DebianPackage{

--- a/etc/pod-security-policy.yml
+++ b/etc/pod-security-policy.yml
@@ -2,9 +2,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
 spec:
   privileged: false
   # Required to prevent escalations to root.
@@ -82,9 +79,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: coil
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
 spec:
   privileged: true
   allowPrivilegeEscalation: true
@@ -117,9 +111,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: squid
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities:
@@ -147,9 +138,6 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: unbound
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
 spec:
   allowPrivilegeEscalation: false
   allowedCapabilities:


### PR DESCRIPTION
In addition, remove `seccomp.security.alpha.kubernetes.io/*` annotations
from PodSecurityPolicies because `docker/default` was deprecated as of
Kubernetes 1.11.