### PR TITLE
Fix setup-partition

### DIFF
--- a/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules
+++ b/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules
@@ -1,5 +1,5 @@
 KERNEL!="dm-*", GOTO="neco_end"
-ENV{ID_PART_ENTRY_NAME}!="primary", GOTO="neco_end"
+ENV{ID_PART_ENTRY_NAME}!="ceph-osd", GOTO="neco_end"
 
 IMPORT{program}=="/etc/udev/crypt-base-path $name $env{DM_UUID}", SYMLINK+="crypt-part/by-path/$env{CRYPT_BASE_PATH}-p$env{DM_PART}"
 

--- a/ignitions/roles/ss/files/opt/sbin/setup-partition
+++ b/ignitions/roles/ss/files/opt/sbin/setup-partition
@@ -1,6 +1,27 @@
 #!/bin/sh -u
 
-PART_NAME=primary
+PART_TYPE=f800
+PART_NAME=ceph-osd
+
+# Execute the following subcommands.
+#  1. o : create a new empty GUID partition table (GPT)
+#  2. n : add a new partition
+#  3. c : change a partition's name
+#  4. w : write table to disk and exit
+GDISK_CMD=$(cat << EOS
+o
+y
+n
+
+
+
+$PART_TYPE
+c
+$PART_NAME
+w
+y
+EOS
+)
 
 is_target_device() {
     DEV=$(basename $1)
@@ -20,13 +41,13 @@ for DM in $(ls /dev/dm-*); do
     DEV_PATH=$(cryptsetup status $DM | grep device | awk '{print $2}')
     if [ -n "$DEV_PATH" ]; then
         if [ $(is_target_device $DEV_PATH) = 'true' ]; then
-            if [ -n "$(parted -s $DM print 2> /dev/null | grep $PART_NAME)" ]; then
-                echo "partition is already exists on $DM (backed by $DEV_PATH)"
-                partprobe $DM
-            else
+            tmp=$(echo i | gdisk $DM 2> /dev/null | grep "Partition name:" | grep "'$PART_NAME'")
+            if [ -z "$tmp" ]; then
                 echo "create a partition on $DM (backed by $DEV_PATH)"
-                parted -s -a optimal $DM -- mklabel gpt mkpart $PART_NAME 1MiB -0
+                echo "$GDISK_CMD" | gdisk $DM
             fi
+            echo "update partition devmappings on $DM"
+            kpartx -u $DM
         fi
     fi
 done

--- a/ignitions/roles/ss/files/opt/sbin/setup-partition
+++ b/ignitions/roles/ss/files/opt/sbin/setup-partition
@@ -3,11 +3,8 @@
 PART_TYPE=f800
 PART_NAME=ceph-osd
 
-# Execute the following subcommands.
-#  1. o : create a new empty GUID partition table (GPT)
-#  2. n : add a new partition
-#  3. c : change a partition's name
-#  4. w : write table to disk and exit
+# The following command creates a partition with gdisk. 
+# Its type is $PART_TYPE and its name is $PART_NAME.
 GDISK_CMD=$(cat << EOS
 o
 y
@@ -39,15 +36,12 @@ is_target_device() {
 
 for DM in $(ls /dev/dm-*); do
     DEV_PATH=$(cryptsetup status $DM | grep device | awk '{print $2}')
-    if [ -n "$DEV_PATH" ]; then
-        if [ $(is_target_device $DEV_PATH) = 'true' ]; then
-            tmp=$(echo i | gdisk $DM 2> /dev/null | grep "Partition name:" | grep "'$PART_NAME'")
-            if [ -z "$tmp" ]; then
-                echo "create a partition on $DM (backed by $DEV_PATH)"
-                echo "$GDISK_CMD" | gdisk $DM
-            fi
-            echo "update partition devmappings on $DM"
-            kpartx -u $DM
-        fi
+    if [ -z "$DEV_PATH" ]; then continue; fi
+    if [ $(is_target_device $DEV_PATH) != 'true' ]; then continue; fi
+    if ! $(echo i | gdisk $DM 2> /dev/null | grep "Partition name:" | grep -q "'$PART_NAME'"); then
+        echo "create a partition on $DM (backed by $DEV_PATH)"
+        echo "$GDISK_CMD" | gdisk $DM
     fi
+    echo "update partition devmappings on $DM"
+    kpartx -u $DM
 done


### PR DESCRIPTION
Create partitions using `gdisk` instead of `parted`.
The partitions created by parted isn't recognized properly. It would come from a bug in parted
that can't handle 4KB sector properly. Let's use gdisk and kpartx instead.