### PR TITLE
Increase retry count to stabilize test

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -5,7 +5,7 @@ package neco
 
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
-		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.18.6", Private: false},
+		{Name: "cke", Repository: "quay.io/cybozu/cke", Tag: "1.18.7", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.25.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.7.0", Private: true},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.3", Private: false},

--- a/progs/sabakan/upload.go
+++ b/progs/sabakan/upload.go
@@ -28,7 +28,7 @@ const (
 	imageOS = "coreos"
 )
 
-const retryCount = 5
+const retryCount = 10
 
 // UploadContents upload contents to sabakan
 func UploadContents(ctx context.Context, sabakanHTTP *http.Client, proxyHTTP *http.Client, version string, auth *DockerAuth, st storage.Storage) error {


### PR DESCRIPTION
When fetching an image from ghcr, this error https://app.circleci.com/pipelines/github/cybozu-go/neco-apps/4279/workflows/d34e9d40-15d9-448e-9f70-35a83348aa34/jobs/14796 occurs.
This PR mitigates this failure because this is probably a problem on the ghcr side.

Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>