### PR TITLE
git-neco: use default branch instead of `master`

### DIFF
--- a/pkg/git-neco/cmd/clean.go
+++ b/pkg/git-neco/cmd/clean.go
@@ -8,24 +8,28 @@ import (
 
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
-	Short: "remove local branches merged into origin/master",
-	Long:  `Remove local branches merged into origin/master.`,
+	Short: "remove local branches merged into default branch",
+	Long:  `Remove local branches merged into default branch.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := sanityCheck(); err != nil {
 			return err
 		}
 
-		if err := git("checkout", "master"); err != nil {
+		defBranch, err := defaultBranch()
+		if err != nil {
+			return err
+		}
+		if err := git("checkout", defBranch); err != nil {
 			return err
 		}
 		if err := git("fetch", "origin"); err != nil {
 			return err
 		}
-		data, err := gitOutput("branch", "--format=%(refname:short)", "--merged", "origin/master")
+		data, err := gitOutput("branch", "--format=%(refname:short)", "--merged", "origin/"+defBranch)
 		if err != nil {
 			return err
 		}
-		for _, b := range gcFilterBranch(strings.Fields(string(data))) {
+		for _, b := range gcFilterBranch(defBranch, strings.Fields(string(data))) {
 			if err := git("branch", "-D", b); err != nil {
 				return err
 			}

--- a/pkg/git-neco/cmd/dev.go
+++ b/pkg/git-neco/cmd/dev.go
@@ -6,8 +6,8 @@ import (
 
 var devCmd = &cobra.Command{
 	Use:   "dev BRANCH_NAME",
-	Short: "create a feature branch from the latest origin/master",
-	Long:  `Create a feature branch from the latest origin/master.`,
+	Short: "create a feature branch from the latest default branch",
+	Long:  `Create a feature branch from the latest default branch.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := sanityCheck(); err != nil {
@@ -18,7 +18,11 @@ var devCmd = &cobra.Command{
 			return err
 		}
 
-		return git("checkout", "--no-track", "-b", args[0], "origin/master")
+		defBranch, err := defaultBranch()
+		if err != nil {
+			return err
+		}
+		return git("checkout", "--no-track", "-b", args[0], "origin/"+defBranch)
 	},
 }
 

--- a/pkg/git-neco/cmd/gc.go
+++ b/pkg/git-neco/cmd/gc.go
@@ -6,10 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func gcFilterBranch(branches []string) (ret []string) {
+func gcFilterBranch(defBranch string, branches []string) (ret []string) {
 	for _, b := range branches {
 		switch b {
-		case "master", "HEAD", "release":
+		case defBranch, "HEAD", "release":
 			continue
 		}
 		if strings.HasPrefix(b, "release-") {
@@ -32,11 +32,15 @@ var gcCmd = &cobra.Command{
 		if err := git("fetch", "origin", "--prune"); err != nil {
 			return err
 		}
-		data, err := gitOutput("branch", "--format=%(refname:lstrip=3)", "-r", "--merged", "origin/master")
+		defBranch, err := defaultBranch()
 		if err != nil {
 			return err
 		}
-		for _, b := range gcFilterBranch(strings.Fields(string(data))) {
+		data, err := gitOutput("branch", "--format=%(refname:lstrip=3)", "-r", "--merged", "origin/"+defBranch)
+		if err != nil {
+			return err
+		}
+		for _, b := range gcFilterBranch(defBranch, strings.Fields(string(data))) {
 			if err := git("push", "origin", ":"+b); err != nil {
 				return err
 			}

--- a/pkg/git-neco/cmd/git.go
+++ b/pkg/git-neco/cmd/git.go
@@ -36,6 +36,18 @@ func currentBranch() (string, error) {
 	return br, nil
 }
 
+func defaultBranch() (string, error) {
+	data, err := gitOutput("symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", err
+	}
+	items := strings.Split(strings.TrimSpace(string(data)), "/")
+	if len(items) < 1 {
+		return "", errors.New("HEAD is empty")
+	}
+	return items[len(items)-1], nil
+}
+
 func checkUncommittedFiles() (bool, error) {
 	data, err := gitOutput("status", "-s")
 	if err != nil {
@@ -44,9 +56,9 @@ func checkUncommittedFiles() (bool, error) {
 	return strings.TrimSpace(string(data)) == "", nil
 }
 
-func firstUnmerged() (hash string, summary string, body string, err error) {
+func firstUnmerged(defBranch string) (hash string, summary string, body string, err error) {
 	var data []byte
-	data, err = gitOutput("log", "HEAD", "--not", "origin/master", "--format=%H", "--reverse")
+	data, err = gitOutput("log", "HEAD", "--not", "origin/"+defBranch, "--format=%H", "--reverse")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The default branch name on GitHub has been changed to `main`.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>