### PR TITLE
git-neco: wait for PR creation

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.3", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.4", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.15.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.8", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.4.7", Private: false},

--- a/pkg/git-neco/cmd/draft.go
+++ b/pkg/git-neco/cmd/draft.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/tcnksm/go-input"
@@ -138,6 +139,9 @@ func runDraftCmd(cmd *cobra.Command, args []string, draft bool) error {
 	if draftOpts.issue == 0 {
 		return nil
 	}
+
+	// wait for the pr get created
+	time.Sleep(2 * time.Second)
 
 	fmt.Printf("Connect %s/%s#%d with %s/%s#%d.\n",
 		curRepo.Owner, curRepo.Name, pr.Number, issueRepo.Owner, issueRepo.Name, draftOpts.issue)


### PR DESCRIPTION
Sometimes `git neco draft` or `git neco review` fails to connect a new PR with ZenHub.
It seems GitHub API may need some time before reporting new PRs.

```console
$ git neco review 591
Draft pull request is not found.  Creating a new pull request...
cybozu-go/neco#591: Set higher priority to Pods with TopoLVM volumes
Is this ok? [y/N]: y

Counting objects: 4, done.
Delta compression using up to 6 threads.
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 974 bytes | 974.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
remote:
remote: Create a pull request for 'priority' on GitHub by visiting:
remote:      https://github.com/cybozu-go/topolvm/pull/new/priority
remote:
To ssh://g/cybozu-go/topolvm
 * [new branch]      priority -> priority
Branch 'priority' set up to track remote branch 'priority' from 'origin'.

Created a pull request: https://github.com/cybozu-go/topolvm/pull/66
Connect cybozu-go/topolvm#66 with cybozu-go/neco#591.
Error: Not found
Not found
```