### PR TITLE
Update kubectl-moco v0.6.0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -14,7 +14,7 @@ ARGOCD_VERSION = 1.8.3
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L22
 KUSTOMIZE_VERSION = 3.7.0
-MOCO_VERSION = 0.5.1
+MOCO_VERSION = 0.6.0
 NODE_EXPORTER_VERSION = 1.0.1
 TELEPORT_VERSION = 5.1.2
 # kubeseal is a CLI tool for Sealed Secrets

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -224,7 +224,7 @@ cke: $(CKE_DOWNLOAD)
 $(MOCO_DOWNLOAD):
 	mkdir -p $(MOCO_DLDIR)
 	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco     https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco-linux-amd64
-	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco.exe https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco-windows-amd64
+	$(WGET) -O $(MOCO_DLDIR)/kubectl-moco.exe https://github.com/cybozu-go/moco/releases/download/v$(MOCO_VERSION)/kubectl-moco-windows-amd64.exe
 	$(WGET) -O $(MOCO_DLDIR)/LICENSE          https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/LICENSE
 	$(WGET) -O $(MOCO_DLDIR)/README.md        https://raw.githubusercontent.com/cybozu-go/moco/v$(MOCO_VERSION)/README.md
 	touch $@


### PR DESCRIPTION
Update `kubectl-moco` to v0.6.0 in neco tools packages.
I build locally and verified that the `kubectl-moco` is updated.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>