### PR TITLE
ignitions: set kernel parameter to reboot on kernel hung

### DIFF
--- a/ignitions/common/files/etc/sysctl.d/60-cybozu.conf
+++ b/ignitions/common/files/etc/sysctl.d/60-cybozu.conf
@@ -13,3 +13,5 @@ net.ipv4.neigh.default.gc_thresh3 = 4096
 net.ipv4.tcp_keepalive_time = 600
 # Increase the maximum TCP send buffer size settable with setsockopt(2).
 net.core.wmem_max = 16777216
+# To reboot the kernel on high CPU usage.
+kernel.hung_task_panic = 1


### PR DESCRIPTION
We observe some nodes suffer from high CPU usage and sabakan recognizes them as unhealthy.
This PR sets hung_task_panic to 1 to reboot on such event.

#1103