### PR TITLE
dctest: Wait for each machine to execute ipmipower-start

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.17.9", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.17.10", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.22.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.6.9", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.2", Private: false},

--- a/dctest/reboot.go
+++ b/dctest/reboot.go
@@ -140,7 +140,8 @@ func TestRebootAllNodes() {
 
 		By("start all nodes")
 		//　Wait for each booting to balance the load on the instance
-		ticker := time.NewTicker(190 * time.Second)
+		const waitInterval = 190
+		ticker := time.NewTicker(waitInterval * time.Second)
 		defer ticker.Stop()
 		for _, m := range machines {
 			if m.Spec.Rack == 3 {
@@ -151,7 +152,7 @@ func TestRebootAllNodes() {
 			Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
 			select {
 			case <-ticker.C:
-				fmt.Println("slept 30 seconds")
+				fmt.Printf("slept %d seconds\n", waitInterval)
 			}
 		}
 

--- a/dctest/reboot.go
+++ b/dctest/reboot.go
@@ -112,7 +112,7 @@ spec:
 			if err != nil {
 				return fmt.Errorf("failed to get debug-reboot-test. stderr: %s, err: %v", stderr, err)
 			}
-			stdout, stderr, err := execAt(bootServers[0], "kubectl", "exec", string(debugPodName), "curl", "-s", "http://nginx-reboot-test")
+			stdout, stderr, err := execAt(bootServers[0], "kubectl", "exec", string(debugPodName), "--", "curl", "-s", "http://nginx-reboot-test")
 			if err != nil {
 				return fmt.Errorf("unable to exec curl. stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 			}

--- a/dctest/reboot.go
+++ b/dctest/reboot.go
@@ -187,7 +187,7 @@ spec:
 
 		By("start all nodes")
 		//　Wait for each booting to balance the load on the instance
-		const waitInterval = 190
+		const waitInterval = 60
 		ticker := time.NewTicker(waitInterval * time.Second)
 		defer ticker.Stop()
 		for _, m := range machines {

--- a/dctest/reboot.go
+++ b/dctest/reboot.go
@@ -139,16 +139,18 @@ func TestRebootAllNodes() {
 		}).Should(Succeed())
 
 		By("start all nodes")
-		//　Wait 10 seconds for each machine to balance the load on the instance
-		ticker := time.NewTicker(10 * time.Second)
+		//　Wait for each booting to balance the load on the instance
+		ticker := time.NewTicker(30 * time.Second)
 		for _, m := range machines {
 			if m.Spec.Rack == 3 {
 				continue
 			}
+			fmt.Println("ipmipower-start", m.Spec.IPv4[0])
+			stdout, stderr, err := execAt(bootServers[0], "neco", "ipmipower", "start", m.Spec.IPv4[0])
+			Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
 			select {
 			case <-ticker.C:
-				stdout, stderr, err := execAt(bootServers[0], "neco", "ipmipower", "start", m.Spec.IPv4[0])
-				Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+				fmt.Println("slept 30 seconds")
 			}
 		}
 

--- a/dctest/reboot.go
+++ b/dctest/reboot.go
@@ -140,7 +140,8 @@ func TestRebootAllNodes() {
 
 		By("start all nodes")
 		//　Wait for each booting to balance the load on the instance
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(190 * time.Second)
+		defer ticker.Stop()
 		for _, m := range machines {
 			if m.Spec.Rack == 3 {
 				continue

--- a/dctest/reboot.go
+++ b/dctest/reboot.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cybozu-go/sabakan/v2"
 	. "github.com/onsi/ginkgo"
@@ -138,12 +139,17 @@ func TestRebootAllNodes() {
 		}).Should(Succeed())
 
 		By("start all nodes")
+		//　Wait 10 seconds for each machine to balance the load on the instance
+		ticker := time.NewTicker(10 * time.Second)
 		for _, m := range machines {
 			if m.Spec.Rack == 3 {
 				continue
 			}
-			stdout, stderr, err := execAt(bootServers[0], "neco", "ipmipower", "start", m.Spec.IPv4[0])
-			Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+			select {
+			case <-ticker.C:
+				stdout, stderr, err := execAt(bootServers[0], "neco", "ipmipower", "start", m.Spec.IPv4[0])
+				Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s", stdout, stderr)
+			}
 		}
 
 		By("wait for recovery of all nodes")


### PR DESCRIPTION
Wait 10 seconds for each machine to execute ipmipower-start in order to balance the load to the instance.