### PR TITLE
add deb package build for operator tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 # Debian package
 /work
 /neco_*_amd64.deb
+/op-work
+/neco-operation-cli_*_amd64.deb
 
 # ignore go.sum
 /go.sum

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ $(OP_DEB):
 		cp $(BINDIR)/$$BINNAME $(OPBINDIR) ; \
 		cp -r $(DOCDIR)/$$BINNAME $(OPDOCDIR) ; \
 	done
+	$(MAKE) -f Makefile.tools SUDO=$(SUDO) BINDIR=$(OPBINDIR) DOCDIR=$(OPDOCDIR) teleport
 	$(FAKEROOT) dpkg-deb --build $(DEBBUILD_FLAGS) $(OPWORKDIR) $(DEST)
 
 gcp-deb: setup-files-for-deb

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ PACKAGES := fakeroot btrfs-tools pkg-config libdevmapper-dev libostree-dev libgp
 VERSION = 0.0.1-master
 DEST = .
 DEB = neco_$(VERSION)_amd64.deb
+OP_DEB = neco-operation-cli_$(VERSION)_amd64.deb
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker
@@ -30,7 +31,7 @@ all:
 	@echo "    stop-etcd   - stop etcd."
 	@echo "    test        - run single host tests."
 	@echo "    mod         - update and vendor Go modules."
-	@echo "    deb         - build Debian package."
+	@echo "    deb         - build Debian packages."
 	@echo "    setup       - install dependencies."
 
 start-etcd:
@@ -60,7 +61,7 @@ mod:
 	git add -f vendor
 	git add go.mod
 
-deb: $(DEB)
+deb: $(DEB) $(OP_DEB)
 
 setup-files-for-deb:
 	$(MAKE) -f Makefile.tools SUDO=$(SUDO)
@@ -77,6 +78,15 @@ setup-files-for-deb:
 
 $(DEB): setup-files-for-deb
 	$(FAKEROOT) dpkg-deb --build $(DEBBUILD_FLAGS) $(WORKDIR) $(DEST)
+
+$(OP_DEB):
+	mkdir -p $(OPBINDIR) $(OPDOCDIR) $(OPWORKDIR)/DEBIAN
+	sed 's/@VERSION@/$(patsubst v%,%,$(VERSION))/; /Package: neco/s/$$/-operation-cli/; s/Continuous delivery tool/Operation tools/' debian/DEBIAN/control > $(OPCONTROL)
+	for BINNAME in argocd kubectl kustomize stern; do \
+		cp $(BINDIR)/$$BINNAME $(OPBINDIR) ; \
+		cp -r $(DOCDIR)/$$BINNAME $(OPDOCDIR) ; \
+	done
+	$(FAKEROOT) dpkg-deb --build $(DEBBUILD_FLAGS) $(OPWORKDIR) $(DEST)
 
 gcp-deb: setup-files-for-deb
 	cp dctest/passwd.yml $(SHAREDIR)/ignitions/common/passwd.yml
@@ -96,6 +106,6 @@ setup:
 
 clean:
 	$(MAKE) -f Makefile.tools clean
-	rm -rf $(ETCD_DIR) $(WORKDIR) $(DEB)
+	rm -rf $(ETCD_DIR) $(WORKDIR) $(DEB) $(OPWORKDIR) $(OP_DEB)
 
 .PHONY:	all start-etcd stop-etcd test mod deb setup-files-for-deb gcp-deb necogcp git-neco setup clean

--- a/Makefile.common
+++ b/Makefile.common
@@ -8,3 +8,7 @@ BINDIR := $(WORKDIR)/usr/bin
 SBINDIR := $(WORKDIR)/usr/sbin
 LIBEXECDIR := $(WORKDIR)/usr/libexec/neco
 SHAREDIR := $(WORKDIR)/usr/share/neco
+OPWORKDIR := $(CURDIR)/op-work
+OPCONTROL := $(OPWORKDIR)/DEBIAN/control
+OPBINDIR := $(OPWORKDIR)/usr/bin
+OPDOCDIR := $(OPWORKDIR)/usr/share/doc

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -29,6 +29,9 @@ STERN_VERSION = 1.11.0
 # https://github.com/cybozu/neco-containers/blob/master/argocd/Dockerfile#L32
 KUSTOMIZE_VERSION = 3.5.3
 
+## for teleport
+TELEPORT_VERSION = 4.2.8
+
 all: node_exporter containerd crictl argocd kubectl lvmd stern kustomize
 
 node_exporter:
@@ -90,7 +93,14 @@ kustomize:
 	$(CURL) -o $(DOCDIR)/$@/LICENSE https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v${KUSTOMIZE_VERSION}/LICENSE
 	$(CURL) -o $(DOCDIR)/$@/README.md https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v${KUSTOMIZE_VERSION}/README.md
 
+teleport:
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/
+	$(CURL) https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-linux-amd64-bin.tar.gz | tar xzf - -C $(BINDIR) --strip 1 $@/tsh
+	$(CURL) -o $(OPDOCDIR)/$@/LICENSE https://raw.githubusercontent.com/gravitational/teleport/v$(TELEPORT_VERSION)/LICENSE
+	$(CURL) -o $(DOCDIR)/$@/README.md https://raw.githubusercontent.com/gravitational/teleport/v$(TELEPORT_VERSION)/README.md
+
+
 clean:
 	rm -rf $(BUILDDIR)
 
-.PHONY:	all setup clean node_exporter containerd crictl argocd kubectl lvmd stern kustomize
+.PHONY:	all setup clean node_exporter containerd crictl argocd kubectl lvmd stern kustomize teleport


### PR DESCRIPTION
This adds the creation of a `neco-operation-cli` package containing a subset of what's bundled in the neco deb, namely tools oriented towards operator-use and their documentation/license files.