### PR TITLE
Refine 'neco power' command using Redfish API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
+	github.com/stmcginnis/gofish v0.7.0
 	github.com/tcnksm/go-input v0.0.0-20180404061846-548a7d7a8ee8
 	github.com/vektah/gqlparser v1.3.1
 	github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -671,6 +671,7 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/stmcginnis/gofish v0.7.0 h1:qlFXZbs3lJlBKasi6rNilijk0GN6OgNBnyg835WfrmI=
 github.com/stmcginnis/gofish v0.7.0/go.mod h1:t0RUeoOLznx9vExQOeLZUrjU0u3yy0wL4iVMQviUl+k=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/pkg/neco/cmd/reboot_and_wait.go
+++ b/pkg/neco/cmd/reboot_and_wait.go
@@ -92,7 +92,7 @@ func rebootAndWaitMain(target string) error {
 	log.Info("rebooting a machine", map[string]interface{}{
 		"serial_or_ip": target,
 	})
-	err = ipmiPower(context.Background(), "restart", machine.Spec.BMC.IPv4)
+	err = power(context.Background(), "restart", machine.Spec.BMC.IPv4)
 	if err != nil {
 		log.Error("failed to reboot via IPMI", map[string]interface{}{
 			"serial_or_ip": target,

--- a/pkg/neco/cmd/reboot_worker.go
+++ b/pkg/neco/cmd/reboot_worker.go
@@ -190,7 +190,7 @@ func rebootMain() error {
 			"node":   m.Spec.IPv4[0],
 			"bmc":    m.Spec.BMC.IPv4,
 		})
-		err := ipmiPower(context.Background(), "restart", addr)
+		err := power(context.Background(), "restart", addr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Refine `neco power` command using Redfish API.

`start`, `stop` or `restart` action.
```
# When the action is successful, 
$ neco power stop <addr>
ok

# failed
$ neco power start <addr>
2021-04-08T08:41:00.859206Z ubuntu-bionic neco error: "409: {\"error\":{\"@Message.ExtendedInfo\":[{\"Message\":\"Server is already powered ON.\",\"MessageArgs\":[],\"MessageArgs@odata.count\":0,\"MessageId\":\"IDRAC.2.1.PSU501\",\"RelatedProperties\":[],\"RelatedProperties@odata.count\":0,\"Resolution\":\"No response action is required.\",\"Severity\":\"Informational\"}],\"code\":\"Base.1.5.GeneralError\",\"message\":\"A general error has occurred. See ExtendedInfo for more information\"}}\n"
```

`status` action
```
# When machine power is on.
$ neco power status <addr>
On

# When machine power is off.
$ neco power status <addr>
Off
```


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>