### PR TITLE
gcp: Update software

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.2", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.3", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.15.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.8", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.4.7", Private: false},

--- a/gcp/artifacts.go
+++ b/gcp/artifacts.go
@@ -1,12 +1,12 @@
 package gcp
 
 var artifacts = artifactSet{
-	goVersion:           "1.12.8",
+	goVersion:           "1.12.10",
 	rktVersion:          "1.30.0",
 	etcdVersion:         "3.3.15",
-	placematVersion:     "1.3.7",
+	placematVersion:     "1.3.8",
 	customUbuntuVersion: "20190829",
-	coreOSVersion:       "2135.6.0",
+	coreOSVersion:       "2191.5.0",
 	ctVersion:           "0.9.0",
 	baseImage:           "ubuntu-1804-bionic-v20190628",
 	baseImageProject:    "ubuntu-os-cloud",


### PR DESCRIPTION
- go: update to 1.12.10.
- placemat: update to 1.3.8.
- CoreOS: udpate to 2191.5.0 as same as artifacts.go.