### PR TITLE
neco reboot-worker: skip reboot if machine power is already off

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -16,7 +16,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.6.3.1", Private: false},
 	},
 	Debs: []DebianPackage{
-		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.1.0"},
+		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.1.1"},
 	},
 	CoreOS: CoreOSImage{Channel: "stable", Version: "2765.2.0"},
 }

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -188,6 +188,7 @@ Synopsis
 
     This uses CKE's function of [graceful reboot](https://github.com/cybozu-go/cke/blob/main/docs/reboot.md) for the nodes used by CKE.
     As for the other nodes, this reboots them immediately.
+    If some nodes are already powered off, this command does not do anything to those nodes.
 
 ### CKE related functions
 


### PR DESCRIPTION
`neco reboot-worker` will fail if there are machines powered off.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>