### PR TITLE
Use wget to download teleport binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOTAGS = $(TAGS) containers_image_openpgp containers_image_ostree_stub
 export GOFLAGS
 
 ### for debian package
-PACKAGES := fakeroot btrfs-tools pkg-config libdevmapper-dev libostree-dev libgpgme-dev libgpgme11 unzip zip
+PACKAGES := fakeroot btrfs-tools pkg-config libdevmapper-dev libostree-dev libgpgme-dev libgpgme11 unzip zip wget
 VERSION = 0.0.1-master
 DEST = .
 DEB = neco_$(VERSION)_amd64.deb

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -4,7 +4,7 @@ MAKEFLAGS += -j$(shell nproc)
 
 ### for containerd
 CONTAINERD_VERSION = 1.3.2
-CURL=curl -Lsf --retry 3
+CURL=curl -Lsf
 
 ### for node_exporter
 NODE_EXPORTER_VERSION = 0.18.1
@@ -104,15 +104,18 @@ kustomize:
 
 teleport:
 	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR)/$@/ $(WINDOWS_DOCDIR)/$@/
-	$(CURL) https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-linux-amd64-bin.tar.gz | tar xzf - -C $(BINDIR) --strip 1 $@/tsh
+	wget --no-verbose -O /tmp/teleport.tar.gz https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-linux-amd64-bin.tar.gz
+	tar xzf /tmp/teleport.tar.gz -C $(BINDIR) --strip 1 $@/tsh
+	rm -f /tmp/teleport.tar.gz
 	$(CURL) -o $(DOCDIR)/$@/LICENSE https://raw.githubusercontent.com/gravitational/teleport/v$(TELEPORT_VERSION)/LICENSE
 	$(CURL) -o $(DOCDIR)/$@/README.md https://raw.githubusercontent.com/gravitational/teleport/v$(TELEPORT_VERSION)/README.md
-	$(CURL) -o /tmp/teleport-v$(TELEPORT_VERSION)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-windows-amd64-bin.zip
-	unzip -o /tmp/teleport-v$(TELEPORT_VERSION)-windows-amd64-bin.zip teleport/tsh.exe -d $(WINDOWS_BINDIR)
-	unzip -o /tmp/teleport-v$(TELEPORT_VERSION)-windows-amd64-bin.zip teleport/README.md -d $(WINDOWS_DOCDIR)
+	wget --no-verbose -O /tmp/teleport.zip https://get.gravitational.com/teleport-v$(TELEPORT_VERSION)-windows-amd64-bin.zip
+	unzip -o /tmp/teleport.zip teleport/tsh.exe -d $(WINDOWS_BINDIR)
+	unzip -o /tmp/teleport.zip teleport/README.md -d $(WINDOWS_DOCDIR)
+	rm -f /tmp/teleport.zip
 	cp $(DOCDIR)/$@/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 
 clean:
 	rm -rf $(BUILDDIR)
 
-.PHONY:	all setup clean node_exporter containerd crictl argocd kubectl lvmd stern kustomize teleport
+.PHONY:	all clean node_exporter containerd crictl argocd kubectl lvmd stern kustomize teleport


### PR DESCRIPTION
because curl does not retry even with `--retry` option.