### PR TITLE
reboot-worker: use CKE's graceful reboot functionality for cluster nodes.

### DIFF
--- a/docs/neco.md
+++ b/docs/neco.md
@@ -151,6 +151,9 @@ Synopsis
 
     Reboot all worker nodes.
 
+    This uses CKE's function of [graceful reboot](https://github.com/cybozu-go/cke/blob/master/docs/reboot.md) for the nodes used by CKE.
+    As for the other nodes, this reboots them immediately.
+
 ### CKE related functions
 
 The name of the cluster in [cke-template.yml](../etc/cke-template.yml) will be overwritten with the value read from `/etc/neco/cluster`.


### PR DESCRIPTION
This PR updates `neco reboot-worker` command.
Originally this command reboots worker nodes immediately via IPMI.
CKE now provides the function of graceful reboot, so use that function for the nodes assigned to CKE.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
