### PR TITLE
Update setup-hw to 1.6.8

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -7,17 +7,17 @@ var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
 		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.14.15", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.15.1", Private: false},
-		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.7", Private: true},
+		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.8", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.4.6", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.8.3.2", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.1.2.1", Private: false},
-		{Name: "coil", Repository: "quay.io/cybozu/coil", Tag: "1.1.4", Private: false},
+		{Name: "coil", Repository: "quay.io/cybozu/coil", Tag: "1.1.5", Private: false},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "3.5.27.1.5", Private: false},
 		{Name: "teleport", Repository: "quay.io/cybozu/teleport", Tag: "4.0.2.2", Private: false},
 	},
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.0.0"},
-		{Name: "neco", Owner: "cybozu-go", Repository: "neco", Release: "release-2019.08.14-5916"},
+		{Name: "neco", Owner: "cybozu-go", Repository: "neco", Release: "release-2019.08.23-6190"},
 	},
 	CoreOS: CoreOSImage{Channel: "stable", Version: "2135.6.0"},
 }

--- a/ignitions/common/systemd/setup-hw.service
+++ b/ignitions/common/systemd/setup-hw.service
@@ -13,6 +13,7 @@ OOMScoreAdjust=-1000
 ExecStartPre=-/usr/bin/docker kill setup-hw
 ExecStartPre=-/usr/bin/docker rm setup-hw
 ExecStartPre=/opt/bin/load-docker-image {{ MyURL }}/api/v1/assets/{{ Metadata "setup-hw.img" }} {{ Metadata "setup-hw.ref" }}
+ExecStartPre=-/bin/mkdir -p /var/lib/setup-hw
 ExecStart=/usr/bin/docker run \
   --name setup-hw \
   --log-driver=journald \
@@ -20,6 +21,7 @@ ExecStart=/usr/bin/docker run \
   -v /dev:/dev \
   -v /lib/modules:/lib/modules:ro \
   -v /etc/neco:/etc/neco:ro \
+  -v /var/lib/setup-hw:/var/lib/setup-hw \
   {{ Metadata "setup-hw.ref" }}
 
 [Install]

--- a/progs/setuphw/templates.go
+++ b/progs/setuphw/templates.go
@@ -15,6 +15,7 @@ KillMode=mixed
 Restart=on-failure
 RestartSec=10s
 OOMScoreAdjust=-1000
+ExecStartPre=/bin/mkdir -p /var/lib/setup-hw
 ExecStart=/usr/bin/rkt run \
   --pull-policy=never \
   --insecure-options=all \
@@ -23,6 +24,7 @@ ExecStart=/usr/bin/rkt run \
   --volume sys,kind=host,source=/sys --mount volume=sys,target=/sys \
   --volume modules,kind=host,source=/lib/modules,readOnly=true --mount volume=modules,target=/lib/modules \
   --volume neco,kind=host,source=/etc/neco,readOnly=true --mount volume=neco,target=/etc/neco \
+  --volume var,kind=host,source=/var/lib/setup-hw --mount volume=var,target=/var/lib/setup-hw \
   {{.Image}} \
     --name setup-hw \
     --caps-retain=CAP_SYS_ADMIN,CAP_SYS_CHROOT,CAP_CHOWN,CAP_FOWNER,CAP_NET_ADMIN


### PR DESCRIPTION
/var/lib/setup-hw should be mounted to the same directory
on the host to create `no-reset` file.