### PR TITLE
ignitions: Set HTTP(s) proxy from neco metadata

### DIFF
--- a/dctest/contents.go
+++ b/dctest/contents.go
@@ -66,6 +66,7 @@ func TestInitData() {
 		weight, err = strconv.ParseFloat(ckeTemplate.Nodes[2].Labels[sabakan.CKELabelWeight], 64)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(weight).To(BeNumerically("==", 1.000000))
+		execSafeAt(boot0, "neco", "config", "set", "proxy", "http://squid.internet-egress.svc.cluster.local:3128")
 		execSafeAt(boot0, "neco", "init-data")
 	})
 }

--- a/dctest/contents.go
+++ b/dctest/contents.go
@@ -66,6 +66,7 @@ func TestInitData() {
 		weight, err = strconv.ParseFloat(ckeTemplate.Nodes[2].Labels[sabakan.CKELabelWeight], 64)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(weight).To(BeNumerically("==", 1.000000))
+		execSafeAt(boot0, "neco", "init-data", "--upload", "assets")
 		execSafeAt(boot0, "neco", "config", "set", "proxy", "http://squid.internet-egress.svc.cluster.local:3128")
 		execSafeAt(boot0, "neco", "init-data")
 	})

--- a/dctest/squid.go
+++ b/dctest/squid.go
@@ -58,4 +58,8 @@ func TestSquid() {
 		By("removing testhttpd deployments")
 		execSafeAt(boot0, "kubectl", "delete", "deployments/testhttpd")
 	})
+
+	It("reverts proxy config", func() {
+		execSafeAt(boot0, "neco", "config", "set", "proxy", proxy)
+	})
 }

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -65,6 +65,11 @@ Synopsis
     This command must be invoked only once in the cluster after `neco init` and
     `neco init-local` completed.
 
+    When `--upload` option is specified, it uploads only given target.
+    - `all`: Upload ignitions and sabakan & cke assets(default)
+    - `ignitions`: Upload ignitions
+    - `assets`: Upload sabakan & cke assets
+
 * `neco status`
 
     Show the status of the current update process.

--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -331,7 +331,7 @@ metadata:
   name: squid
   namespace: internet-egress
 spec:
-  type: NodePort
+  type: LoadBalancer
   selector:
     app.kubernetes.io/name: squid
   ports:

--- a/ignitions/common/systemd/docker.service
+++ b/ignitions/common/systemd/docker.service
@@ -17,8 +17,8 @@ EnvironmentFile=-/run/flannel/flannel_docker_opts.env
 Environment=DOCKER_SELINUX=--selinux-enabled=true
 
 # settings for Neco
-Environment="HTTP_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
-Environment="HTTPS_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
+Environment="HTTP_PROXY={{ Metadata "proxy_url" }}"
+Environment="HTTPS_PROXY={{ Metadata "proxy_url" }}"
 Environment=DOCKER_OPTS="--bridge=none --iptables=false --ip-masq=false --dns=127.0.0.1 --cpu-rt-runtime=950000"
 LimitMEMLOCK=infinity
 

--- a/ignitions/common/systemd/k8s-containerd.service
+++ b/ignitions/common/systemd/k8s-containerd.service
@@ -11,8 +11,8 @@ Restart=always
 ExecStartPre=/bin/mkdir -p /var/lib/k8s-containerd
 ExecStartPre=/bin/mkdir -p /run/k8s-containerd
 ExecStart=/opt/sbin/containerd --config /etc/k8s-containerd/config.toml
-Environment="HTTP_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
-Environment="HTTPS_PROXY=http://{{ index .Spec.IPv4 0 }}:30128"
+Environment="HTTP_PROXY={{ Metadata "proxy_url" }}"
+Environment="HTTPS_PROXY={{ Metadata "proxy_url" }}"
 
 # (lack of) limits from the upstream docker service unit
 LimitNOFILE=1048576

--- a/progs/sabakan/upload.go
+++ b/progs/sabakan/upload.go
@@ -45,13 +45,7 @@ func UploadContents(ctx context.Context, sabakanHTTP *http.Client, proxyHTTP *ht
 		return uploadAssets(ctx, client, auth)
 	})
 	env.Stop()
-	err = env.Wait()
-	if err != nil {
-		return err
-	}
-
-	// ignitions refers assets, so upload ignitions at the end
-	return uploadIgnitions(ctx, client, version, st)
+	return env.Wait()
 }
 
 // uploadOSImages uploads CoreOS images

--- a/progs/sabakan/upload.go
+++ b/progs/sabakan/upload.go
@@ -298,6 +298,16 @@ func uploadIgnitions(ctx context.Context, c *sabac.Client, id string, st storage
 		return err
 	}
 
+	proxy, err := st.GetProxyConfig(ctx)
+	switch err {
+	case storage.ErrNotFound:
+		metadata["proxy_url"] = ""
+	case nil:
+		metadata["proxy_url"] = proxy
+	default:
+		return err
+	}
+
 	// set boot server addresses in metadata
 	req, err := st.GetRequest(ctx)
 	if err != nil {

--- a/worker/sabakan.go
+++ b/worker/sabakan.go
@@ -136,6 +136,9 @@ func (o *operator) UpdateSabakanContents(ctx context.Context, req *neco.UpdateRe
 	}
 
 	err = sabakan.UploadContents(ctx, o.localClient, o.proxyClient, req.Version, auth, o.storage)
+	if err == nil {
+		err = sabakan.UploadIgnitions(ctx, o.localClient, req.Version, o.storage)
+	}
 	ret := &neco.ContentsUpdateStatus{
 		Version: req.Version,
 		Success: err == nil,


### PR DESCRIPTION
Squid service is deployed as type: LoadBalancer for using proxy if
own kube-proxy is stopped.