### PR TITLE
Enable audit log settings

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 # tool versions used for both local bin and deb/zip packages
 
 ## These should be updated when Kubernetes is updated
-CKE_VERSION = 1.19.4
+CKE_VERSION = 1.19.5
 CONTAINERD_VERSION = 1.4.4
 CRITOOLS_VERSION = 1.19.0
 K8S_VERSION = 1.19.7

--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -26,9 +26,46 @@ reboot:
   command_timeout_seconds: 1800
 options:
   kube-api:
+    audit_log_enabled: true
+    audit_log_path: /var/log/audit/audit.log
+    audit_log_policy: |
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      omitStages:
+        - RequestReceived
+      rules:
+        # Avoid logging secret values
+        - level: Metadata
+          resources:
+            - group: ""
+              resources: ["secrets"]
+            - group: "bitnami.com"
+              resources: ["sealedsecrets"]
+        - level: None
+          verbs: ["get", "watch", "list"]
+        - level: Metadata
+          verbs: ["delete", "deletecollection"]
+        - level: None
+          userGroups:
+            - system:nodes
+            - system:serviceaccounts
+        - level: None
+          users:
+            - system:apiserver
+            - system:kube-controller-manager
+            - system:kube-proxy
+            - system:kube-scheduler
+        - level: RequestResponse
     extra_args:
       - "--enable-admission-plugins=PodSecurityPolicy"
       - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"
+      - "--audit-log-maxage=1"
+      - "--audit-log-maxsize=10"
+      - "--audit-log-maxbackup=10"
+    extra_binds:
+      - source: /var/log/audit
+        destination: /var/log/audit
+        read_only: false
   kube-controller-manager:
     extra_args:
       - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"


### PR DESCRIPTION
This PR deploys CKE 1.19.5 and adds audit log settings.
It should be merged after the `manual-dctest-with-neco-feature-branch` test succeeds on neco-apps.
-> The test on the feature branch succeeded. Now this PR is ready.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>