### PR TITLE
eventually ckecli kubenetes issue

### DIFF
--- a/dctest/cke_test.go
+++ b/dctest/cke_test.go
@@ -106,7 +106,13 @@ func testCKE() {
 	It("wait for Kubernetes cluster to become ready", func() {
 		By("generating kubeconfig for cluster admin")
 		execSafeAt(bootServers[0], "mkdir", "-p", ".kube")
-		execSafeAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
+		Eventually(func() error {
+			_, stderr, err := execAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
+			if err != nil {
+				return fmt.Errorf("err: %v, stderr: %s", err, stderr)
+			}
+			return nil
+		}).Should(Succeed())
 
 		By("waiting nodes")
 		Eventually(func() error {

--- a/dctest/upgrade_test.go
+++ b/dctest/upgrade_test.go
@@ -163,7 +163,13 @@ func testUpgrade() {
 
 		By("generating kubeconfig for cluster admin")
 		execSafeAt(bootServers[0], "mkdir", "-p", ".kube")
-		execSafeAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
+		Eventually(func() error {
+			_, stderr, err := execAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
+			if err != nil {
+				return fmt.Errorf("err: %v, stderr: %s", err, stderr)
+			}
+			return nil
+		}).Should(Succeed())
 
 		stdout, stderr, err = execAt(bootServers[0], "ckecli", "images")
 		Expect(err).ShouldNot(HaveOccurred(), "stderr=%s", stderr)


### PR DESCRIPTION
Fix the following flaky test.

https://app.circleci.com/pipelines/github/cybozu-go/neco/4426/workflows/40521746-f25f-41b8-96ca-fbb088204d13/jobs/13514
```
------------------------------
Neco upgrade 
  should running newer cke desired image version
  /root/go/src/github.com/cybozu-go/neco/dctest/upgrade_test.go:156
START: 2021-04-05T05:19:42Z
STEP: generating kubeconfig for cluster admin
END: 2021-04-05T05:19:47Z

• Failure [5.205 seconds]
Neco
/root/go/src/github.com/cybozu-go/neco/dctest/suites_test.go:35
  upgrade
  /root/go/src/github.com/cybozu-go/neco/dctest/suites_test.go:91
    should running newer cke desired image version [It]
    /root/go/src/github.com/cybozu-go/neco/dctest/upgrade_test.go:156

    [10.72.48.0] [ckecli kubernetes issue > .kube/config]: 2021-04-05T05:19:47.506232Z gcp0-boot-0 ckecli error: "failed to login to vault" endpoint="https://127.0.0.1:8200" error="Error making API request.\n\nURL: PUT https://127.0.0.1:8200/v1/auth/approle/login\nCode: 500. Errors:\n\n* internal error"
    Error: Error making API request.
    
    URL: PUT https://127.0.0.1:8200/v1/auth/approle/login
    Code: 500. Errors:
    
    * internal error
    2021-04-05T05:19:47.508310Z gcp0-boot-0 ckecli error: "Error making API request.\n\nURL: PUT https://127.0.0.1:8200/v1/auth/approle/login\nCode: 500. Errors:\n\n* internal error"
    
    Expected success, but got an error:
        <*ssh.ExitError | 0xc000847c00>: {
            Waitmsg: {status: 1, signal: "", msg: "", lang: ""},
        }
        Process exited with status 1

    /root/go/src/github.com/cybozu-go/neco/dctest/upgrade_test.go:166
------------------------------
```



Signed-off-by: Masayuki Ishii <masa213f@gmail.com>