### PR TITLE
[systemd] Add etcd-container.service to Wants=, After=

### DIFF
--- a/progs/cke/templates.go
+++ b/progs/cke/templates.go
@@ -5,8 +5,8 @@ import "text/template"
 var serviceTmpl = template.Must(template.New("cke.service").
 	Parse(`[Unit]
 Description=CKE container
-Wants=network-online.target etcd-container.service
-After=network-online.target etcd-container.service
+Wants=network-online.target etcd-container.service vault.service
+After=network-online.target etcd-container.service vault.service
 ConditionPathExists={{ .ConfFile }}
 ConditionPathExists={{ .CertFile }}
 ConditionPathExists={{ .KeyFile }}
@@ -17,7 +17,7 @@ Slice=machine.slice
 Type=simple
 KillMode=mixed
 Restart=on-failure
-RestartSec=10s
+RestartSec=30s
 ExecStart=/usr/bin/rkt run \
   --pull-policy never \
   --net=host \

--- a/progs/cke/templates.go
+++ b/progs/cke/templates.go
@@ -5,8 +5,8 @@ import "text/template"
 var serviceTmpl = template.Must(template.New("cke.service").
 	Parse(`[Unit]
 Description=CKE container
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target etcd-container.service
+After=network-online.target etcd-container.service
 ConditionPathExists={{ .ConfFile }}
 ConditionPathExists={{ .CertFile }}
 ConditionPathExists={{ .KeyFile }}

--- a/progs/etcdpasswd/conf.go
+++ b/progs/etcdpasswd/conf.go
@@ -31,6 +31,10 @@ Wants=etcd-container.service
 After=etcd-container.service
 ConditionPathExists=%s
 ConditionPathExists=%s
+StartLimitIntervalSec=600s
+
+[Service]
+RestartSec=30s
 `
 	_, err := fmt.Fprintf(w, tmpl, neco.EtcdpasswdCertFile, neco.EtcdpasswdKeyFile)
 	return err

--- a/progs/etcdpasswd/conf.go
+++ b/progs/etcdpasswd/conf.go
@@ -27,6 +27,8 @@ func GenerateConf(w io.Writer, lrns []int) error {
 func GenerateSystemdDropIn(w io.Writer) error {
 	tmpl := `
 [Unit]
+Wants=etcd-container.service
+After=etcd-container.service
 ConditionPathExists=%s
 ConditionPathExists=%s
 `

--- a/progs/sabakan/template.go
+++ b/progs/sabakan/template.go
@@ -16,7 +16,7 @@ Slice=machine.slice
 Type=simple
 KillMode=mixed
 Restart=on-failure
-RestartSec=10s
+RestartSec=30s
 ExecStart=/usr/bin/rkt run \
   --pull-policy never --net=host \
   --volume neco,kind=host,source=/etc/neco,readOnly=true \

--- a/progs/sabakan/template.go
+++ b/progs/sabakan/template.go
@@ -4,8 +4,8 @@ import "text/template"
 
 var serviceTmpl = template.Must(template.New("sabakan.service").Parse(`[Unit]
 Description=Sabakan container on rkt
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target etcd-container.service
+After=network-online.target etcd-container.service
 ConditionPathExists={{ .ConfFile }}
 ConditionPathExists={{ .CertFile }}
 ConditionPathExists={{ .KeyFile }}

--- a/progs/vault/templates.go
+++ b/progs/vault/templates.go
@@ -26,8 +26,8 @@ storage "etcd" {
 var serviceTmpl = template.Must(template.New("vault.service").
 	Parse(`[Unit]
 Description=Vault container
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target etcd-container.service
+After=network-online.target etcd-container.service
 StartLimitIntervalSec=600s
 
 [Service]

--- a/progs/vault/templates.go
+++ b/progs/vault/templates.go
@@ -26,8 +26,8 @@ storage "etcd" {
 var serviceTmpl = template.Must(template.New("vault.service").
 	Parse(`[Unit]
 Description=Vault container
-Wants=network-online.target etcd-container.service vault.service
-After=network-online.target etcd-container.service vault.service
+Wants=network-online.target etcd-container.service
+After=network-online.target etcd-container.service
 StartLimitIntervalSec=600s
 
 [Service]

--- a/progs/vault/templates.go
+++ b/progs/vault/templates.go
@@ -26,8 +26,8 @@ storage "etcd" {
 var serviceTmpl = template.Must(template.New("vault.service").
 	Parse(`[Unit]
 Description=Vault container
-Wants=network-online.target etcd-container.service
-After=network-online.target etcd-container.service
+Wants=network-online.target etcd-container.service vault.service
+After=network-online.target etcd-container.service vault.service
 StartLimitIntervalSec=600s
 
 [Service]


### PR DESCRIPTION
When boot server restarts, etcd required systemd services might be
failed to start because etcd cluster in the boot server is not yet ready.

Ref: https://circleci.com/gh/cybozu-go/neco/5858

To solve the problem, add etcd-container.service to `Wants=` and `After=`, and extend restart interval `RestartSec=`