### PR TITLE
ignitions: Add by-path based name for encrypted devices

### DIFF
--- a/dctest/ignitions.go
+++ b/dctest/ignitions.go
@@ -1,0 +1,27 @@
+package dctest
+
+import (
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestIgnitions tests for ignitions functions.
+func TestIgnitions() {
+	It("should create by-path based name for encrypted devices", func() {
+		machines, err := getMachinesSpecifiedRole("ss")
+		Expect(err).NotTo(HaveOccurred())
+
+		stdout, stderr, err := execAt(boot0, "ckecli", "ssh", "cybozu@"+machines[0].Spec.IPv4[0], "ls", "/dev/crypt-disk/by-path/")
+		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+
+		devices := strings.Fields(strings.TrimSpace(string(stdout)))
+		Expect(devices).ShouldNot(BeEmpty())
+		for _, d := range devices {
+			stdout, stderr, err = execAt(boot0, "ckecli", "ssh", "cybozu@"+machines[0].Spec.IPv4[0], "sudo", "cryptsetup", "status", filepath.Join("/dev/crypt-disk/by-path/", d))
+			Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		}
+	})
+}

--- a/dctest/ignitions.go
+++ b/dctest/ignitions.go
@@ -14,13 +14,14 @@ func TestIgnitions() {
 		machines, err := getMachinesSpecifiedRole("ss")
 		Expect(err).NotTo(HaveOccurred())
 
-		stdout, stderr, err := execAt(boot0, "ckecli", "ssh", "cybozu@"+machines[0].Spec.IPv4[0], "ls", "/dev/crypt-disk/by-path/")
+		cryptDiskDir := "/dev/crypt-disk/by-path/"
+		stdout, stderr, err := execAt(boot0, "ckecli", "ssh", "cybozu@"+machines[0].Spec.IPv4[0], "ls", cryptDiskDir)
 		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 
 		devices := strings.Fields(strings.TrimSpace(string(stdout)))
 		Expect(devices).ShouldNot(BeEmpty())
 		for _, d := range devices {
-			stdout, stderr, err = execAt(boot0, "ckecli", "ssh", "cybozu@"+machines[0].Spec.IPv4[0], "sudo", "cryptsetup", "status", filepath.Join("/dev/crypt-disk/by-path/", d))
+			stdout, stderr, err = execAt(boot0, "ckecli", "ssh", "cybozu@"+machines[0].Spec.IPv4[0], "sudo", "cryptsetup", "status", filepath.Join(cryptDiskDir, d))
 			Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 		}
 	})

--- a/dctest/suites.go
+++ b/dctest/suites.go
@@ -15,6 +15,7 @@ var BootstrapSuite = func() {
 	Context("sabakan-state-setter", func() {
 		TestSabakanStateSetter(availableNodes)
 	})
+	Context("ignitions", TestIgnitions)
 	Context("cke", func() {
 		TestCKESetup()
 		TestCKE(availableNodes)

--- a/ignitions/roles/ss/files/etc/systemd/system/sabakan-cryptsetup.d/mkdir.conf
+++ b/ignitions/roles/ss/files/etc/systemd/system/sabakan-cryptsetup.d/mkdir.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPre=/bin/mkdir -p /dev/crypt-disk/by-path/

--- a/ignitions/roles/ss/files/etc/systemd/system/sabakan-cryptsetup.d/mkdir.conf
+++ b/ignitions/roles/ss/files/etc/systemd/system/sabakan-cryptsetup.d/mkdir.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/mkdir -p /dev/crypt-disk/by-path/

--- a/ignitions/roles/ss/files/etc/udev/crypt-base-path
+++ b/ignitions/roles/ss/files/etc/udev/crypt-base-path
@@ -10,3 +10,4 @@ for symlink in $(udevadm info -q symlink -n "${BASE_DEV}"); do
       ;;
   esac
 done
+return 0

--- a/ignitions/roles/ss/files/etc/udev/crypt-base-path
+++ b/ignitions/roles/ss/files/etc/udev/crypt-base-path
@@ -11,4 +11,4 @@ for symlink in $(udevadm info -q symlink -n "${BASE_DEV}"); do
   esac
 done
 mkdir -p /dev/crypt-disk/by-path/
-return 0
+exit 0

--- a/ignitions/roles/ss/files/etc/udev/crypt-base-path
+++ b/ignitions/roles/ss/files/etc/udev/crypt-base-path
@@ -1,0 +1,12 @@
+#!/bin/sh
+BASE_DEV=$(cryptsetup status "${1}" | grep device | awk '{print $2}')
+
+for symlink in $(udevadm info -q symlink -n "${BASE_DEV}"); do
+  case ${symlink} in
+    disk/by-path/virtio-*)
+      ;;
+    disk/by-path/*)
+      echo "CRYPT_BASE_PATH=${symlink#disk/by-path/}"
+      ;;
+  esac
+done

--- a/ignitions/roles/ss/files/etc/udev/crypt-base-path
+++ b/ignitions/roles/ss/files/etc/udev/crypt-base-path
@@ -10,4 +10,5 @@ for symlink in $(udevadm info -q symlink -n "${BASE_DEV}"); do
       ;;
   esac
 done
+mkdir -p /dev/crypt-disk/by-path/
 return 0

--- a/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules
+++ b/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{DEVTYPE}=="disk", IMPORT{program}=="/etc/udev/crypt-base-path %s{dm/name}", SYMLINK+="crypt-disk/by-path/$env{CRYPT_BASE_PATH}"

--- a/ignitions/roles/ss/site.yml
+++ b/ignitions/roles/ss/site.yml
@@ -2,4 +2,5 @@ include: ../../common/common.yml
 files:
   - /etc/udev/crypt-base-path
   - /etc/udev/rules.d/99-neco.rules
+  # I want to only make `/dev/crypt-disk/by-path/` directory. It is workaround to make a `dummy` file.
   - /dev/crypt-disk/by-path/dummy

--- a/ignitions/roles/ss/site.yml
+++ b/ignitions/roles/ss/site.yml
@@ -2,5 +2,4 @@ include: ../../common/common.yml
 files:
   - /etc/udev/crypt-base-path
   - /etc/udev/rules.d/99-neco.rules
-  # I want to only make `/dev/crypt-disk/by-path/` directory. It is workaround to make a `dummy` file.
-  - /dev/crypt-disk/by-path/dummy
+  - /etc/systemd/system/sabakan-cryptsetup.d/mkdir.conf

--- a/ignitions/roles/ss/site.yml
+++ b/ignitions/roles/ss/site.yml
@@ -2,4 +2,3 @@ include: ../../common/common.yml
 files:
   - /etc/udev/crypt-base-path
   - /etc/udev/rules.d/99-neco.rules
-  - /etc/systemd/system/sabakan-cryptsetup.d/mkdir.conf

--- a/ignitions/roles/ss/site.yml
+++ b/ignitions/roles/ss/site.yml
@@ -1,1 +1,5 @@
 include: ../../common/common.yml
+files:
+  - /etc/udev/crypt-base-path
+  - /etc/udev/rules.d/99-neco.rules
+  - /dev/crypt-disk/by-path/dummy


### PR DESCRIPTION
For storage servers, add by-path based name for encrypted devices using `udev`.
- Add a udev rule file on `/etc/udev/rules.d/99-neco.rules`.
    - When encrypted devices appear, add a symlink to `/dev/crypt-disk/by-path`.
- Add a script that called by udev rules.