### PR TITLE
squid: Decrease shutdown_time

### DIFF
--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -54,6 +54,7 @@ data:
     detect_broken_pconn on
     forwarded_for delete
     httpd_suppress_version_string on
+    shutdown_lifetime 10 seconds
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
squid's shutdown_time is 30 sec by default,
But pod's terminationGracePeriodSeconds is also 30 sec.
This sometimes causes problems.

To prevent it, change this value to 10 sec.