### PR TITLE
placemat-menu: update dnsmasq and chrony images

### DIFF
--- a/menu/cluster.go
+++ b/menu/cluster.go
@@ -11,9 +11,9 @@ import (
 const (
 	dockerImageBird    = "docker://quay.io/cybozu/bird:2.0"
 	dockerImageDebug   = "docker://quay.io/cybozu/ubuntu-debug:20.04"
-	dockerImageDnsmasq = "docker://quay.io/cybozu/dnsmasq:2.79"
+	dockerImageDnsmasq = "docker://quay.io/cybozu/dnsmasq:2.84"
 	dockerImageSquid   = "docker://quay.io/cybozu/squid:3.5"
-	dockerImageChrony  = "docker://quay.io/cybozu/chrony:3.5"
+	dockerImageChrony  = "docker://quay.io/cybozu/chrony:4.0"
 )
 
 var birdContainer = placemat.PodAppSpec{

--- a/menu/testdata/cluster.yml
+++ b/menu/testdata/cluster.yml
@@ -396,7 +396,7 @@ apps:
 - args:
   - -f
   - /etc/chrony/chrony.conf
-  image: docker://quay.io/cybozu/chrony:3.5
+  image: docker://quay.io/cybozu/chrony:4.0
   mount:
   - target: /etc/chrony
     volume: config
@@ -575,7 +575,7 @@ apps:
   - CAP_NET_BIND_SERVICE
   - CAP_NET_RAW
   - CAP_NET_BROADCAST
-  image: docker://quay.io/cybozu/dnsmasq:2.79
+  image: docker://quay.io/cybozu/dnsmasq:2.84
   name: dhcp-relay
   readonly-rootfs: true
 interfaces:
@@ -625,7 +625,7 @@ apps:
   - CAP_NET_BIND_SERVICE
   - CAP_NET_RAW
   - CAP_NET_BROADCAST
-  image: docker://quay.io/cybozu/dnsmasq:2.79
+  image: docker://quay.io/cybozu/dnsmasq:2.84
   name: dhcp-relay
   readonly-rootfs: true
 interfaces:
@@ -675,7 +675,7 @@ apps:
   - CAP_NET_BIND_SERVICE
   - CAP_NET_RAW
   - CAP_NET_BROADCAST
-  image: docker://quay.io/cybozu/dnsmasq:2.79
+  image: docker://quay.io/cybozu/dnsmasq:2.84
   name: dhcp-relay
   readonly-rootfs: true
 interfaces:
@@ -725,7 +725,7 @@ apps:
   - CAP_NET_BIND_SERVICE
   - CAP_NET_RAW
   - CAP_NET_BROADCAST
-  image: docker://quay.io/cybozu/dnsmasq:2.79
+  image: docker://quay.io/cybozu/dnsmasq:2.84
   name: dhcp-relay
   readonly-rootfs: true
 interfaces:


### PR DESCRIPTION
placemat-menu references images with branch tags, so
they are updated as follows:

- chrony 4.0
- dnsmasq 2.84

Since `rkt` cannot run the new squid image (`quay.io/cybozu/squid:4`),
it remains 3.5.