### PR TITLE
Fixing things

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -148,8 +148,7 @@ var (
 	EtcdpasswdConfFile = filepath.Join(EtcdpasswdDir, "config.yml")
 	EtcdpasswdDropIn   = "/etc/systemd/system/ep-agent.service.d/10-check-certificate.conf"
 
-	TeleportTokenFile = filepath.Join(TeleportDir, "token")
-	TeleportConfFile  = filepath.Join(TeleportDir, "teleport.yaml")
+	TeleportConfFile = filepath.Join(TeleportDir, "teleport.yaml")
 
 	SabakanCertFile           = filepath.Join(SabakanDir, "etcd.crt")
 	SabakanKeyFile            = filepath.Join(SabakanDir, "etcd.key")

--- a/dctest/init_test.go
+++ b/dctest/init_test.go
@@ -53,23 +53,7 @@ func testInit() {
 	})
 
 	It("should initialize teleport", func() {
-		token := getVaultToken()
-
 		execSafeAt(bootServers[0], "neco", "init", "teleport")
-
-		for _, host := range bootServers {
-			stdout, stderr, err := execAt(
-				host, "sudo", "env", "VAULT_TOKEN="+token, "neco", "init-local", "teleport")
-			if err != nil {
-				log.Error("neco init-local teleport", map[string]interface{}{
-					"host":   host,
-					"stdout": string(stdout),
-					"stderr": string(stderr),
-				})
-				Expect(err).NotTo(HaveOccurred())
-			}
-			execSafeAt(host, "test", "-f", neco.TeleportTokenFile)
-		}
 	})
 
 	It("should success initialize Serf", func() {

--- a/dctest/setup_test.go
+++ b/dctest/setup_test.go
@@ -94,7 +94,7 @@ func testSetup() {
 
 		By("Installing sshd_config and sudoers")
 		for _, h := range bootServers {
-			execSafeAt(h, "grep", "-q", "'^PasswordAuthentication.no$'", "/etc/ssh/sshd_config")
+			execSafeAt(h, "test", "-f", "/etc/ssh/sshd_config.d/neco.conf")
 			execSafeAt(h, "sudo", "test", "-f", "/etc/sudoers.d/cybozu")
 		}
 	})

--- a/ignitions/common/files/opt/sbin/setup-hw
+++ b/ignitions/common/files/opt/sbin/setup-hw
@@ -14,6 +14,10 @@ if [ $ok = false ]; then
     exit 2
 fi
 
+# setup-hw container resets iDRAC at startup.
+# Wait here to avoid the reset from occurring while the tool is running.
+sleep 60
+
 docker exec setup-hw setup-hw
 RET=$?
 

--- a/pkg/neco/cmd/init_local.go
+++ b/pkg/neco/cmd/init_local.go
@@ -3,13 +3,10 @@ package cmd
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
 	"github.com/cybozu-go/neco/progs/sabakan"
-	"github.com/cybozu-go/neco/storage"
 	"github.com/cybozu-go/well"
 	"github.com/hashicorp/vault/api"
 	"github.com/spf13/cobra"
@@ -56,8 +53,6 @@ new a application NAME.`,
 			switch initLocalParams.name {
 			case "etcdpasswd":
 				err = issueCerts(ctx, vc, "etcdpasswd", neco.EtcdpasswdCertFile, neco.EtcdpasswdKeyFile)
-			case "teleport":
-				err = getToken(ctx, ce, neco.TeleportTokenFile)
 			case "sabakan":
 				err = issueCerts(ctx, vc, "sabakan", neco.SabakanCertFile, neco.SabakanKeyFile)
 				if err != nil {
@@ -76,8 +71,6 @@ new a application NAME.`,
 			switch initLocalParams.name {
 			case "etcdpasswd":
 				err = neco.StartService(ctx, neco.EtcdpasswdService)
-			case "teleport":
-				err = neco.StartService(ctx, neco.TeleportService)
 			case "sabakan":
 				err = neco.StartService(ctx, neco.SabakanService)
 			case "cke":
@@ -112,18 +105,4 @@ func issueCerts(ctx context.Context, vc *api.Client, commonName, cert, key strin
 	}
 	return neco.WriteFile(key, secret.Data["private_key"].(string))
 
-}
-
-func getToken(ctx context.Context, ce *clientv3.Client, filename string) error {
-	st := storage.NewStorage(ce)
-	token, err := st.GetTeleportAuthToken(ctx)
-	if err != nil {
-		return err
-	}
-	if len(token) == 0 {
-		return errors.New("teleport/auth-token is empty")
-	}
-
-	err = ioutil.WriteFile(filename, []byte(token), 0600)
-	return err
 }

--- a/pkg/neco/cmd/teleport_config.go
+++ b/pkg/neco/cmd/teleport_config.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
 	"github.com/cybozu-go/neco/progs/teleport"
 	"github.com/cybozu-go/neco/storage"
@@ -20,50 +19,55 @@ var teleportConfigCmd = &cobra.Command{
 	Long: `Generate config for teleport by filling template with secret in file
 and dynamic info in etcd.`,
 
-	Run: func(cmd *cobra.Command, args []string) {
-		if os.Getuid() != 0 {
-			log.ErrorExit(errors.New("run as root"))
-		}
-
-		token, err := ioutil.ReadFile(neco.TeleportTokenFile)
-		if err != nil {
-			log.ErrorExit(err)
-		}
-
-		ce, err := neco.EtcdClient()
-		if err != nil {
-			log.ErrorExit(err)
-		}
-		defer ce.Close()
-		st := storage.NewStorage(ce)
-
-		authServers, err := st.GetTeleportAuthServers(context.Background())
-		if err != nil {
-			log.ErrorExit(err)
-		}
-
-		mylrn, err := neco.MyLRN()
-		if err != nil {
-			log.ErrorExit(err)
-		}
-
-		buf := &bytes.Buffer{}
-		err = teleport.GenerateConf(buf, mylrn, string(token), authServers)
-		if err != nil {
-			log.ErrorExit(err)
-		}
-		err = ioutil.WriteFile(neco.TeleportConfFile, buf.Bytes(), 0600)
-		if err != nil {
-			log.ErrorExit(err)
-		}
-
-		err = neco.RestartService(context.Background(), "teleport-node")
-		if err != nil {
-			log.ErrorExit(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return teleportConfig(context.Background())
 	},
 }
 
 func init() {
 	teleportCmd.AddCommand(teleportConfigCmd)
+}
+
+func teleportConfig(ctx context.Context) error {
+	if os.Getuid() != 0 {
+		return errors.New("run as root")
+	}
+
+	ce, err := neco.EtcdClient()
+	if err != nil {
+		return err
+	}
+	defer ce.Close()
+	st := storage.NewStorage(ce)
+
+	token, err := st.GetTeleportAuthToken(ctx)
+	if err != nil {
+		return err
+	}
+	if len(token) == 0 {
+		return errors.New("no teleport token is found")
+	}
+
+	authServers, err := st.GetTeleportAuthServers(context.Background())
+	if err != nil {
+		return err
+	}
+
+	mylrn, err := neco.MyLRN()
+	if err != nil {
+		return err
+	}
+
+	buf := &bytes.Buffer{}
+	err = teleport.GenerateConf(buf, mylrn, string(token), authServers)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(neco.TeleportConfFile, buf.Bytes(), 0600)
+	if err != nil {
+		return err
+	}
+
+	return neco.RestartService(context.Background(), "teleport-node")
 }

--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -12,13 +12,11 @@ import (
 )
 
 func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest) error {
-	_, err := replaceFile("/etc/ssh/sshd_config", []byte(etcdpasswd.SshdConf), 0644)
-	if err != nil {
+	if err := etcdpasswd.InstallSshdConf(); err != nil {
 		return err
 	}
 
-	err = etcdpasswd.InstallSudoers()
-	if err != nil {
+	if err := etcdpasswd.InstallSudoers(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR contains three fixes for recently found problems:

- Install sshd_config under `/etc/ssh/sshd_config.d` directory on Ubuntu 20.04 or later.
- Wait for iDRAC reset before running `setup-hw` utility in `neco bmc setuphw`.
- Remove `neco init-local teleport` sub command.