### PR TITLE
Update kube-proxy mode from sh to rr

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -35,7 +35,6 @@ options:
   kube-proxy:
     extra_args:
       - "--ipvs-strict-arp=true"
-      - "--ipvs-scheduler=sh"
       - "--feature-gates=EphemeralContainers=true"
   kube-scheduler:
     extenders:


### PR DESCRIPTION
"sh" is no longer needed because of https://github.com/cybozu-go/neco-apps/pull/884 .
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>