### PR TITLE
ingress-watcher: pass "instance" as grouping key, not label.

### DIFF
--- a/pkg/ingress-watcher/cmd/export.go
+++ b/pkg/ingress-watcher/cmd/export.go
@@ -81,7 +81,6 @@ var exportCmd = &cobra.Command{
 		client.Transport = ht
 
 		well.Go(watch.NewWatcher(
-			"",
 			exportConfig.TargetURLs,
 			exportConfig.WatchInterval,
 			&well.HTTPClient{Client: client},

--- a/pkg/ingress-watcher/cmd/push.go
+++ b/pkg/ingress-watcher/cmd/push.go
@@ -80,7 +80,6 @@ var pushCmd = &cobra.Command{
 		client.Transport = ht
 
 		well.Go(watch.NewWatcher(
-			pushConfig.Instance,
 			pushConfig.TargetURLs,
 			pushConfig.WatchInterval,
 			&well.HTTPClient{Client: client},
@@ -89,7 +88,7 @@ var pushCmd = &cobra.Command{
 			tick := time.NewTicker(pushConfig.PushInterval)
 			defer tick.Stop()
 
-			pusher := push.New(pushConfig.PushAddr, "ingress-watcher").Gatherer(registry)
+			pusher := push.New(pushConfig.PushAddr, "ingress-watcher").Grouping("instance", pushConfig.Instance).Gatherer(registry)
 			for {
 				select {
 				case <-ctx.Done():

--- a/pkg/ingress-watcher/cmd/root.go
+++ b/pkg/ingress-watcher/cmd/root.go
@@ -29,6 +29,7 @@ func init() {
 	registry = prometheus.NewRegistry()
 	registry.MustRegister(
 		metrics.WatchInterval,
+		metrics.UpdateTime,
 		metrics.HTTPGetTotal,
 		metrics.HTTPGetSuccessfulTotal,
 		metrics.HTTPGetFailTotal,

--- a/pkg/ingress-watcher/metrics/metrics.go
+++ b/pkg/ingress-watcher/metrics/metrics.go
@@ -17,6 +17,15 @@ var WatchInterval = prometheus.NewGauge(
 	},
 )
 
+// UpdateTime returns the last update time of watched result.
+var UpdateTime = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "update_time",
+		Help:      "last update time of watched result.",
+	},
+)
+
 // HTTPGetTotal returns the total successful count of http get.
 var HTTPGetTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{

--- a/pkg/ingress-watcher/metrics/metrics.go
+++ b/pkg/ingress-watcher/metrics/metrics.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 )
 
 const (
@@ -10,13 +9,12 @@ const (
 )
 
 // WatchInterval returns the interval of watch.
-var WatchInterval = prometheus.NewGaugeVec(
+var WatchInterval = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "watch_interval",
 		Help:      "interval of watch.",
 	},
-	[]string{model.InstanceLabel},
 )
 
 // HTTPGetTotal returns the total successful count of http get.
@@ -26,7 +24,7 @@ var HTTPGetTotal = prometheus.NewCounterVec(
 		Name:      "http_get_total",
 		Help:      "The total count of http get.",
 	},
-	[]string{"path", model.InstanceLabel},
+	[]string{"path"},
 )
 
 // HTTPGetSuccessfulTotal returns the total successful count of http get.
@@ -36,7 +34,7 @@ var HTTPGetSuccessfulTotal = prometheus.NewCounterVec(
 		Name:      "http_get_successful_total",
 		Help:      "The total successful count of http get.",
 	},
-	[]string{"code", "path", model.InstanceLabel},
+	[]string{"code", "path"},
 )
 
 // HTTPGetFailTotal returns the total fail count of http get.
@@ -46,5 +44,5 @@ var HTTPGetFailTotal = prometheus.NewCounterVec(
 		Name:      "http_get_fail_total",
 		Help:      "The total fail count of http get.",
 	},
-	[]string{"path", model.InstanceLabel},
+	[]string{"path"},
 )

--- a/pkg/ingress-watcher/watch/watch.go
+++ b/pkg/ingress-watcher/watch/watch.go
@@ -13,7 +13,6 @@ import (
 
 // Watcher watches target server health and creates metrics from it.
 type Watcher struct {
-	instance    string
 	targetAddrs []string
 	interval    time.Duration
 	httpClient  *well.HTTPClient
@@ -21,13 +20,11 @@ type Watcher struct {
 
 // NewWatcher creates an Ingress watcher.
 func NewWatcher(
-	instance string,
 	targetURLs []string,
 	interval time.Duration,
 	httpClient *well.HTTPClient,
 ) *Watcher {
 	return &Watcher{
-		instance:    instance,
 		targetAddrs: targetURLs,
 		interval:    interval,
 		httpClient:  httpClient,
@@ -37,12 +34,12 @@ func NewWatcher(
 // Run repeats to get server health and send it via channel.
 func (w *Watcher) Run(ctx context.Context) error {
 	env := well.NewEnvironment(ctx)
-	metrics.WatchInterval.WithLabelValues(w.instance).Set(w.interval.Seconds())
+	metrics.WatchInterval.Set(w.interval.Seconds())
 	for _, t := range w.targetAddrs {
 		// Initialize counter value as 0.
 		// Not initialize HTTPGetSuccessfulTotal because it needs status code.
-		metrics.HTTPGetTotal.WithLabelValues(t, w.instance)
-		metrics.HTTPGetFailTotal.WithLabelValues(t, w.instance)
+		metrics.HTTPGetTotal.WithLabelValues(t)
+		metrics.HTTPGetFailTotal.WithLabelValues(t)
 
 		t := t
 		env.Go(func(ctx context.Context) error {
@@ -64,18 +61,18 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 					req = req.WithContext(ctx)
 					res, err := w.httpClient.Do(req)
-					metrics.HTTPGetTotal.WithLabelValues(t, w.instance).Inc()
+					metrics.HTTPGetTotal.WithLabelValues(t).Inc()
 					if err != nil {
 						log.Info("GET failed.", map[string]interface{}{
 							"url":       t,
 							log.FnError: err,
 						})
-						metrics.HTTPGetFailTotal.WithLabelValues(t, w.instance).Inc()
+						metrics.HTTPGetFailTotal.WithLabelValues(t).Inc()
 					} else {
 						log.Info("GET succeeded.", map[string]interface{}{
 							"url": t,
 						})
-						metrics.HTTPGetSuccessfulTotal.WithLabelValues(strconv.Itoa(res.StatusCode), t, w.instance).Inc()
+						metrics.HTTPGetSuccessfulTotal.WithLabelValues(strconv.Itoa(res.StatusCode), t).Inc()
 						res.Body.Close()
 					}
 				}

--- a/pkg/ingress-watcher/watch/watch.go
+++ b/pkg/ingress-watcher/watch/watch.go
@@ -75,6 +75,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 						metrics.HTTPGetSuccessfulTotal.WithLabelValues(strconv.Itoa(res.StatusCode), t).Inc()
 						res.Body.Close()
 					}
+					metrics.UpdateTime.Set(float64(time.Now().Unix()))
 				}
 			}
 		})

--- a/pkg/ingress-watcher/watch/watch_test.go
+++ b/pkg/ingress-watcher/watch/watch_test.go
@@ -107,7 +107,6 @@ func TestWatcherRun(t *testing.T) {
 
 			// create watcher and run
 			w := NewWatcher(
-				"1.2.3.4",
 				tt.fields.targetURLs,
 				tt.fields.interval,
 				&well.HTTPClient{
@@ -137,12 +136,6 @@ func TestWatcherRun(t *testing.T) {
 			mfMapWithPath := make(map[metricKey]*dto.Metric)
 			mfMapWithoutPath := make(map[string]*dto.Metric)
 			for _, mf := range metricsFamily {
-				for _, met := range mf.Metric {
-					inst := labelToMap(met.Label)["instance"]
-					if inst != "1.2.3.4" {
-						t.Errorf("%s: metric %s has wrong instance label: %s", tt.name, *mf.Name, inst)
-					}
-				}
 				if containsSliceString(namesWithPath, *mf.Name) {
 					if len(mf.Metric) != len(tt.fields.targetURLs) {
 						t.Fatalf("%s: metric %s should contain only one element.", tt.name, *mf.Name)


### PR DESCRIPTION
- In push mode, "instance" must be sent as grouping key, not label.
- add "update_time" metrics what indicates last check time.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>