### PR TITLE
ingress-watcher: set timeout for pushing metrics

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.18.4", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.18.6", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.25.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.7.0", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.3", Private: false},

--- a/pkg/ingress-watcher/cmd/push.go
+++ b/pkg/ingress-watcher/cmd/push.go
@@ -88,7 +88,10 @@ var pushCmd = &cobra.Command{
 			tick := time.NewTicker(pushConfig.PushInterval)
 			defer tick.Stop()
 
-			pusher := push.New(pushConfig.PushAddr, "ingress-watcher").Grouping("instance", pushConfig.Instance).Gatherer(registry)
+			pusher := push.New(pushConfig.PushAddr, "ingress-watcher").
+				Client(&http.Client{Timeout: pushConfig.PushInterval}).
+				Grouping("instance", pushConfig.Instance).
+				Gatherer(registry)
 			for {
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
`ingress-watcher` get stuck when the connection to push-gateway is refused.
This is because the default timeout setting is 0, which means no timeout on the client side.
This PR fixes this behavior. 
Signed-off-by: zoetrope <a.ikezoe@gmail.com>