### PR TITLE
kube-proxy: use source-hash scheduling algorithm

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -31,6 +31,7 @@ options:
   kube-proxy:
     extra_args:
       - "--ipvs-strict-arp=true"
+      - "--ipvs-scheduler=sh"
       - "--feature-gates=EphemeralContainers=true"
   kube-scheduler:
     extenders:


### PR DESCRIPTION
IPVS with source-hash (sh) scheduler can eliminate needs for
session persistence.  This work is to prepare Coil v2 Egress
NAT feature.

ref: https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/#ipvs-based-kube-proxy

neco-apps CI with this branch has passed:
https://app.circleci.com/pipelines/github/cybozu-go/neco-apps/3819/workflows/359764da-d3af-4e08-9d7e-5831289cfeb3/jobs/12982