### PR TITLE
Add kubectl-moco

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ OP_ZIP = neco-operation-cli-windows_$(VERSION)_amd64.zip
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker ./pkg/ingress-watcher
-OPDEB_BINNAMES = argocd kubectl kustomize stern tsh
-OPDEB_DOCNAMES = argocd kubectl kustomize stern teleport
+OPDEB_BINNAMES = argocd kubectl kustomize stern tsh kubectl-moco
+OPDEB_DOCNAMES = argocd kubectl kustomize stern teleport moco
 
 .PHONY: all
 all:

--- a/Makefile.common
+++ b/Makefile.common
@@ -14,7 +14,7 @@ ARGOCD_VERSION = 1.8.3
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L22
 KUSTOMIZE_VERSION = 3.7.0
-MOCO_VERSION = 0.4.0
+MOCO_VERSION = 0.5.1
 NODE_EXPORTER_VERSION = 1.0.1
 TELEPORT_VERSION = 5.1.2
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -14,6 +14,7 @@ ARGOCD_VERSION = 1.8.3
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L22
 KUSTOMIZE_VERSION = 3.7.0
+MOCO_VERSION = 0.4.0
 NODE_EXPORTER_VERSION = 1.0.1
 TELEPORT_VERSION = 5.1.2
 

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -89,12 +89,12 @@ $(ARGOCD_DOWNLOAD):
 
 .PHONY: argocd
 argocd: $(ARGOCD_DOWNLOAD)
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR)/$@/ $(WINDOWS_DOCDIR)/$@/
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/
 	cp $(ARGOCD_DLDIR)/argocd $(BINDIR)/argocd
 	chmod +x $(BINDIR)/argocd
 	cp $(ARGOCD_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(ARGOCD_DLDIR)/README.md $(DOCDIR)/$@/README.md
-	cp $(ARGOCD_DLDIR)/argocd.exe $(WINDOWS_BINDIR)/$@/argocd.exe
+	cp $(ARGOCD_DLDIR)/argocd.exe $(WINDOWS_BINDIR)/argocd.exe
 	cp $(ARGOCD_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 	cp $(ARGOCD_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
 
@@ -108,12 +108,12 @@ $(KUBECTL_DOWNLOAD):
 
 .PHONY: kubectl
 kubectl: $(KUBECTL_DOWNLOAD)
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR)/$@/ $(WINDOWS_DOCDIR)/$@/
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/
 	cp $(KUBECTL_DLDIR)/kubectl $(BINDIR)/kubectl
 	chmod +x $(BINDIR)/kubectl
 	cp $(KUBECTL_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(KUBECTL_DLDIR)/README.md $(DOCDIR)/$@/README.md
-	cp $(KUBECTL_DLDIR)/kubectl.exe $(WINDOWS_BINDIR)/$@/kubectl.exe
+	cp $(KUBECTL_DLDIR)/kubectl.exe $(WINDOWS_BINDIR)/kubectl.exe
 	cp $(KUBECTL_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 	cp $(KUBECTL_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
 
@@ -140,12 +140,12 @@ $(STERN_DOWNLOAD):
 
 .PHONY: stern
 stern: $(STERN_DOWNLOAD)
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR)/$@/ $(WINDOWS_DOCDIR)/$@/
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/
 	cp $(STERN_DLDIR)/stern_$(STERN_VERSION)_linux_amd64/stern $(BINDIR)/stern
 	chmod +x $(BINDIR)/stern
 	cp $(STERN_DLDIR)/stern_$(STERN_VERSION)_linux_amd64/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(STERN_DLDIR)/README.md $(DOCDIR)/$@/README.md
-	cp $(STERN_DLDIR)/stern_$(STERN_VERSION)_windows_amd64/stern.exe $(WINDOWS_BINDIR)/$@/stern.exe
+	cp $(STERN_DLDIR)/stern_$(STERN_VERSION)_windows_amd64/stern.exe $(WINDOWS_BINDIR)/stern.exe
 	cp $(STERN_DLDIR)/stern_$(STERN_VERSION)_windows_amd64/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 	cp $(STERN_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
 
@@ -176,13 +176,13 @@ $(TELEPORT_DOWNLOAD):
 
 .PHONY: teleport
 teleport: $(TELEPORT_DOWNLOAD)
-	mkdir -p $(BINDIR) $(SBINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR)/$@/ $(WINDOWS_DOCDIR)/$@/
+	mkdir -p $(BINDIR) $(SBINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/
 	cp $(TELEPORT_DLDIR)/out/tctl $(BINDIR)
 	cp $(TELEPORT_DLDIR)/out/teleport $(SBINDIR)
 	cp $(TELEPORT_DLDIR)/out/tsh $(BINDIR)
 	cp $(TELEPORT_DLDIR)/teleport/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(TELEPORT_DLDIR)/teleport/README.md $(DOCDIR)/$@/README.md
-	cp $(TELEPORT_DLDIR)/out/tsh.exe $(WINDOWS_BINDIR)/$@
+	cp $(TELEPORT_DLDIR)/out/tsh.exe $(WINDOWS_BINDIR)
 	cp $(TELEPORT_DLDIR)/teleport/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 	cp $(TELEPORT_DLDIR)/teleport/README.md $(WINDOWS_DOCDIR)/$@/README.md
 

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -25,9 +25,11 @@ TELEPORT_DLDIR := $(DOWNLOADDIR)/teleport-v$(TELEPORT_VERSION)
 TELEPORT_DOWNLOAD := $(TELEPORT_DLDIR)/downloaded
 CKE_DLDIR := $(DOWNLOADDIR)/cke-v$(CKE_VERSION)
 CKE_DOWNLOAD := $(CKE_DLDIR)/downloaded
+MOCO_DLDIR := $(DOWNLOADDIR)/moco-v$(MOCO_VERSION)
+MOCO_DOWNLOAD := $(MOCO_DLDIR)/downloaded
 
 .PHONY: all
-all: node_exporter containerd crictl argocd kubectl lvmd stern kustomize teleport cke
+all: node_exporter containerd crictl argocd kubectl lvmd stern kustomize teleport cke moco
 	mkdir -p $(DOWNLOADDIR)
 	touch $(DOWNLOADDIR)/.downloaded
 
@@ -196,6 +198,22 @@ cke: $(CKE_DOWNLOAD)
 	mkdir -p $(BINDIR) $(SBINDIR)
 	cp $(CKE_DLDIR)/source/cke $(SBINDIR)/cke
 	cp $(CKE_DLDIR)/source/ckecli $(BINDIR)/ckecli
+
+# TODO: download the kubectl-moco windows binary after MOCO v0.5.0 is released.
+$(MOCO_DOWNLOAD):
+	mkdir -p $(MOCO_DLDIR)
+	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco
+	$(WGET) -O $(MOCO_DLDIR)/LICENSE      https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/LICENSE
+	$(WGET) -O $(MOCO_DLDIR)/README.md    https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/README.md
+	touch $@
+
+.PHONY: moco
+moco: $(MOCO_DOWNLOAD)
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/
+	cp $(MOCO_DLDIR)/kubectl-moco $(BINDIR)/kubectl-moco
+	chmod +x $(BINDIR)/kubectl-moco
+	cp $(MOCO_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
+	cp $(MOCO_DLDIR)/README.md $(DOCDIR)/$@/README.md
 
 .PHONY: clean
 clean:

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -202,18 +202,22 @@ cke: $(CKE_DOWNLOAD)
 # TODO: download the kubectl-moco windows binary after MOCO v0.5.0 is released.
 $(MOCO_DOWNLOAD):
 	mkdir -p $(MOCO_DLDIR)
-	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco
-	$(WGET) -O $(MOCO_DLDIR)/LICENSE      https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/LICENSE
-	$(WGET) -O $(MOCO_DLDIR)/README.md    https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/README.md
+	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco     https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco-linux-amd64
+	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco.exe https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco-windows-amd64
+	$(WGET) -O $(MOCO_DLDIR)/LICENSE          https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/LICENSE
+	$(WGET) -O $(MOCO_DLDIR)/README.md        https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/README.md
 	touch $@
 
 .PHONY: moco
 moco: $(MOCO_DOWNLOAD)
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/
 	cp $(MOCO_DLDIR)/kubectl-moco $(BINDIR)/kubectl-moco
 	chmod +x $(BINDIR)/kubectl-moco
 	cp $(MOCO_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(MOCO_DLDIR)/README.md $(DOCDIR)/$@/README.md
+	cp $(MOCO_DLDIR)/kubectl-moco.exe $(WINDOWS_BINDIR)
+	cp $(MOCO_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
+	cp $(MOCO_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
 
 .PHONY: clean
 clean:

--- a/artifacts.go
+++ b/artifacts.go
@@ -9,7 +9,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "bird", Repository: "quay.io/cybozu/bird", Tag: "2.0.7.5", Private: false},
 		{Name: "chrony", Repository: "quay.io/cybozu/chrony", Tag: "4.0.0.1", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.25.3", Private: false},
-		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.5", Private: false},
+		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.6", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.9.5.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.7.1", Private: true},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "4.13.1", Private: false},


### PR DESCRIPTION
- Add the `kubectl-moco` binary to `neco` and `neco-operation-cli-{linux, windows}` packages.
By this PR, the following files are added to the packages.
```
# neco and neco-operation-cli-linux deb packages
./usr/bin/kubectl-moco
./usr/share/doc/moco/{LICENSE, README.md}
```
```
# neco-operation-cli-windows zip packages
./bin/kubectl-moco.exe
./doc/moco/{LICENSE, README.md}
```

- Change the directory structure of the `neco-operation-cli-windows` zip file as follows.

```
./bin/{argocd.exe, kubectl.exe, kubectl-moco.exe, stern.exe, tsh.exe}
./doc/argocd/{LICENSE, README.md}
./doc/kubectl/{LICENSE, README.md}
./doc/moco/{LICENSE, README.md}
./doc/stern/{LICENSE, README.md}
./doc/teleport/{LICENSE, README.md}
```