### PR TITLE
remove unncessary lables

### DIFF
--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -202,7 +202,6 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: squid
-        k8s-app: squid
     spec:
       # system priority class cannot be specified for pods in namespaces
       # other than kube-system as of k8s 1.12.

--- a/etc/unbound.yml
+++ b/etc/unbound.yml
@@ -154,7 +154,6 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: unbound
-        k8s-app: unbound
     spec:
       # system priority class cannot be specified for pods in namespaces
       # other than kube-system as of k8s 1.12.


### PR DESCRIPTION
This pull request made the following changes.

- remove `k8s-app` label for squid and unbound because the deletion does not affect to `network-policy` anymore.