### PR TITLE
Reboot upon sabakan-cryptsetup failure

### DIFF
--- a/ignitions/common/systemd/sabakan-cryptsetup.service
+++ b/ignitions/common/systemd/sabakan-cryptsetup.service
@@ -3,6 +3,7 @@ Description=sabakan-cryptsetup
 Wants=neco-wait-dhcp-online.service rngd.service
 After=neco-wait-dhcp-online.service rngd.service
 DefaultDependencies=no
+FailureAction=reboot-immediate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Since it is a critical event, the machine should be rebooted
immediately when sabakan-cryptsetup.service failed.