### PR TITLE
Integrate scripts for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,12 @@ commands:
   dctest-command:
     description: "datacenter test"
     parameters:
-      script:
-        type: string
       suite:
         type: string
       datacenter:
+        type: string
+        default: ""
+      tag:
         type: string
         default: ""
     steps:
@@ -54,7 +55,7 @@ commands:
       - run:
           command: |
             if [ -f .skip ]; then exit 0; fi
-            ./bin/<<parameters.script>> <<parameters.suite>> <<parameters.datacenter>>
+            ./bin/run-dctest.sh <<parameters.suite>> <<parameters.datacenter>> <<parameters.tag>>
           no_output_timeout: 20m
 
 jobs:
@@ -102,7 +103,6 @@ jobs:
     steps:
       - checkout
       - dctest-command:
-          script: run-dctest.sh
           suite: ./bootstrap
       - run:
           name: run dctest functions
@@ -123,9 +123,9 @@ jobs:
     steps:
       - checkout
       - dctest-command:
-          script: run-dctest-release.sh
           suite: ./bootstrap
           datacenter: staging
+          tag: release
       - run:
           command: ./bin/run-dctest-suite.sh upgrade
           no_output_timeout: 20m
@@ -166,9 +166,10 @@ jobs:
             diffs=$(git status -s)
             if [ "$diffs" = "" ]; then touch .skip; exit 0; fi
             printf "%s\n" "$diffs"
+        # Skip the following steps if there is no difference.
       - dctest-command:
-          script: run-dctest-release.sh
           suite: ./bootstrap
+          tag: release
       - run:
           name: Run tests
           command: |
@@ -197,9 +198,9 @@ jobs:
       - run: git merge --no-commit origin/${CIRCLE_BRANCH}
       - run: cp /tmp/workspace/artifacts_release.go .
       - dctest-command:
-          script: run-dctest-release.sh
           suite: ./bootstrap
           datacenter: staging
+          tag: release
       - run:
           command: ./bin/run-dctest-suite.sh upgrade release
           no_output_timeout: 20m
@@ -212,6 +213,9 @@ jobs:
     docker:
       - image: quay.io/cybozu/golang:1.12-bionic
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "d7:2a:c8:5d:c4:32:7e:20:6f:bc:20:7c:ab:c4:24:88"
       - checkout
       - attach_workspace:
           at: /tmp/workspace
@@ -229,9 +233,7 @@ jobs:
             diffs=$(git status -s)
             if [ "$diffs" = "" ]; then touch .skip; exit 0; fi
             printf "%s\n" "$diffs"
-      - add_ssh_keys:
-          fingerprints:
-            - "d7:2a:c8:5d:c4:32:7e:20:6f:bc:20:7c:ab:c4:24:88"
+        # Skip the following steps if there is no difference.
       - run:
           name: Store github-token
           command: |

--- a/bin/run-dctest-suite.sh
+++ b/bin/run-dctest-suite.sh
@@ -8,14 +8,13 @@ TAG_NAME=$2
 cat >run.sh <<EOF
 #!/bin/sh -e
 
-GOPATH=\$HOME/go
-export GOPATH
-PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH
-export PATH
+# Set environment variables
+export GO111MODULE=on
+export GOPATH=\$HOME/go
+export PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH
 
 # Run dctest
 cd \$GOPATH/src/github.com/cybozu-go/neco/dctest
-export GO111MODULE=on
 exec make test TAGS=${TAG_NAME} SUITE=${SUITE_NAME}
 EOF
 chmod +x run.sh

--- a/bin/run-dctest-suite.sh
+++ b/bin/run-dctest-suite.sh
@@ -9,12 +9,15 @@ cat >run.sh <<EOF
 #!/bin/sh -e
 
 # Set environment variables
-export GO111MODULE=on
-export GOPATH=\$HOME/go
-export PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH
+GO111MODULE=on
+export GO111MODULE
+GOPATH=\${HOME}/go
+export GOPATH
+PATH=/usr/local/go/bin:\${GOPATH}/bin:\${PATH}
+export PATH
 
 # Run dctest
-cd \$GOPATH/src/github.com/cybozu-go/neco/dctest
+cd \${GOPATH}/src/github.com/cybozu-go/neco/dctest
 exec make test TAGS=${TAG_NAME} SUITE=${SUITE_NAME}
 EOF
 chmod +x run.sh

--- a/bin/run-dctest.sh
+++ b/bin/run-dctest.sh
@@ -33,12 +33,15 @@ mount -t ext4 /dev/disk/by-id/google-local-ssd-0 /var/scratch
 chmod 1777 /var/scratch
 
 # Set environment variables
-export GO111MODULE=on
-export GOPATH=\${HOME}/go
-export PATH=/usr/local/go/bin:\${GOPATH}/bin:\${PATH}
+GO111MODULE=on
+export GO111MODULE
+GOPATH=\${HOME}/go
+export GOPATH
+PATH=/usr/local/go/bin:\${GOPATH}/bin:\${PATH}
+export PATH
 
-NECO_DIR=\$GOPATH/src/github.com/cybozu-go/neco
-TEMP_DIR=/tme/release
+NECO_DIR=\${GOPATH}/src/github.com/cybozu-go/neco
+TEMP_DIR=/tmp/release
 
 # Prepare neco repository
 mkdir -p \${NECO_DIR}

--- a/bin/run-dctest.sh
+++ b/bin/run-dctest.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -ex
 
-SUITE=$1
-DATACENTER=$2
-
 . $(dirname $0)/env
+SUITE_NAME=$1
+DATACENTER=$2
+TAG_NAME=$3
 
 # Create GCE instance
 $GCLOUD compute instances delete ${INSTANCE_NAME} --zone ${ZONE} --quiet || true
@@ -32,30 +32,48 @@ mkdir -p /var/scratch
 mount -t ext4 /dev/disk/by-id/google-local-ssd-0 /var/scratch
 chmod 1777 /var/scratch
 
-# Run dctest
-GOPATH=\$HOME/go
-export GOPATH
-PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH
-export PATH
-
-git clone https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-cd \$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
-git checkout -qf ${CIRCLE_SHA1}
-
-cd dctest
-cp /home/cybozu/secrets .
-cp /home/cybozu/github-token .
-cp /assets/cybozu-ubuntu-18.04-server-cloudimg-amd64.img .
+# Set environment variables
 export GO111MODULE=on
+export GOPATH=\${HOME}/go
+export PATH=/usr/local/go/bin:\${GOPATH}/bin:\${PATH}
+
+NECO_DIR=\$GOPATH/src/github.com/cybozu-go/neco
+TEMP_DIR=/tme/release
+
+# Prepare neco repository
+mkdir -p \${NECO_DIR}
+cd \${NECO_DIR}
+tar xzf /home/cybozu/neco.tgz
+
+# Prepare files
+cp \${NECO_DIR}/github-token \${NECO_DIR}/dctest/
+cp \${NECO_DIR}/secrets \${NECO_DIR}/dctest/
+cp /assets/cybozu-ubuntu-18.04-server-cloudimg-amd64.img \${NECO_DIR}/dctest/
+
+# Check out released sources which are used in the specified datacenter
+if [ -n "${DATACENTER}" ]; then
+  go install -mod=vendor ./pkg/find-installed-release
+  RELEASE=\$(find-installed-release ${DATACENTER})
+  git worktree add \${TEMP_DIR} release-\$RELEASE
+  cd \${TEMP_DIR}
+
+  # Prepare files
+  cp \${NECO_DIR}/github-token \${TEMP_DIR}/dctest/
+  cp \${NECO_DIR}/secrets \${TEMP_DIR}/dctest/
+  cp /assets/cybozu-ubuntu-18.04-server-cloudimg-amd64.img \${TEMP_DIR}/dctest/
+fi
+
+# Run dctest
+cd dctest
 make setup
-make placemat
+make placemat TAGS=${TAG_NAME}
 sleep 3
-exec make test SUITE=${SUITE} DATACENTER=${DATACENTER}
+exec make test TAGS=${TAG_NAME} SUITE=${SUITE_NAME} DATACENTER=${DATACENTER}
 EOF
 chmod +x run.sh
 
-$GCLOUD compute scp --zone=${ZONE} secrets cybozu@${INSTANCE_NAME}:
-$GCLOUD compute scp --zone=${ZONE} github-token cybozu@${INSTANCE_NAME}:
+tar czf /tmp/neco.tgz .
+$GCLOUD compute scp --zone=${ZONE} /tmp/neco.tgz cybozu@${INSTANCE_NAME}:
 $GCLOUD compute scp --zone=${ZONE} run.sh cybozu@${INSTANCE_NAME}:
 set +e
 $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command='sudo -H /home/cybozu/run.sh'


### PR DESCRIPTION
Integrate the 2 scripts(`bin/run-dctest.sh`, `bin/run-dctest-release.sh`) into `bin/run-dctest.sh`.

But `bin/run-dctest-release.sh` is not deleted because it is still used in neco-apps.