### PR TITLE
Ignore gcloud error when adding canceled labels

### DIFF
--- a/bin/run-dctest.sh
+++ b/bin/run-dctest.sh
@@ -20,7 +20,7 @@ LABEL_REF=ref=${REF_VALUE}
 # Set state label to old instances
 CANCELED_LIST=$($GCLOUD compute instances list --project neco-test --filter="labels.${LABEL_REPO} AND labels.${LABEL_REF} AND labels.${LABEL_JOB}" --format "value(name)")
 for CANCELED in ${CANCELED_LIST}; do
-  $GCLOUD compute instances add-labels ${CANCELED} --zone=${ZONE} --labels=state=canceled
+  $GCLOUD compute instances add-labels ${CANCELED} --zone=${ZONE} --labels=state=canceled || true
 done
 
 # Create GCE instance


### PR DESCRIPTION
If an instance is deleted after listing, this gcloud fails. Prevents CI Error from this error.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>