### PR TITLE
installer: purge fwupd

### DIFF
--- a/installer/setup/packages.go
+++ b/installer/setup/packages.go
@@ -10,6 +10,7 @@ var (
 	purgeList = []string{
 		"apport",
 		"apport-symptoms",
+		"fwupd",
 		"nano",
 		//"netplan.io",
 		"popularity-contest",


### PR DESCRIPTION
fwupd tries to download firmware over the Internet.
This is not possible on boot servers, so we purge it.