### PR TITLE
when dctest cleans, it also deletes the root file

### DIFF
--- a/dctest/Makefile
+++ b/dctest/Makefile
@@ -105,6 +105,7 @@ stop:
 .PHONY: clean
 clean:
 	rm -rf $(OUTPUT)
+	cd ../ && $(MAKE) clean
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>