### PR TITLE
Revert "disable upgrade ci job temporarily."

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,12 +356,12 @@ workflows:
               ignore:
                 - release
                 - master
-#      - dctest-upgrade:
-#          filters:
-#            branches:
-#              ignore:
-#                - release
-#                - master
+      - dctest-upgrade:
+          filters:
+            branches:
+              ignore:
+                - release
+                - master
 
   # Update github release page.
   release:
@@ -392,13 +392,13 @@ workflows:
       - dctest-functions-release:
           requires:
             - generate-artifacts
-#      - dctest-upgrade-release:
-#          requires:
-#            - generate-artifacts
+      - dctest-upgrade-release:
+          requires:
+            - generate-artifacts
       - update-release:
           requires:
             - dctest-functions-release
-#            - dctest-upgrade-release
+            - dctest-upgrade-release
 
   # For updating `artifact_release.go` regularly, run the same job as `master` workflow.
   daily:


### PR DESCRIPTION
This reverts commit 176fc54a6a3ca02e7fb94350e9242626e20bce5e.