### PR TITLE
Update containerd to 1.3.2.

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -3,7 +3,7 @@ include Makefile.common
 MAKEFLAGS += -j$(shell nproc)
 
 ### for containerd
-CONTAINERD_VERSION = 1.2.10
+CONTAINERD_VERSION = 1.3.2
 CURL=curl -Lsf
 
 ### for node_exporter

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -45,7 +45,7 @@ node_exporter:
 containerd:
 	mkdir -p $(LIBEXECDIR) $(DOCDIR)/$@/
 	$(CURL) https://github.com/containerd/containerd/releases/download/v$(CONTAINERD_VERSION)/containerd-$(CONTAINERD_VERSION).linux-amd64.tar.gz | \
-	tar xzf - --strip-components=1 -C $(LIBEXECDIR) bin/containerd bin/containerd-shim bin/ctr
+	tar xzf - --strip-components=1 -C $(LIBEXECDIR) bin/containerd bin/containerd-shim bin/containerd-shim-runc-v1 bin/containerd-shim-runc-v2 bin/ctr
 	$(CURL) -o $(DOCDIR)/$@/LICENSE   https://raw.githubusercontent.com/containerd/containerd/v$(CONTAINERD_VERSION)/LICENSE
 	$(CURL) -o $(DOCDIR)/$@/NOTICE    https://raw.githubusercontent.com/containerd/containerd/v$(CONTAINERD_VERSION)/NOTICE
 	$(CURL) -o $(DOCDIR)/$@/README.md https://raw.githubusercontent.com/containerd/containerd/v$(CONTAINERD_VERSION)/README.md

--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.5", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.15.6", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.18.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.8", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.4.8", Private: false},

--- a/ignitions/common/files/etc/k8s-containerd/config.toml
+++ b/ignitions/common/files/etc/k8s-containerd/config.toml
@@ -1,65 +1,119 @@
+version = 2
 root = "/var/lib/k8s-containerd"
 state = "/run/k8s-containerd"
-oom_score = 0
+plugin_dir = ""
+disabled_plugins = []
+required_plugins = []
+oom_score = -999
+
 [grpc]
   address = "/var/run/k8s-containerd.sock"
+  tcp_address = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
   uid = 0
   gid = 0
   max_recv_message_size = 16777216
   max_send_message_size = 16777216
+
+[ttrpc]
+  address = ""
+  uid = 0
+  gid = 0
+
 [debug]
   address = ""
   uid = 0
   gid = 0
   level = ""
+
 [metrics]
   address = ""
   grpc_histogram = false
+
 [cgroup]
   path = ""
+
+[timeouts]
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
 [plugins]
-  [plugins.cgroups]
-    no_prometheus = false
-  [plugins.cri]
+  [plugins."io.containerd.gc.v1.scheduler"]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+  [plugins."io.containerd.grpc.v1.cri"]
+    disable_tcp_service = true
     stream_server_address = "127.0.0.1"
     stream_server_port = "10010"
+    stream_idle_timeout = "4h0m0s"
     enable_selinux = false
     sandbox_image = "{{ Metadata "cke:pause.ref" }}"
     stats_collect_period = 10
     systemd_cgroup = false
     enable_tls_streaming = false
     max_container_log_line_size = 16384
-    [plugins.cri.containerd]
+    disable_cgroup = false
+    disable_apparmor = false
+    restrict_oom_score_adj = false
+    max_concurrent_downloads = 3
+    disable_proc_mount = false
+    [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "overlayfs"
-      [plugins.cri.containerd.default_runtime]
-        runtime_type = "io.containerd.runtime.v1.linux"
-        runtime_engine = ""
-        runtime_root = ""
-      [plugins.cri.containerd.untrusted_workload_runtime]
+      default_runtime_name = "runc"
+      no_pivot = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
         runtime_type = ""
         runtime_engine = ""
         runtime_root = ""
-    [plugins.cri.cni]
+        privileged_without_host_devices = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        runtime_type = ""
+        runtime_engine = ""
+        runtime_root = ""
+        privileged_without_host_devices = false
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          runtime_engine = ""
+          runtime_root = ""
+          privileged_without_host_devices = false
+    [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"
+      max_conf_num = 1
       conf_template = ""
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
-          endpoint = ["http://localhost:5000"]
-        [plugins.cri.registry.mirrors."quay.io"]
-          endpoint = ["http://localhost:5000"]
-  [plugins.diff-service]
-    default = ["walking"]
-  [plugins.linux]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+  [plugins."io.containerd.runtime.v1.linux"]
     shim = "/opt/sbin/containerd-shim"
     runtime = "runc"
     runtime_root = ""
     no_shim = false
     shim_debug = false
-  [plugins.scheduler]
-    pause_threshold = 0.02
-    deletion_threshold = 0
-    mutation_threshold = 100
-    schedule_delay = "0s"
-    startup_delay = "100ms"
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    root_path = ""
+    pool_name = ""
+    base_image_size = ""

--- a/ignitions/common/files/opt/sbin/setup-containerd
+++ b/ignitions/common/files/opt/sbin/setup-containerd
@@ -17,6 +17,22 @@ for i in $(seq 20); do
 done
 
 for i in $(seq 20); do
+    rm -f /opt/sbin/containerd-shim-runc-v1
+    if curl -sfSL -o /opt/sbin/containerd-shim-runc-v1 {{ MyURL }}/api/v1/assets/containerd-shim-runc-v1; then
+        break
+    fi
+    sleep 5
+done
+
+for i in $(seq 20); do
+    rm -f /opt/sbin/containerd-shim-runc-v2
+    if curl -sfSL -o /opt/sbin/containerd-shim-runc-v2 {{ MyURL }}/api/v1/assets/containerd-shim-runc-v2; then
+        break
+    fi
+    sleep 5
+done
+
+for i in $(seq 20); do
     rm -f /opt/bin/ctr
     if curl -sfSL -o /opt/bin/ctr {{ MyURL }}/api/v1/assets/ctr; then
         break
@@ -34,5 +50,7 @@ done
 
 chmod a+x /opt/sbin/containerd
 chmod a+x /opt/sbin/containerd-shim
+chmod a+x /opt/sbin/containerd-shim-runc-v1
+chmod a+x /opt/sbin/containerd-shim-runc-v2
 chmod a+x /opt/bin/ctr
 chmod a+x /opt/bin/crictl

--- a/ignitions/common/systemd/k8s-containerd.service
+++ b/ignitions/common/systemd/k8s-containerd.service
@@ -8,6 +8,7 @@ After=setup-k8s-containerd.service
 Delegate=yes
 KillMode=process
 Restart=always
+ExecStartPre=-/sbin/modprobe overlay
 ExecStartPre=/bin/mkdir -p /var/lib/k8s-containerd
 ExecStartPre=/bin/mkdir -p /run/k8s-containerd
 ExecStart=/opt/sbin/containerd --config /etc/k8s-containerd/config.toml


### PR DESCRIPTION
Update containerd to 1.3.2.
[containerd 1.3.0](https://github.com/containerd/containerd/releases/tag/v1.3.0) [fixed a bug of ingest corruption](https://github.com/containerd/containerd/pull/3160), which causes instability of [neco-apps](https://github.com/cybozu-go/neco-apps) CI.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
