### PR TITLE
setup: On Ubuntu 20.04, install btrfs-progs and libbtrfs-dev instead of btrfs-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 include Makefile.common
 
-LSB_DISTRIB_ID      := $(shell . /etc/lsb-release ; echo $$DISTRIB_ID)
 LSB_DISTRIB_RELEASE := $(shell . /etc/lsb-release ; echo $$DISTRIB_RELEASE)
 
 FAKEROOT = fakeroot

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 include Makefile.common
 
+LSB_DISTRIB_ID      := $(shell . /etc/lsb-release ; echo $$DISTRIB_ID)
+LSB_DISTRIB_RELEASE := $(shell . /etc/lsb-release ; echo $$DISTRIB_RELEASE)
+
 FAKEROOT = fakeroot
 ETCD_DIR = /tmp/neco-etcd
 TAGS =
@@ -12,7 +15,12 @@ GOTAGS = $(TAGS) containers_image_openpgp containers_image_ostree_stub
 export GOFLAGS
 
 ### for debian package
-PACKAGES := fakeroot btrfs-tools pkg-config libdevmapper-dev libostree-dev libgpgme-dev libgpgme11 unzip zip wget
+PACKAGES = fakeroot pkg-config libdevmapper-dev libostree-dev libgpgme-dev libgpgme11 unzip zip wget
+ifeq (20.04, $(word 1, $(sort 20.04 $(LSB_DISTRIB_RELEASE)))) # is Ubuntu 20.04 or later?
+    PACKAGES += btrfs-progs libbtrfs-dev
+else
+    PACKAGES += btrfs-tools
+endif
 VERSION = 0.0.1-master
 DEST = .
 DEB = neco_$(VERSION)_amd64.deb


### PR DESCRIPTION
btrfs-tools package is deprecated and split into btrfs-progs and libbtrfs-dev.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>