### PR TITLE
Fix udev-trigger.service dependencies

### DIFF
--- a/ignitions/common/systemd/udev-trigger.service
+++ b/ignitions/common/systemd/udev-trigger.service
@@ -1,9 +1,6 @@
 [Unit]
 Description=Request udev device events
-Wants=systemd-udevd.service
-After=systemd-udevd-kernel.socket systemd-udevd-control.socket
-Before=setup-var.service
-PartOf=udev-trigger.timer
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Since this unit is invoked only by the timer, it should
have no dependencies including the default ones.