### PR TITLE
Enable bash completion for argocd

### DIFF
--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -18,6 +18,7 @@ configure() {
     /usr/bin/neco completion > /etc/bash_completion.d/neco
     /usr/bin/kubectl completion bash > /etc/bash_completion.d/kubectl
     /usr/bin/stern --completion bash > /etc/bash_completion.d/stern
+    /usr/bin/argocd completion bash > /etc/bash_completion.d/argocd
 }
 
 if test "$1" = "configure"; then


### PR DESCRIPTION
It is supported since v1.2.0.