### PR TITLE
Update upgrade test for increasing SS servers

### DIFF
--- a/dctest/cke.go
+++ b/dctest/cke.go
@@ -53,12 +53,19 @@ func TestCKESetup() {
 func TestCKE() {
 	It("all systemd units are active", func() {
 		By("getting machines list")
-		stdout, _, err := execAt(boot0, "sabactl", "machines", "get")
+		stdout, _, err := execAt(boot0, "sabactl", "machines", "get", "--role=cs")
 		Expect(err).ShouldNot(HaveOccurred())
-		var machines []sabakan.Machine
-		err = json.Unmarshal(stdout, &machines)
+		var csMachines []sabakan.Machine
+		err = json.Unmarshal(stdout, &csMachines)
 		Expect(err).ShouldNot(HaveOccurred())
-		availableNodes := len(machines)
+
+		stdout, _, err = execAt(boot0, "sabactl", "machines", "get", "--role=ss")
+		Expect(err).ShouldNot(HaveOccurred())
+		var ssMachines []sabakan.Machine
+		err = json.Unmarshal(stdout, &ssMachines)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		availableNodes := len(csMachines) + len(ssMachines)
 		Expect(availableNodes).NotTo(Equal(0))
 
 		By("getting systemd unit statuses by serf members")

--- a/dctest/cke.go
+++ b/dctest/cke.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cybozu-go/sabakan/v2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -49,8 +50,17 @@ func TestCKESetup() {
 }
 
 // TestCKE tests CKE
-func TestCKE(availableNodes int) {
+func TestCKE() {
 	It("all systemd units are active", func() {
+		By("getting machines list")
+		stdout, _, err := execAt(boot0, "sabactl", "machines", "get")
+		Expect(err).ShouldNot(HaveOccurred())
+		var machines []sabakan.Machine
+		err = json.Unmarshal(stdout, &machines)
+		Expect(err).ShouldNot(HaveOccurred())
+		availableNodes := len(machines)
+		Expect(availableNodes).NotTo(Equal(0))
+
 		By("getting systemd unit statuses by serf members")
 		Eventually(func() error {
 			m, err := getSerfWorkerMembers()

--- a/dctest/sabakan_state_setter.go
+++ b/dctest/sabakan_state_setter.go
@@ -16,12 +16,19 @@ import (
 func TestSabakanStateSetter() {
 	It("should wait for all nodes to join serf", func() {
 		By("getting machines list")
-		stdout, _, err := execAt(boot0, "sabactl", "machines", "get")
+		stdout, _, err := execAt(boot0, "sabactl", "machines", "get", "--role=cs")
 		Expect(err).ShouldNot(HaveOccurred())
-		var machines []sabakan.Machine
-		err = json.Unmarshal(stdout, &machines)
+		var csMachines []sabakan.Machine
+		err = json.Unmarshal(stdout, &csMachines)
 		Expect(err).ShouldNot(HaveOccurred())
-		availableNodes := len(machines)
+
+		stdout, _, err = execAt(boot0, "sabactl", "machines", "get", "--role=ss")
+		Expect(err).ShouldNot(HaveOccurred())
+		var ssMachines []sabakan.Machine
+		err = json.Unmarshal(stdout, &ssMachines)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		availableNodes := len(csMachines) + len(ssMachines)
 		Expect(availableNodes).NotTo(Equal(0))
 
 		By("checking all serf members are active")

--- a/dctest/sabakan_state_setter.go
+++ b/dctest/sabakan_state_setter.go
@@ -13,8 +13,17 @@ import (
 )
 
 // TestSabakanStateSetter tests the behavior of sabakan-state-setter in bootstrapping
-func TestSabakanStateSetter(availableNodes int) {
+func TestSabakanStateSetter() {
 	It("should wait for all nodes to join serf", func() {
+		By("getting machines list")
+		stdout, _, err := execAt(boot0, "sabactl", "machines", "get")
+		Expect(err).ShouldNot(HaveOccurred())
+		var machines []sabakan.Machine
+		err = json.Unmarshal(stdout, &machines)
+		Expect(err).ShouldNot(HaveOccurred())
+		availableNodes := len(machines)
+		Expect(availableNodes).NotTo(Equal(0))
+
 		By("checking all serf members are active")
 		Eventually(func() error {
 			m, err := getSerfWorkerMembers()

--- a/dctest/suites.go
+++ b/dctest/suites.go
@@ -1,6 +1,12 @@
 package dctest
 
-import . "github.com/onsi/ginkgo"
+import (
+	"encoding/json"
+
+	"github.com/cybozu-go/cke/sabakan"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
 
 // BootstrapSuite is a test suite that tests initial setup of Neco
 var BootstrapSuite = func() {
@@ -41,8 +47,15 @@ var FunctionsSuite = func() {
 
 // UpgradeSuite is a test suite that tests upgrading process works correctry
 var UpgradeSuite = func() {
-	// cs x 6 + ss x 4 = 10
-	availableNodes := 10
+	By("getting machines list")
+	stdout, _, err := execAt(boot0, "sabactl", "machines", "get")
+	Expect(err).ShouldNot(HaveOccurred())
+	var machines []sabakan.Machine
+	err = json.Unmarshal(stdout, &machines)
+	Expect(err).ShouldNot(HaveOccurred())
+	availableNodes := len(machines)
+	Expect(availableNodes).NotTo(Equal(0))
+
 	Context("sabakan-state-setter", func() {
 		TestSabakanStateSetter(availableNodes)
 	})

--- a/dctest/suites.go
+++ b/dctest/suites.go
@@ -41,9 +41,8 @@ var FunctionsSuite = func() {
 
 // UpgradeSuite is a test suite that tests upgrading process works correctry
 var UpgradeSuite = func() {
-	// TODO: reflect increase of ss after new menu.yml is released
-	// cs x 6 + ss x 1 = 7
-	availableNodes := 7
+	// cs x 6 + ss x 4 = 10
+	availableNodes := 10
 	Context("sabakan-state-setter", func() {
 		TestSabakanStateSetter(availableNodes)
 	})

--- a/dctest/suites.go
+++ b/dctest/suites.go
@@ -1,17 +1,11 @@
 package dctest
 
 import (
-	"encoding/json"
-
-	"github.com/cybozu-go/cke/sabakan"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 // BootstrapSuite is a test suite that tests initial setup of Neco
 var BootstrapSuite = func() {
-	// cs x 6 + ss x 4 = 10
-	availableNodes := 10
 	Context("setup", TestSetup)
 	Context("initialize", TestInit)
 	Context("sabakan", TestSabakan)
@@ -19,12 +13,12 @@ var BootstrapSuite = func() {
 	Context("init-data", TestInitData)
 	Context("etcdpasswd", TestEtcdpasswd)
 	Context("sabakan-state-setter", func() {
-		TestSabakanStateSetter(availableNodes)
+		TestSabakanStateSetter()
 	})
 	Context("ignitions", TestIgnitions)
 	Context("cke", func() {
 		TestCKESetup()
-		TestCKE(availableNodes)
+		TestCKE()
 	})
 	Context("coil", func() {
 		TestCoilSetup()
@@ -47,21 +41,12 @@ var FunctionsSuite = func() {
 
 // UpgradeSuite is a test suite that tests upgrading process works correctry
 var UpgradeSuite = func() {
-	By("getting machines list")
-	stdout, _, err := execAt(boot0, "sabactl", "machines", "get")
-	Expect(err).ShouldNot(HaveOccurred())
-	var machines []sabakan.Machine
-	err = json.Unmarshal(stdout, &machines)
-	Expect(err).ShouldNot(HaveOccurred())
-	availableNodes := len(machines)
-	Expect(availableNodes).NotTo(Equal(0))
-
 	Context("sabakan-state-setter", func() {
-		TestSabakanStateSetter(availableNodes)
+		TestSabakanStateSetter()
 	})
 	Context("upgrade", TestUpgrade)
 	Context("upgraded cke", func() {
-		TestCKE(availableNodes)
+		TestCKE()
 	})
 	Context("upgraded coil", TestCoil)
 	Context("upgraded unbound", TestUnbound)


### PR DESCRIPTION
In #874, SS servers were increased. However, as our upgrade test is relying on the previously released neco which is not increasing SS server yet, so, to pass CI, #874 intentionally keeps setting the number of available nodes as 7 in our upgrade test.
This will cause CI error, once #874 is merged to the release branch.

See [this](https://bozuman.cybozu.com/k/#/space/3801/thread/38010/2308422/3141610).