### PR TITLE
installer: do not install freeipmi-tools

### DIFF
--- a/installer/setup/packages.go
+++ b/installer/setup/packages.go
@@ -19,7 +19,6 @@ var (
 	}
 
 	installList = []string{
-		"freeipmi-tools",
 		"jq",
 	}
 )


### PR DESCRIPTION
Now that "neco power" does not depend on IPMI.