### PR TITLE
Update coil to 2.0.3 and remove "tuning" CNI plugin

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,13 +5,13 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.18.2", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.18.3", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.25.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.7.0", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.3", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.9.5.1", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.4.1.2", Private: false},
-		{Name: "coil", Repository: "ghcr.io/cybozu-go/coil", Tag: "2.0.2", Private: false},
+		{Name: "coil", Repository: "ghcr.io/cybozu-go/coil", Tag: "2.0.3", Private: false},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "3.5.27.1.11", Private: false},
 		{Name: "teleport", Repository: "quay.io/cybozu/teleport", Tag: "4.3.7.1", Private: false},
 	},

--- a/etc/coil.yaml
+++ b/etc/coil.yaml
@@ -4651,10 +4651,6 @@ data:
           "socket": "/run/coild.sock"
         },
         {
-          "type": "tuning",
-          "mtu": 1400
-        },
-        {
           "type": "portmap",
           "capabilities": {
             "portMappings": true
@@ -4666,7 +4662,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/name: coil
-  name: coil-config-22b825t954
+  name: coil-config-85b6k6c66t
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4739,7 +4735,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ghcr.io/cybozu-go/coil:2.0.2
+        image: ghcr.io/cybozu-go/coil:2.0.3
         livenessProbe:
           httpGet:
             host: localhost
@@ -4817,7 +4813,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: ghcr.io/cybozu-go/coil:2.0.2
+        image: ghcr.io/cybozu-go/coil:2.0.3
         livenessProbe:
           httpGet:
             host: localhost
@@ -4859,8 +4855,8 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni_netconf
-              name: coil-config-22b825t954
-        image: ghcr.io/cybozu-go/coil:2.0.2
+              name: coil-config-85b6k6c66t
+        image: ghcr.io/cybozu-go/coil:2.0.3
         name: coil-installer
         securityContext:
           privileged: true

--- a/etc/netconf.json
+++ b/etc/netconf.json
@@ -7,10 +7,6 @@
       "socket": "/run/coild.sock"
     },
     {
-      "type": "tuning",
-      "mtu": 1400
-    },
-    {
       "type": "portmap",
       "capabilities": {
         "portMappings": true

--- a/ignitions/common/files/opt/sbin/setup-local-network
+++ b/ignitions/common/files/opt/sbin/setup-local-network
@@ -17,6 +17,11 @@ for i in $(seq 20); do
     sleep 5
 done
 
+MTU=1500
+if systemd-detect-virt -q; then
+    MTU=1460
+fi
+
 cat >/etc/systemd/network/01-eth0.network <<EOF
 [Match]
 Name=eth0 eno1
@@ -28,6 +33,9 @@ EmitLLDP=nearest-bridge
 [Address]
 Address={{ index .Spec.IPv4 1 }}/{{ (index .Info.Network.IPv4 1).MaskBits }}
 Scope=link
+
+[Link]
+MTUBytes=${MTU}
 EOF
 
 cat >/etc/systemd/network/01-eth1.network <<EOF
@@ -41,6 +49,9 @@ EmitLLDP=nearest-bridge
 [Address]
 Address={{ index .Spec.IPv4 2 }}/{{ (index .Info.Network.IPv4 2).MaskBits }}
 Scope=link
+
+[Link]
+MTUBytes=${MTU}
 EOF
 
 cat >/etc/systemd/network/10-node0.netdev <<EOF


### PR DESCRIPTION
Now that Coil detects the optimal MTU value automatically,
tuning plugin is no longer necessary on GCP environment.