### PR TITLE
tuning memory size to avoid the error when CI

### DIFF
--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -44,10 +44,10 @@ kind: Node
 type: cs
 spec:
   cpu: 8
-  memory: 16G
+  memory: 12G
 ---
 kind: Node
 type: ss
 spec:
   cpu: 2
-  memory: 10G
+  memory: 6G


### PR DESCRIPTION
Sometimes, the CI test failed due to a kernel soft lock up crash.
It seems the linux kernel could not allocate enough memory in the watchdog timer interval.
This decreases VM memory size to reduce the possibility of such situation.
