### PR TITLE
Fix clients for sabakan-state-setter

### DIFF
--- a/pkg/sabakan-state-setter/config_test.go
+++ b/pkg/sabakan-state-setter/config_test.go
@@ -18,17 +18,17 @@ func TestParseConfigFile(t *testing.T) {
         labels:
           aaa: bbb
 `
-	cfg, err := parseConfig(strings.NewReader(fileContent))
+	machineTypes, err := parseConfig(strings.NewReader(fileContent))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cfg.MachineTypes) != 2 {
-		t.Error("len(cfg.MachineTypes) != 2, actual ", len(cfg.MachineTypes))
+	if len(machineTypes) != 2 {
+		t.Error("len(machineTypesMap) != 2, actual ", len(machineTypes))
 	}
-	if cfg.MachineTypes[0].GracePeriod.Duration != 10*time.Second {
+	if machineTypes["qemu"].GracePeriod.Duration != 10*time.Second {
 		t.Error("GracePeriod is not set")
 	}
-	if cfg.MachineTypes[1].GracePeriod.Duration != time.Hour {
+	if machineTypes["boot"].GracePeriod.Duration != time.Hour {
 		t.Error("default value of GracePeriod is not set")
 	}
 

--- a/pkg/sabakan-state-setter/controller.go
+++ b/pkg/sabakan-state-setter/controller.go
@@ -207,7 +207,7 @@ func (c *Controller) runOnce(ctx context.Context) error {
 		return nil
 	}
 
-	members, err := c.serfClient.GetSerfMembers()
+	serfStatus, err := c.serfClient.GetSerfStatus()
 	if err != nil {
 		log.Warn("failed to get serf members", map[string]interface{}{
 			log.FnError: err.Error(),
@@ -219,7 +219,7 @@ func (c *Controller) runOnce(ctx context.Context) error {
 	// Construct a slice of machineStateSource
 	machineStateSources := make([]*machineStateSource, len(machines))
 	for i, m := range machines {
-		machineStateSources[i] = newMachineStateSource(m, members, c.machineTypes)
+		machineStateSources[i] = newMachineStateSource(m, serfStatus, c.machineTypes)
 	}
 
 	// Get machine metrics

--- a/pkg/sabakan-state-setter/controller_test.go
+++ b/pkg/sabakan-state-setter/controller_test.go
@@ -15,7 +15,7 @@ func newMockController(gql *gqlMockClient, metricsInput string, serf *serfMockCl
 		sabakanClient:     gql,
 		promClient:        newMockPromClient(metricsInput),
 		serfClient:        serf,
-		machineTypes:      []*machineType{mt},
+		machineTypes:      map[string]*machineType{mt.Name: mt},
 		unhealthyMachines: make(map[string]time.Time),
 	}
 }

--- a/pkg/sabakan-state-setter/controller_test.go
+++ b/pkg/sabakan-state-setter/controller_test.go
@@ -61,12 +61,12 @@ func testControllerRun(t *testing.T) {
 	}
 
 	// transition machine state to unhealthy due to cpu warning
-	gql := newMockGQLClient("qemu")
+	gql := newMockGQLClient()
 	serf, _ := newMockSerfClient()
 	metricsInput := `
-	hw_processor_status_health{processor="CPU.Socket.1"} 0
-	hw_processor_status_health{processor="CPU.Socket.2"} 1
-	`
+hw_processor_status_health{processor="CPU.Socket.1"} 0
+hw_processor_status_health{processor="CPU.Socket.2"} 1
+`
 	ctr := newMockController(gql, metricsInput, serf, machineTypeQEMU)
 	for i := 0; i < 2; i++ {
 		err := ctr.runOnce(context.Background())
@@ -75,19 +75,19 @@ func testControllerRun(t *testing.T) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if gql.machine.Status.State != sabakan.StateUnhealthy {
-		t.Errorf("machine is not unhealthy: %s", gql.machine.Status.State)
+	if gql.getState("00000001") != sabakan.StateUnhealthy {
+		t.Errorf("machine is not unhealthy: %s", gql.getState("00000001"))
 	}
 
 	// transition machine state to unhealthy due to warning disks become larger than one
-	gql = newMockGQLClient("qemu")
+	gql = newMockGQLClient()
 	serf, _ = newMockSerfClient()
 	metricsInput = `
-	hw_processor_status_health{processor="CPU.Socket.1"} 0
-	hw_processor_status_health{processor="CPU.Socket.2"} 0
-	hw_storage_controller_status_health{controller="SATAHDD.Slot.1"} 1
-	hw_storage_controller_status_health{controller="SATAHDD.Slot.2"} 1
-	`
+hw_processor_status_health{processor="CPU.Socket.1"} 0
+hw_processor_status_health{processor="CPU.Socket.2"} 0
+hw_storage_controller_status_health{controller="SATAHDD.Slot.1"} 1
+hw_storage_controller_status_health{controller="SATAHDD.Slot.2"} 1
+`
 	ctr = newMockController(gql, metricsInput, serf, machineTypeQEMU)
 	for i := 0; i < 2; i++ {
 		err := ctr.runOnce(context.Background())
@@ -96,12 +96,12 @@ func testControllerRun(t *testing.T) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if gql.machine.Status.State != sabakan.StateUnhealthy {
-		t.Errorf("machine is not unhealthy: %s", gql.machine.Status.State)
+	if gql.getState("00000001") != sabakan.StateUnhealthy {
+		t.Errorf("machine is not unhealthy: %s", gql.getState("00000001"))
 	}
 
 	// transition machine state to healthy even one disk warning occurred
-	gql = newMockGQLClient("qemu")
+	gql = newMockGQLClient()
 	serf, _ = newMockSerfClient()
 	metricsInput = `
 # TYPE hw_processor_status_health gauge
@@ -121,8 +121,8 @@ hw_storage_controller_status_health{controller="SATAHDD.Slot.2", system="System.
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if gql.machine.Status.State != sabakan.StateHealthy {
-		t.Errorf("machine is not healthy: %s", gql.machine.Status.State)
+	if gql.getState("00000001") != sabakan.StateHealthy {
+		t.Errorf("machine is not healthy: %s", gql.getState("00000001"))
 	}
 }
 

--- a/pkg/sabakan-state-setter/machine_state_source.go
+++ b/pkg/sabakan-state-setter/machine_state_source.go
@@ -1,10 +1,7 @@
 package sss
 
 import (
-	"net"
-
 	"github.com/cybozu-go/log"
-	serf "github.com/hashicorp/serf/client"
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -13,12 +10,12 @@ type machineStateSource struct {
 	serial string
 	ipv4   string
 
-	serfStatus  *serf.Member
-	metrics     map[string]*dto.MetricFamily
+	serfStatus  *serfStatus
 	machineType *machineType
+	metrics     map[string]*dto.MetricFamily
 }
 
-func newMachineStateSource(m *machine, members []serf.Member, machineTypes map[string]*machineType) *machineStateSource {
+func newMachineStateSource(m *machine, serfStatuses map[string]*serfStatus, machineTypes map[string]*machineType) *machineStateSource {
 	machineType, ok := machineTypes[m.Type]
 	if !ok {
 		log.Warn(machineTypeLabelName+" is not defined", map[string]interface{}{
@@ -27,19 +24,11 @@ func newMachineStateSource(m *machine, members []serf.Member, machineTypes map[s
 			"name":   m.Type,
 		})
 	}
+
 	return &machineStateSource{
 		serial:      m.Serial,
 		ipv4:        m.IPv4Addr,
-		serfStatus:  findMember(members, m.IPv4Addr),
+		serfStatus:  serfStatuses[m.IPv4Addr],
 		machineType: machineType,
 	}
-}
-
-func findMember(members []serf.Member, addr string) *serf.Member {
-	for _, member := range members {
-		if member.Addr.Equal(net.ParseIP(addr)) {
-			return &member
-		}
-	}
-	return nil
 }

--- a/pkg/sabakan-state-setter/machine_state_source.go
+++ b/pkg/sabakan-state-setter/machine_state_source.go
@@ -18,9 +18,9 @@ type machineStateSource struct {
 	machineType *machineType
 }
 
-func newMachineStateSource(m *machine, members []serf.Member, machineTypes []*machineType) *machineStateSource {
-	machineType := findMachineType(m.Type, machineTypes)
-	if machineType == nil {
+func newMachineStateSource(m *machine, members []serf.Member, machineTypes map[string]*machineType) *machineStateSource {
+	machineType, ok := machineTypes[m.Type]
+	if !ok {
 		log.Warn(machineTypeLabelName+" is not defined", map[string]interface{}{
 			"serial": m.Serial,
 			"ipv4":   m.IPv4Addr,
@@ -39,15 +39,6 @@ func findMember(members []serf.Member, addr string) *serf.Member {
 	for _, member := range members {
 		if member.Addr.Equal(net.ParseIP(addr)) {
 			return &member
-		}
-	}
-	return nil
-}
-
-func findMachineType(name string, machineTypes []*machineType) *machineType {
-	for _, mt := range machineTypes {
-		if mt.Name == name {
-			return mt
 		}
 	}
 	return nil

--- a/pkg/sabakan-state-setter/serf.go
+++ b/pkg/sabakan-state-setter/serf.go
@@ -2,13 +2,22 @@ package sss
 
 import serf "github.com/hashicorp/serf/client"
 
+const (
+	systemdUnitsFailedTag = "systemd-units-failed"
+)
+
 type serfClient struct {
 	*serf.RPCClient
 }
 
 // SerfClient is interface for serf client
 type SerfClient interface {
-	GetSerfMembers() ([]serf.Member, error)
+	GetSerfStatus() (map[string]*serfStatus, error)
+}
+
+type serfStatus struct {
+	Status             string
+	SystemdUnitsFailed *string
 }
 
 func newSerfClient(address string) (SerfClient, error) {
@@ -19,7 +28,30 @@ func newSerfClient(address string) (SerfClient, error) {
 	return &serfClient{c}, nil
 }
 
+func strPtr(str string) *string {
+	return &str
+}
+
 // GetSerfMembers returns serf members
-func (s *serfClient) GetSerfMembers() ([]serf.Member, error) {
-	return s.Members()
+func (s *serfClient) GetSerfStatus() (map[string]*serfStatus, error) {
+	members, err := s.Members()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[string]*serfStatus)
+	for _, m := range members {
+		ipv4 := m.Addr.String()
+
+		var systemdStatus *string
+		if tagValue, ok := m.Tags[systemdUnitsFailedTag]; ok {
+			systemdStatus = strPtr(tagValue)
+		}
+
+		ret[ipv4] = &serfStatus{
+			Status:             m.Status,
+			SystemdUnitsFailed: systemdStatus,
+		}
+	}
+	return ret, nil
 }

--- a/pkg/sabakan-state-setter/serf_mock.go
+++ b/pkg/sabakan-state-setter/serf_mock.go
@@ -1,11 +1,5 @@
 package sss
 
-import (
-	"net"
-
-	serf "github.com/hashicorp/serf/client"
-)
-
 type serfMockClient struct {
 }
 
@@ -14,14 +8,11 @@ func newMockSerfClient() (*serfMockClient, error) {
 }
 
 // GetSerfMembers returns serf members
-func (s *serfMockClient) GetSerfMembers() ([]serf.Member, error) {
-	return []serf.Member{
-		{
-			Status: "alive",
-			Tags: map[string]string{
-				systemdUnitsFailedTag: "",
-			},
-			Addr: net.ParseIP("10.0.0.100"),
+func (s *serfMockClient) GetSerfStatus() (map[string]*serfStatus, error) {
+	return map[string]*serfStatus{
+		"10.0.0.100": {
+			Status:             "alive",
+			SystemdUnitsFailed: strPtr(""),
 		},
 	}, nil
 }

--- a/pkg/sabakan-state-setter/strategy_test.go
+++ b/pkg/sabakan-state-setter/strategy_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/cybozu-go/sabakan/v2"
-	serf "github.com/hashicorp/serf/client"
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -82,11 +81,9 @@ func TestDecideSabakanState(t *testing.T) {
 			expected:      sabakan.StateUnreachable,
 			hasTransition: true,
 			mss: machineStateSource{
-				serfStatus: &serf.Member{
-					Status: "failed",
-					Tags: map[string]string{
-						"systemd-units-failed": "",
-					},
+				serfStatus: &serfStatus{
+					Status:             "failed",
+					SystemdUnitsFailed: strPtr(""),
 				},
 			},
 		},
@@ -95,11 +92,9 @@ func TestDecideSabakanState(t *testing.T) {
 			expected:      sabakan.StateUnhealthy,
 			hasTransition: true,
 			mss: machineStateSource{
-				serfStatus: &serf.Member{
-					Status: "alive",
-					Tags: map[string]string{
-						"systemd-units-failed": "aaa",
-					},
+				serfStatus: &serfStatus{
+					Status:             "alive",
+					SystemdUnitsFailed: strPtr("aaa"),
 				},
 			},
 		},
@@ -108,7 +103,7 @@ func TestDecideSabakanState(t *testing.T) {
 			expected:      sabakan.MachineState(""),
 			hasTransition: false,
 			mss: machineStateSource{
-				serfStatus: &serf.Member{
+				serfStatus: &serfStatus{
 					Status: "alive",
 				},
 				metrics: machineMetrics{
@@ -131,7 +126,7 @@ func TestDecideSabakanState(t *testing.T) {
 			expected:      sabakan.StateUnhealthy,
 			hasTransition: true,
 			mss: machineStateSource{
-				serfStatus: &serf.Member{
+				serfStatus: &serfStatus{
 					Status: "alive",
 				},
 				metrics: machineMetrics{
@@ -154,11 +149,9 @@ func TestDecideSabakanState(t *testing.T) {
 			expected:      sabakan.StateUnreachable,
 			hasTransition: true,
 			mss: machineStateSource{
-				serfStatus: &serf.Member{
-					Status: "failed",
-					Tags: map[string]string{
-						"systemd-units-failed": "",
-					},
+				serfStatus: &serfStatus{
+					Status:             "failed",
+					SystemdUnitsFailed: strPtr(""),
 				},
 				metrics: machineMetrics{
 					Labels: map[string]string{"aaa": "bbb"},
@@ -190,9 +183,9 @@ func TestDecideByMonitorHW(t *testing.T) {
 	parts2 := "parts2_status_health"
 	parts3 := "parts3_status_health"
 
-	base := &serf.Member{
-		Status: "alive",
-		Tags:   map[string]string{"systemd-units-failed": ""},
+	base := &serfStatus{
+		Status:             "alive",
+		SystemdUnitsFailed: strPtr(""),
 	}
 	testCases := []struct {
 		message  string


### PR DESCRIPTION
sabakan-state-setter uses `serf.Member` and the result value of Sabakan GraphQL directly.
For that reason, the implementation is becoming more complicated in some places.

This PR changes the clients (`SabakanGQLClient` and `SerfClient`) to return only the values sabakan-state-setter needs.

And for https://github.com/cybozu-go/neco/issues/675, I change the GraphQL request to get the status and the BMC address of a machine.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>