### PR TITLE
extend /var/lib/k8s-containerd to avoid disk pressure when testing rook/ceph

### DIFF
--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -2,7 +2,7 @@
 
 VG=vg1
 LVLIST="k8s-containerd docker kubelet rkt"
-CONTAINERD_SIZE=10g
+CONTAINERD_SIZE=20g
 DOCKER_SIZE=10g
 KUBELET_SIZE=10g
 RKT_SIZE=10g

--- a/menu/cluster.go
+++ b/menu/cluster.go
@@ -259,7 +259,7 @@ func emptyNode(rackName, rackShortName, nodeName, serial string, disks int, reso
 	for i := 0; i < disks; i++ {
 		volumes[i].Kind = "raw"
 		volumes[i].Name = fmt.Sprintf("data%d", i+1)
-		volumes[i].Size = "30G"
+		volumes[i].Size = "50G"
 		volumes[i].Cache = "writeback"
 	}
 

--- a/menu/testdata/cluster.yml
+++ b/menu/testdata/cluster.yml
@@ -200,11 +200,11 @@ volumes:
 - cache: writeback
   kind: raw
   name: data1
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data2
-  size: 30G
+  size: 50G
 - copy-on-write: true
   image: docker-image
   kind: image
@@ -224,11 +224,11 @@ volumes:
 - cache: writeback
   kind: raw
   name: data1
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data2
-  size: 30G
+  size: 50G
 - copy-on-write: true
   image: docker-image
   kind: image
@@ -271,11 +271,11 @@ volumes:
 - cache: writeback
   kind: raw
   name: data1
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data2
-  size: 30G
+  size: 50G
 - copy-on-write: true
   image: docker-image
   kind: image
@@ -295,11 +295,11 @@ volumes:
 - cache: writeback
   kind: raw
   name: data1
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data2
-  size: 30G
+  size: 50G
 - copy-on-write: true
   image: docker-image
   kind: image
@@ -318,19 +318,19 @@ volumes:
 - cache: writeback
   kind: raw
   name: data1
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data2
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data3
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data4
-  size: 30G
+  size: 50G
 - copy-on-write: true
   image: docker-image
   kind: image
@@ -349,19 +349,19 @@ volumes:
 - cache: writeback
   kind: raw
   name: data1
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data2
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data3
-  size: 30G
+  size: 50G
 - cache: writeback
   kind: raw
   name: data4
-  size: 30G
+  size: 50G
 - copy-on-write: true
   image: docker-image
   kind: image


### PR DESCRIPTION
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>