### PR TITLE
Add PodDisruptionBudget for squid and unbound

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -13,7 +13,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.2.2.2", Private: false},
 		{Name: "coil", Repository: "quay.io/cybozu/coil", Tag: "1.1.6", Private: false},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "3.5.27.1.6", Private: false},
-		{Name: "teleport", Repository: "quay.io/cybozu/teleport", Tag: "4.0.9.1", Private: false},
+		{Name: "teleport", Repository: "quay.io/cybozu/teleport", Tag: "4.0.9.2", Private: false},
 	},
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.0.0"},

--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.2", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.3", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.15.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.8", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.4.7", Private: false},

--- a/dctest/squid.go
+++ b/dctest/squid.go
@@ -41,7 +41,7 @@ func TestSquid() {
 		err = json.Unmarshal(stdout, &pdb)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(pdb.Status.CurrentHealthy).Should(Equal(int32(2)))
-		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(int32(1)))
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(1))
 	})
 
 	It("should serve for docker daemon", func() {

--- a/dctest/squid.go
+++ b/dctest/squid.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 )
 
 // TestSquid test installed squid
@@ -31,6 +32,16 @@ func TestSquid() {
 			}
 			return nil
 		}).Should(Succeed())
+		By("checking PodDisruptionBudget for squid Deployment")
+		pdb := policyv1beta1.PodDisruptionBudget{}
+		stdout, stderr, err := execAt(boot0, "kubectl", "get", "poddisruptionbudgets", "squid-pdb", "-n", "internet-egress", "-o", "json")
+		if err != nil {
+			Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		}
+		err = json.Unmarshal(stdout, &pdb)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pdb.Status.CurrentHealthy).Should(Equal(int32(2)))
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(int32(1)))
 	})
 
 	It("should serve for docker daemon", func() {

--- a/dctest/squid.go
+++ b/dctest/squid.go
@@ -41,7 +41,6 @@ func TestSquid() {
 		err = json.Unmarshal(stdout, &pdb)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(pdb.Status.CurrentHealthy).Should(Equal(int32(2)))
-		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(1))
 	})
 
 	It("should serve for docker daemon", func() {

--- a/dctest/unbound.go
+++ b/dctest/unbound.go
@@ -41,7 +41,7 @@ func TestUnbound() {
 		err = json.Unmarshal(stdout, &pdb)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(pdb.Status.CurrentHealthy).Should(Equal(int32(2)))
-		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(int32(1)))
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(1))
 	})
 
 	It("should resolve www.cybozu.com", func() {

--- a/dctest/unbound.go
+++ b/dctest/unbound.go
@@ -41,7 +41,6 @@ func TestUnbound() {
 		err = json.Unmarshal(stdout, &pdb)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(pdb.Status.CurrentHealthy).Should(Equal(int32(2)))
-		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(1))
 	})
 
 	It("should resolve www.cybozu.com", func() {

--- a/dctest/unbound.go
+++ b/dctest/unbound.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 )
 
 // TestUnbound test installed unbound
@@ -31,6 +32,16 @@ func TestUnbound() {
 			}
 			return nil
 		}).Should(Succeed())
+		By("checking PodDisruptionBudget for unbound Deployment")
+		pdb := policyv1beta1.PodDisruptionBudget{}
+		stdout, stderr, err := execAt(boot0, "kubectl", "get", "poddisruptionbudgets", "unbound-pdb", "-n", "internet-egress", "-o", "json")
+		if err != nil {
+			Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		}
+		err = json.Unmarshal(stdout, &pdb)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pdb.Status.CurrentHealthy).Should(Equal(int32(2)))
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).Should(Equal(int32(1)))
 	})
 
 	It("should resolve www.cybozu.com", func() {

--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -339,3 +339,14 @@ spec:
       nodePort: 30128
       port: 3128
       targetPort: 3128
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: squid-pdb
+  namespace: internet-egress
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: squid

--- a/etc/unbound.yml
+++ b/etc/unbound.yml
@@ -246,3 +246,14 @@ spec:
       port: 53
       targetPort: 1053
       protocol: TCP
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: unbound-pdb
+  namespace: internet-egress
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unbound


### PR DESCRIPTION
To ensure redundancy for `squid` and  `unbound` in case of that more than one pod of them are located in a node and the node is drained, this pull request made the following changes.

- add PodDisruptionBudget for `squid` and  `unbound` deployment.