### PR TITLE
ignitions: do not use LABEL= in fstab

### DIFF
--- a/ignitions/common/files/etc/fstab
+++ b/ignitions/common/files/etc/fstab
@@ -1,4 +1,4 @@
-LABEL=k8s-containerd /var/lib/k8s-containerd ext4 x-systemd.device-timeout=600 0 0
-LABEL=docker         /var/lib/docker         ext4 x-systemd.device-timeout=600 0 0
-LABEL=kubelet        /var/lib/kubelet        ext4 x-systemd.device-timeout=600 0 0
-LABEL=rkt            /var/lib/rkt            ext4 x-systemd.device-timeout=600 0 0
+/dev/vg1/k8s-containerd /var/lib/k8s-containerd ext4 x-systemd.device-timeout=600 0 0
+/dev/vg1/docker         /var/lib/docker         ext4 x-systemd.device-timeout=600 0 0
+/dev/vg1/kubelet        /var/lib/kubelet        ext4 x-systemd.device-timeout=600 0 0
+/dev/vg1/rkt            /var/lib/rkt            ext4 x-systemd.device-timeout=600 0 0


### PR DESCRIPTION
To make the test pass, caused by the absence of device files under /dev/disk/by-label.
Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>