### PR TITLE
[cke] Increase quota DB size

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -52,4 +52,7 @@ options:
     container_log_max_size: 10Mi
     container_log_max_files: 10
   etcd:
-    extra_args: ["--listen-metrics-urls=http://0.0.0.0:2381"]
+    extra_args:
+      - --listen-metrics-urls=http://0.0.0.0:2381
+      # 8 * 1024 * 1024 * 1024 = 8589934592 = 8GB
+      - --quota-backend-bytes=8589934592


### PR DESCRIPTION
Current K8s cluster already has etcd alert rules. and the cke-etcd DB
usage is:

- `etcd_mvcc_db_total_size_in_bytes`: 1.7GB
- `etcd_mvcc_db_total_size_in_use_in_bytes`: 1.2GB

Even current k8s cluster is stable, `etcd_mvcc_db_total_size_in_use_in_bytes` is
about 1.2GB and is exceeded 50% of `etcd_server_quota_backend_bytes`
2GB. It would be increased when new worker nodes are added and k8s workloads
are increased. We assume DB usage increases and should not be alerted by AlertManager.