### PR TITLE
Resize ss node memory size

### DIFF
--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -50,4 +50,4 @@ kind: Node
 type: ss
 spec:
   cpu: 2
-  memory: 6G
+  memory: 10G


### PR DESCRIPTION
Currently, the ss node has only 4G memory, which is not enough to have two OSD pods. 
So, the ss node's memory is returned to 10G.