### PR TITLE
Fix backup-cke-etcd not working

### DIFF
--- a/debian/lib/systemd/system/backup-cke-etcd.service
+++ b/debian/lib/systemd/system/backup-cke-etcd.service
@@ -2,8 +2,9 @@
 Description=ckecli etcd local-backup
 After=cke.service
 ConditionPathExists=/etc/cke/etcd.crt
+ConditionVirtualization=false
 
 [Service]
 Type=oneshot
 ExecStartPre=/bin/mkdir -p /var/cke/etcd-backups
-ExecStart=/usr/local/bin/ckecli etcd local-backup
+ExecStart=/usr/bin/ckecli etcd local-backup

--- a/progs/setup-serf-tags/template.go
+++ b/progs/setup-serf-tags/template.go
@@ -7,10 +7,7 @@ var scriptTmpl = template.Must(template.New("setup-serf-tags").Parse(`#!/bin/sh
 # list failed unit names
 # limit to 300 bytes because whole length of tags must be < 512 bytes.
 
-# Ignore failure of backup-cke-etcd.service because it does not mean
-# that the machine is not healthy.  Ideally, it should care only about
-# the essential services related to the machine health.
-systemd_units_failed="$(systemctl list-units --state=failed --no-legend --plain --full | grep -v backup-cke-etcd.service | cut -d' ' -f1  | tr '\n' ',' | head --bytes=300)"
+systemd_units_failed="$(systemctl list-units --state=failed --no-legend --plain --full | cut -d' ' -f1  | tr '\n' ',' | head --bytes=300)"
 
 /usr/local/bin/serf tags \
        -set uptime="$(uptime -s)" \


### PR DESCRIPTION
This bug was introduced when we switched CKE installation
from container to the debian package.

`setup-serf-tags` is also fixed not to ignore the unit failure
so that we can notice the failure.