### PR TITLE
Revert kustomize to 3.7.0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -13,7 +13,7 @@ STERN_VERSION = 1.13.1
 ARGOCD_VERSION = 1.8.3
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L22
-KUSTOMIZE_VERSION = 3.9.2
+KUSTOMIZE_VERSION = 3.7.0
 NODE_EXPORTER_VERSION = 1.0.1
 TELEPORT_VERSION = 5.1.2
 


### PR DESCRIPTION
kustomize 3.9.2 has a critical bug to us.
https://github.com/kubernetes-sigs/kustomize/issues/3489