### PR TITLE
add download-binaries command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ jobs:
   build_release:
     docker:
       - image: quay.io/cybozu/golang:1.13-bionic
-      - image: quay.io/coreos/etcd:v3.3
     working_directory: /work
     resource_class: xlarge
     steps:
@@ -96,6 +95,21 @@ jobs:
           root: .
           paths:
             - "*.deb"
+
+  download_binaries:
+    docker:
+      - image: quay.io/cybozu/golang:1.13-bionic
+    working_directory: /work
+    steps:
+      - checkout
+      - run:
+          name: download binaries to workspace
+          command: go run ./pkg/download-binaries/main.go
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "*.exe"
+            - "*.zip"
 
   deploy_github:
     docker:
@@ -313,6 +327,12 @@ workflows:
   release:
     jobs:
       - build_release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^release-.*/
+      - download_binaries:
           filters:
             branches:
               ignore: /.*/

--- a/docs/donload-binaries.md
+++ b/docs/donload-binaries.md
@@ -1,0 +1,31 @@
+# `download-binaries`
+
+## What's this?
+
+We often forgot upgrading of the CLI tools using for operations.
+To solve this problem we decided to automate the process to upload the binaries on operation environments.
+
+`download-binaries` fetches the following binaries:
+
+#### `teleport`
+
+Download the binary from [the download page](https://gravitational.com/teleport/download/).
+
+The version to use is written on [artifacts.go](https://github.com/cybozu-go/neco/blob/master/artifacts.go).
+
+#### `kubectl`
+
+Download the binary from [the bucket](https://storage.googleapis.com/kubernetes-release/release).
+
+The version is decided by the following process:
+
+1. Check the CKE version written in artifacts.go. We can know the major version and minor version of Neco's Kubernetes.
+1. Check latest patch version from GitHub release in k/k.
+
+#### `argocd`
+
+Download the binary from [the release page](https://github.com/argoproj/argo-cd/releases).
+
+The version to use is written in [neco-apps/argocd/base/upstream/install.yaml](https://github.com/cybozu-go/neco-apps/blob/release/argocd/base/upstream/install.yaml)
+
+However, ArgoCD repository does not distribute Windows binaries now, so `download-binaries` skips to download `argocd`. This document is written at 2020-02-03.

--- a/pkg/download-binaries/main.go
+++ b/pkg/download-binaries/main.go
@@ -1,68 +1,148 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/well"
+	"github.com/google/go-github/v18/github"
+	"github.com/hashicorp/go-version"
+	"golang.org/x/oauth2"
 )
 
-const teleportWindowsURL = "https://get.gravitational.com/teleport-v%s-windows-amd64-bin.zip"
+const (
+	teleportWindowsURL = "https://get.gravitational.com/teleport-v%s-windows-amd64-bin.zip"
+	kubectlWindowsURL  = "https://storage.googleapis.com/kubernetes-release/release/v%s/bin/windows/amd64/kubectl.exe"
+)
 
 var outputDir = flag.String("dir", ".", "The download path. Create the dir if not present.")
 
 func main() {
 	flag.Parse()
+	env := well.NewEnvironment(context.Background())
 
 	_, err := os.Stat(*outputDir)
 	if err != nil && !os.IsNotExist(err) {
-		log.Fatal(err)
+		log.ErrorExit(err)
 	}
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(*outputDir, 0755)
 		if err != nil {
-			log.Fatal(err)
+			log.ErrorExit(err)
 		}
 	}
-
-	teleportTag := getImageTag("teleport")
-	if len(teleportTag) == 0 {
-		log.Fatal("teleport not found in artifacts")
-	}
-	splitTags := strings.Split(teleportTag, ".")
-	if len(splitTags) != 4 {
-		log.Fatal("teleport unexpected tag format:" + teleportTag)
-	}
-	teleportVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
-	err = downloadFile(fmt.Sprintf(teleportWindowsURL, teleportVersion))
+	env.Go(downloadTeleport)
+	env.Go(downloadKubectl)
+	env.Stop()
+	err = env.Wait()
 	if err != nil {
-		log.Fatal(err)
+		log.ErrorExit(err)
 	}
 }
 
-func downloadFile(url string) error {
-	f, err := ioutil.TempFile(*outputDir, "")
-	if err != nil {
-		return err
+func downloadKubectl(ctx context.Context) error {
+	ckeTag := getImageTag("cke")
+	if len(ckeTag) == 0 {
+		return errors.New("cke not found in artifacts")
 	}
-	defer f.Close()
-	resp, err := http.Get(url)
+	splitTags := strings.Split(ckeTag, ".")
+	if len(splitTags) != 3 {
+		return errors.New("cke unexpected tag format:" + ckeTag)
+	}
+	k8sVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
+
+	var hc *http.Client
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		hc = oauth2.NewClient(ctx, ts)
+	}
+	gc := neco.NewGitHubClient(hc)
+	releases, resp, err := gc.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
+	fullVersion, err := getLatestPatchVersion(releases, k8sVersion)
+	if err != nil {
+		return err
+	}
+	log.Info("downloading kubectl...", map[string]interface{}{"version": fullVersion})
+	return downloadFile(ctx, fmt.Sprintf(kubectlWindowsURL, fullVersion))
+}
+
+func getLatestPatchVersion(releases []*github.RepositoryRelease, vString string) (string, error) {
+	latestPatchVersion, err := version.NewVersion(fmt.Sprintf("%s.0", vString))
+	if err != nil {
+		return "", err
+	}
+	for _, r := range releases {
+		if r.GetTargetCommitish() != fmt.Sprintf("release-%s", vString) {
+			continue
+		}
+		v, err := version.NewVersion(strings.TrimPrefix(r.GetTagName(), "v"))
+		if err != nil {
+			log.Error("failed convert tag to version", map[string]interface{}{
+				"tag":       r.GetTagName(),
+				log.FnError: err,
+			})
+			continue
+		}
+		if latestPatchVersion.LessThan(v) {
+			latestPatchVersion = v
+		}
+	}
+	return latestPatchVersion.String(), nil
+}
+
+func downloadTeleport(ctx context.Context) error {
+	teleportTag := getImageTag("teleport")
+	if len(teleportTag) == 0 {
+		return errors.New("teleport not found in artifacts")
+	}
+	splitTags := strings.Split(teleportTag, ".")
+	if len(splitTags) != 4 {
+		return errors.New("teleport unexpected tag format:" + teleportTag)
+	}
+	teleportVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
+	log.Info("downloading teleport...", map[string]interface{}{"version": teleportVersion})
+	return downloadFile(ctx, fmt.Sprintf(teleportWindowsURL, teleportVersion))
+}
+
+func downloadFile(ctx context.Context, url string) error {
+	f, err := ioutil.TempFile(*outputDir, path.Base(url)+"-")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	client := &well.HTTPClient{Client: &http.Client{}}
+	req, _ := http.NewRequest("GET", url, nil)
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
 	_, err = io.Copy(f, resp.Body)
 	if err != nil {
 		return err
 	}
+
 	return os.Rename(f.Name(), filepath.Join(*outputDir, path.Base(url)))
 }
 

--- a/pkg/download-binaries/main.go
+++ b/pkg/download-binaries/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/cybozu-go/neco"
+)
+
+const teleportWindowsURL = "https://get.gravitational.com/teleport-v%s-windows-amd64-bin.zip"
+
+var outputDir = flag.String("dir", ".", "The download path. Create the dir if not present.")
+
+func main() {
+	flag.Parse()
+
+	_, err := os.Stat(*outputDir)
+	if err != nil && !os.IsNotExist(err) {
+		log.Fatal(err)
+	}
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(*outputDir, 0755)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	teleportTag := getImageTag("teleport")
+	if len(teleportTag) == 0 {
+		log.Fatal("teleport not found in artifacts")
+	}
+	splitTags := strings.Split(teleportTag, ".")
+	if len(splitTags) != 4 {
+		log.Fatal("unexpected tag format")
+	}
+	teleportVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
+	err = downloadFile(fmt.Sprintf(teleportWindowsURL, teleportVersion))
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func downloadFile(url string) error {
+	f, err := ioutil.TempFile(*outputDir, "")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), filepath.Join(*outputDir, path.Base(url)))
+}
+
+func getImageTag(name string) (url string) {
+	for _, img := range neco.CurrentArtifacts.Images {
+		if img.Name == name {
+			return img.Tag
+		}
+	}
+	return ""
+}

--- a/pkg/download-binaries/main.go
+++ b/pkg/download-binaries/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 	splitTags := strings.Split(teleportTag, ".")
 	if len(splitTags) != 4 {
-		log.Fatal("unexpected tag format")
+		log.Fatal("teleport unexpected tag format:" + teleportTag)
 	}
 	teleportVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
 	err = downloadFile(fmt.Sprintf(teleportWindowsURL, teleportVersion))

--- a/pkg/download-binaries/main.go
+++ b/pkg/download-binaries/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
@@ -19,31 +20,39 @@ import (
 	"github.com/google/go-github/v18/github"
 	"github.com/hashicorp/go-version"
 	"golang.org/x/oauth2"
+	v1 "k8s.io/api/apps/v1"
+	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 const (
 	teleportWindowsURL = "https://get.gravitational.com/teleport-v%s-windows-amd64-bin.zip"
 	kubectlWindowsURL  = "https://storage.googleapis.com/kubernetes-release/release/v%s/bin/windows/amd64/kubectl.exe"
+	argoCDWindowsURL   = "https://github.com/argoproj/argo-cd/releases/download/v%s/argocd-windows-amd64"
 )
 
-var outputDir = flag.String("dir", ".", "The download path. Create the dir if not present.")
+var outputDir = flag.String("dir", ".", "The output directory. Create the directory if not present.")
+
+type downloader struct {
+	gh *github.Client
+}
 
 func main() {
 	flag.Parse()
-	env := well.NewEnvironment(context.Background())
+	ctx := context.Background()
+	env := well.NewEnvironment(ctx)
 
-	_, err := os.Stat(*outputDir)
-	if err != nil && !os.IsNotExist(err) {
+	err := prepareOutputDir()
+	if err != nil {
 		log.ErrorExit(err)
 	}
-	if os.IsNotExist(err) {
-		err = os.MkdirAll(*outputDir, 0755)
-		if err != nil {
-			log.ErrorExit(err)
-		}
-	}
-	env.Go(downloadTeleport)
-	env.Go(downloadKubectl)
+
+	d := newDownloader(ctx)
+	env.Go(d.downloadKubectl)
+	env.Go(d.downloadTeleport)
+	// TODO: Opt in downloadArgoCD after releasing windows binaries at https://github.com/argoproj/argo-cd/releases/
+	// env.Go(d.downloadArgoCD)
+
 	env.Stop()
 	err = env.Wait()
 	if err != nil {
@@ -51,17 +60,7 @@ func main() {
 	}
 }
 
-func downloadKubectl(ctx context.Context) error {
-	ckeTag := getImageTag("cke")
-	if len(ckeTag) == 0 {
-		return errors.New("cke not found in artifacts")
-	}
-	splitTags := strings.Split(ckeTag, ".")
-	if len(splitTags) != 3 {
-		return errors.New("cke unexpected tag format:" + ckeTag)
-	}
-	k8sVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
-
+func newDownloader(ctx context.Context) downloader {
 	var hc *http.Client
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		ts := oauth2.StaticTokenSource(
@@ -69,57 +68,21 @@ func downloadKubectl(ctx context.Context) error {
 		)
 		hc = oauth2.NewClient(ctx, ts)
 	}
-	gc := neco.NewGitHubClient(hc)
-	releases, resp, err := gc.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	fullVersion, err := getLatestPatchVersion(releases, k8sVersion)
-	if err != nil {
-		return err
-	}
-	log.Info("downloading kubectl...", map[string]interface{}{"version": fullVersion})
-	return downloadFile(ctx, fmt.Sprintf(kubectlWindowsURL, fullVersion))
+	return downloader{neco.NewGitHubClient(hc)}
 }
 
-func getLatestPatchVersion(releases []*github.RepositoryRelease, vString string) (string, error) {
-	latestPatchVersion, err := version.NewVersion(fmt.Sprintf("%s.0", vString))
-	if err != nil {
-		return "", err
+func prepareOutputDir() error {
+	_, err := os.Stat(*outputDir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
 	}
-	for _, r := range releases {
-		if r.GetTargetCommitish() != fmt.Sprintf("release-%s", vString) {
-			continue
-		}
-		v, err := version.NewVersion(strings.TrimPrefix(r.GetTagName(), "v"))
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(*outputDir, 0755)
 		if err != nil {
-			log.Error("failed convert tag to version", map[string]interface{}{
-				"tag":       r.GetTagName(),
-				log.FnError: err,
-			})
-			continue
-		}
-		if latestPatchVersion.LessThan(v) {
-			latestPatchVersion = v
+			return err
 		}
 	}
-	return latestPatchVersion.String(), nil
-}
-
-func downloadTeleport(ctx context.Context) error {
-	teleportTag := getImageTag("teleport")
-	if len(teleportTag) == 0 {
-		return errors.New("teleport not found in artifacts")
-	}
-	splitTags := strings.Split(teleportTag, ".")
-	if len(splitTags) != 4 {
-		return errors.New("teleport unexpected tag format:" + teleportTag)
-	}
-	teleportVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
-	log.Info("downloading teleport...", map[string]interface{}{"version": teleportVersion})
-	return downloadFile(ctx, fmt.Sprintf(teleportWindowsURL, teleportVersion))
+	return nil
 }
 
 func downloadFile(ctx context.Context, url string) error {
@@ -153,4 +116,112 @@ func getImageTag(name string) (url string) {
 		}
 	}
 	return ""
+}
+
+func (d *downloader) downloadKubectl(ctx context.Context) error {
+	ckeTag := getImageTag("cke")
+	if len(ckeTag) == 0 {
+		return errors.New("cke not found in artifacts")
+	}
+	splitTags := strings.Split(ckeTag, ".")
+	if len(splitTags) != 3 {
+		return errors.New("cke unexpected tag format:" + ckeTag)
+	}
+	k8sVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
+
+	releases, resp, err := d.gh.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	fullVersion, err := getLatestPatchVersionFromReleases(releases, k8sVersion)
+	if err != nil {
+		return err
+	}
+	log.Info("downloading kubectl...", map[string]interface{}{"version": fullVersion})
+	return downloadFile(ctx, fmt.Sprintf(kubectlWindowsURL, fullVersion))
+}
+
+func getLatestPatchVersionFromReleases(releases []*github.RepositoryRelease, vString string) (string, error) {
+	latestPatchVersion, err := version.NewVersion(fmt.Sprintf("%s.0", vString))
+	if err != nil {
+		return "", err
+	}
+	for _, r := range releases {
+		if r.GetTargetCommitish() != fmt.Sprintf("release-%s", vString) {
+			continue
+		}
+		v, err := version.NewVersion(strings.TrimPrefix(r.GetTagName(), "v"))
+		if err != nil {
+			log.Error("failed convert tag to version", map[string]interface{}{
+				"tag":       r.GetTagName(),
+				log.FnError: err,
+			})
+			continue
+		}
+		if latestPatchVersion.LessThan(v) {
+			latestPatchVersion = v
+		}
+	}
+	return latestPatchVersion.String(), nil
+}
+
+func (d *downloader) downloadTeleport(ctx context.Context) error {
+	teleportTag := getImageTag("teleport")
+	if len(teleportTag) == 0 {
+		return errors.New("teleport not found in artifacts")
+	}
+	splitTags := strings.Split(teleportTag, ".")
+	if len(splitTags) != 4 {
+		return errors.New("teleport unexpected tag format:" + teleportTag)
+	}
+	teleportVersion := strings.Join(splitTags[:len(splitTags)-1], ".")
+	log.Info("downloading teleport...", map[string]interface{}{"version": teleportVersion})
+	return downloadFile(ctx, fmt.Sprintf(teleportWindowsURL, teleportVersion))
+}
+
+func (d *downloader) downloadArgoCD(ctx context.Context) error {
+	argoCDTag, err := d.getArgoCDTag(ctx)
+	if err != nil {
+		return err
+	}
+	log.Info("downloading argocd...", map[string]interface{}{"version": argoCDTag})
+	return downloadFile(ctx, fmt.Sprintf(argoCDWindowsURL, argoCDTag))
+}
+
+func (d *downloader) getArgoCDTag(ctx context.Context) (string, error) {
+	const argoCDUpstreamFilePath = "argocd/base/upstream/install.yaml"
+	buf, err := d.gh.Repositories.DownloadContents(ctx, "cybozu-go", "neco-apps", argoCDUpstreamFilePath, &github.RepositoryContentGetOptions{Ref: "release"})
+	if err != nil {
+		return "", err
+	}
+	defer buf.Close()
+	y := k8sYaml.NewYAMLReader(bufio.NewReader(buf))
+	for {
+		data, err := y.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return "", err
+		}
+		var d v1.Deployment
+		err = yaml.Unmarshal(data, &d)
+		if err != nil {
+			continue
+		}
+		if d.Name != "argocd-server" {
+			continue
+		}
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == "argocd-server" {
+				split := strings.Split(c.Image, ":")
+				if len(split) != 2 {
+					return "", errors.New("unexpected image format: " + c.Image)
+				}
+				return split[1], nil
+			}
+		}
+	}
+	return "", errors.New("argocd-server deployment not found")
 }


### PR DESCRIPTION
- Add `download-binaries` command.
- Add the job to download `kubectl` and `argocd` on the directory for GHR.