### PR TITLE
dctest: fix to set weights in cke-template.yml properly

### DIFF
--- a/dctest/cke.go
+++ b/dctest/cke.go
@@ -36,9 +36,6 @@ func TestCKESetup() {
 		By("setting configurations")
 		execSafeAt(bootServers[0], "ckecli", "constraints", "set", "control-plane-count", "3")
 		execSafeAt(bootServers[0], "ckecli", "constraints", "set", "minimum-workers", "2")
-		execSafeAt(bootServers[0], "cp", "/usr/share/neco/cke-template.yml", "/tmp")
-		execSafeAt(bootServers[0], "sed", "-i", "'s/#GCPONLY //g'", "/tmp/cke-template.yml")
-		execSafeAt(bootServers[0], "ckecli", "sabakan", "set-template", "/tmp/cke-template.yml")
 		execSafeAt(bootServers[0], "ckecli", "sabakan", "set-url", "http://localhost:10080")
 
 		By("waiting for cluster.yml generation")

--- a/dctest/contents.go
+++ b/dctest/contents.go
@@ -63,6 +63,7 @@ func TestInitData() {
 		stdout, stderr, err = execAt(bootServers[0], "neco", "cke", "weight", "get", "ss")
 		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 		Expect(string(bytes.TrimSpace(stdout))).To(Equal(strconv.Itoa(ssweight)))
+		execSafeAt(bootServers[0], "sudo", "sed", "-i", "'s/#GCPONLY //g'", "/usr/share/neco/cke-template.yml")
 		execSafeAt(bootServers[0], "neco", "cke", "update")
 		stdout, stderr, err = execAt(bootServers[0], "ckecli", "sabakan", "get-template")
 		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)


### PR DESCRIPTION
#1070 introduced a regression that ignored the server role ratio parameter
required for neco-apps CI.  This fixes it.