### PR TITLE
necogcp: add snapshot commands

### DIFF
--- a/docs/gcp/necogcp.md
+++ b/docs/gcp/necogcp.md
@@ -30,6 +30,14 @@ Synopsis
 
     Setup `host-vm` or `vmx-enabled` instance. It can run on only them.
 
+* `necogcp create-snapshott`
+
+    Create `home` volume snapshot.
+
+* `necogcp restore-snapshot`
+
+    Restore `home` volume from the latest snapshot in the zone specified by the flag `--dest-zone`.
+
 ### GCE instance management on neco-test project
 
 * `necogcp neco-test create-image`
@@ -54,9 +62,11 @@ Synopsis
 Flags
 -----
 
-| Flag       | Default value        | Description                                                                      |
-| ---------- | -------------------- | -------------------------------------------------------------------------------- |
-| `--config` | `$HOME/.necogcp.yml` | [Viper configuration file](https://github.com/spf13/viper#reading-config-files). |
+| Flag          | Default value                         | Description                                                                      |
+| ------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| `--config`    | `$HOME/.necogcp.yml`                  | [Viper configuration file](https://github.com/spf13/viper#reading-config-files). |
+| `--src-zone`  | `common.zone` in `$HOME/.necogcp.yml` | zone of the snapshot of `home` volume                                            |
+| `--dest-zone` | `an empty string`                     | zone to restore `home` volume                                                    |
 
 Configuration file
 ------------------

--- a/docs/gcp/necogcp.md
+++ b/docs/gcp/necogcp.md
@@ -62,11 +62,10 @@ Synopsis
 Flags
 -----
 
-| Flag          | Default value                         | Description                                                                      |
-| ------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
-| `--config`    | `$HOME/.necogcp.yml`                  | [Viper configuration file](https://github.com/spf13/viper#reading-config-files). |
-| `--src-zone`  | `common.zone` in `$HOME/.necogcp.yml` | zone of the snapshot of `home` volume                                            |
-| `--dest-zone` | `an empty string`                     | zone to restore `home` volume                                                    |
+| Flag          | Default value        | Description                                                                      |
+| ------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `--config`    | `$HOME/.necogcp.yml` | [Viper configuration file](https://github.com/spf13/viper#reading-config-files). |
+| `--dest-zone` | `an empty string`    | zone to restore `home` volume                                                    |
 
 Configuration file
 ------------------

--- a/gcp/compute.go
+++ b/gcp/compute.go
@@ -49,6 +49,7 @@ type ComputeClient struct {
 	image    string
 }
 
+// Snapshot is GCP snapshot object
 type Snapshot struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
@@ -406,10 +407,7 @@ func (cc *ComputeClient) CreateVolumeSnapshot(ctx context.Context) error {
 }
 
 // RestoreVolumeFromSnapshot restores home volume in the target zone
-func (cc *ComputeClient) RestoreVolumeFromSnapshot(ctx context.Context, srcZone, destZone string) error {
-	if srcZone == "" {
-		srcZone = cc.cfg.Common.Zone
-	}
+func (cc *ComputeClient) RestoreVolumeFromSnapshot(ctx context.Context, destZone string) error {
 	gcmdSnapshot := []string{"gcloud", "--quiet", "--account", cc.cfg.Common.ServiceAccount,
 		"--project", cc.cfg.Common.Project, "compute", "snapshots", "list",
 		"--sort-by=date", "--limit=1", "--filter=sourceDisk:disks/home", "--format=json"}

--- a/pkg/necogcp/cmd/createsnapshot.go
+++ b/pkg/necogcp/cmd/createsnapshot.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/neco/gcp"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var createSnapshotCmd = &cobra.Command{
+	Use:   "create-snapshot",
+	Short: "Create home volume snapshot",
+	Long:  `Create home volume snapshot manually.`,
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		cc := gcp.NewComputeClient(cfg, "host-vm")
+		well.Go(func(ctx context.Context) error {
+			err := cc.CreateVolumeSnapshot(ctx)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+		well.Stop()
+		err := well.Wait()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createSnapshotCmd)
+}

--- a/pkg/necogcp/cmd/restoresnapshot.go
+++ b/pkg/necogcp/cmd/restoresnapshot.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-	srcZone  string
 	destZone string
 )
 
@@ -25,7 +24,7 @@ var restoreSnapshotCmd = &cobra.Command{
 		}
 		cc := gcp.NewComputeClient(cfg, "host-vm")
 		well.Go(func(ctx context.Context) error {
-			err := cc.RestoreVolumeFromSnapshot(ctx, srcZone, destZone)
+			err := cc.RestoreVolumeFromSnapshot(ctx, destZone)
 			if err != nil {
 				return err
 			}
@@ -38,7 +37,6 @@ var restoreSnapshotCmd = &cobra.Command{
 }
 
 func init() {
-	restoreSnapshotCmd.Flags().StringVar(&srcZone, "src-zone", "", "zone name for the target snapshot ")
 	restoreSnapshotCmd.Flags().StringVar(&destZone, "dest-zone", "", "zone name for creating a new volume")
 	rootCmd.AddCommand(restoreSnapshotCmd)
 }

--- a/pkg/necogcp/cmd/restoresnapshot.go
+++ b/pkg/necogcp/cmd/restoresnapshot.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cybozu-go/neco/gcp"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var (
+	srcZone  string
+	destZone string
+)
+
+var restoreSnapshotCmd = &cobra.Command{
+	Use:   "restore-snapshot",
+	Short: "Restore home volume snapshot",
+	Long:  `Restore home volume snapshot manually.`,
+	Args:  cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if destZone == "" {
+			return fmt.Errorf("setting --dest-zone flag is required")
+		}
+		cc := gcp.NewComputeClient(cfg, "host-vm")
+		well.Go(func(ctx context.Context) error {
+			err := cc.RestoreVolumeFromSnapshot(ctx, srcZone, destZone)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		well.Stop()
+		err := well.Wait()
+		return err
+	},
+}
+
+func init() {
+	restoreSnapshotCmd.Flags().StringVar(&srcZone, "src-zone", "", "zone name for the target snapshot ")
+	restoreSnapshotCmd.Flags().StringVar(&destZone, "dest-zone", "", "zone name for creating a new volume")
+	rootCmd.AddCommand(restoreSnapshotCmd)
+}


### PR DESCRIPTION
`necogcp` is currently using the `home` device as a persistent volume.
However, `necogcp` does not have a function to create/restore the volume from snapshot and this cause problems when the volume is corrupt.

Therefore, this PR adds `create-snapshot` and `restore-snapshot` subcommands for handling the problem above.
The new subcommands are manually tested. See [this](https://bozuman.cybozu.com/k/#/space/3801/thread/44932/2467026/3711787)

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>