### PR TITLE
sabakan-state-setter: shutdown retired machines

### DIFF
--- a/dctest/sabakan_state_setter_test.go
+++ b/dctest/sabakan_state_setter_test.go
@@ -98,6 +98,25 @@ func testSabakanStateSetter() {
 			return nil
 		}).Should(Succeed())
 	})
+
+	It("should change shutdown job schedule", func() {
+		// Run the shutdown job every minute in dctest.
+		for _, boot := range bootServers {
+			execSafeAt(boot, "sudo", "sed", "-i", "'s/shutdown-schedule:.*/shutdown-schedule: \"@every 1m\"/'", "/usr/share/neco/sabakan-state-setter.yml")
+			execSafeAt(boot, "sudo", "systemctl", "restart", "sabakan-state-setter.service")
+		}
+
+		By("checking status of sabakan-state-setter")
+		Eventually(func() error {
+			for _, boot := range bootServers {
+				stdout, _, err := execAt(boot, "systemctl", "is-active", "sabakan-state-setter.service")
+				if err != nil {
+					return fmt.Errorf("sabakan-state-setter on %s is not active: %s", boot, stdout)
+				}
+			}
+			return nil
+		}).Should(Succeed())
+	})
 }
 
 func getLeaderNode(leaderKeyPrefix string) (string, error) {

--- a/docs/sabakan-state-setter.md
+++ b/docs/sabakan-state-setter.md
@@ -1,7 +1,7 @@
 sabakan-state-setter
 ====================
 
-sabakan-state-setter changes the state of machines. It has the following two functions.
+sabakan-state-setter changes the state of machines. It has the following three functions.
 
 1. Health check
     Decide sabakan machine states according to [serf][] status and [monitor-hw][] metrics. And update the states.
@@ -14,6 +14,10 @@ sabakan-state-setter changes the state of machines. It has the following two fun
     And clear TPM devices on the machines by `neco tpm clear`.
     If the retirement is succeeded, change the machine's state to `Retired`.
     The power state of retired machines after this retirement are depends on the TPM clear logic in `neco tpm clear`.
+
+3. Shutdown
+    Shutdown the `Retired` machines periodically.
+    The execution cycle can be specified in a config file.
 
 See machine state types at [Sabakan lifecycle management](https://github.com/cybozu-go/sabakan/blob/master/docs/lifecycle.md).
 
@@ -49,14 +53,18 @@ if and only if it judges the machine's state as `unhealthy` for the time specifi
 
 ### Target machine peripherals
 
+You can define the metrics used for health checking in in the configuration file.
+
+The set of the metrics depends on its machine type. So you need configure a set of metrics for each machine type.
+
+Basically, check the following peripherals.
+
 - CPU
 - Memory
 - Storage controllers
 - NVMe SSD
 - [Dell BOSS][]
 - Hard drives on the storage servers
-
-Describe in the configuration file the metrics names with labels.
 
 Retirement
 ----------
@@ -66,6 +74,12 @@ Retirement
 1. Delete disk encryption keys on the sbakan.
 2. Clear TPM devices on the machine by `neco tpm clear`.
 3. Change the mahcine's state to `Retired`.
+
+Shutdown
+--------
+
+`sabakan-state-setter` shutdown retired machines periodically.
+The execution cycle can be specified in a config file.
 
 Usage
 -----
@@ -83,19 +97,16 @@ sabakan-state-setter [OPTIONS]
 | `-sabakan-url`      | `http://localhost:10080` | sabakan URL.                                                                      |
 | `-serf-address`     | `127.0.0.1:7373`         | serf address.                                                                     |
 
-Settings of target machine peripherals
---------------------------------------
+Config file
+-----------
 
-The set of metrics used for health checking depends on its machine type.
-You can configure a set of metrics to scrape for each machine type.
-
-| Field                                             | Default value | Description                                                                                           |
-| ------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------- |
-| `machine-types` [MachineType](#MachineType) array | `nil`         | Machine types is a list of `MachineType`. You should list all machine types used in your data center. |
-
-If all metrics defined in the config file are healthy, the machine is healthy. Otherwise, it's unhealthy.
+| Field                                             | Default value | Description                                                                                                      |
+| ------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `shutdown-schedule` string                        | `""`          | Schedule in Cron format for retired machines shutdown. If this field is omitted, shutdown will not be performed. |
+| `machine-types` [MachineType](#MachineType) array | `nil`         | Machine types is a list of `MachineType`. You should list all machine types used in your data center.            |
 
 ### `MachineType`
+
 | Field                             | Default value | Description                                                                                                 |
 | --------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------- |
 | `name` string                     |               | Name of this machine type. It is expected that this field is unique in setting file.                        |

--- a/etc/sabakan-state-setter.yml
+++ b/etc/sabakan-state-setter.yml
@@ -1,4 +1,4 @@
-shutdown-schedule: 00 16 * * *
+shutdown-schedule: 0 16 * * *
 machine-types:
   - name: qemu
     grace-period: 5s

--- a/etc/sabakan-state-setter.yml
+++ b/etc/sabakan-state-setter.yml
@@ -1,3 +1,4 @@
+shutdown-schedule: 00 16 * * *
 machine-types:
   - name: qemu
     grace-period: 5s

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0 // indirect
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0
+	github.com/robfig/cron/v3 v3.0.0
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -612,6 +612,8 @@ github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULU
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=

--- a/pkg/sabakan-state-setter/config_test.go
+++ b/pkg/sabakan-state-setter/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParseConfigFile(t *testing.T) {
 	fileContent := `
-shutdown-schedule: 00 16 * * *
+shutdown-schedule: 0 16 * * *
 machine-types:
   - name: qemu
     grace-period: 10s
@@ -24,8 +24,8 @@ machine-types:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if shutdownSchedule != "00 16 * * *" {
-		t.Errorf("shutdownSchedule != \"00 16 * * *\", actual \"%s\"", shutdownSchedule)
+	if shutdownSchedule != "0 16 * * *" {
+		t.Errorf("shutdownSchedule != \"0 16 * * *\", actual \"%s\"", shutdownSchedule)
 	}
 	if len(machineTypes) != 2 {
 		t.Error("len(machineTypesMap) != 2, actual ", len(machineTypes))

--- a/pkg/sabakan-state-setter/config_test.go
+++ b/pkg/sabakan-state-setter/config_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestParseConfigFile(t *testing.T) {
-	fileContent := `machine-types:
+	fileContent := `
+shutdown-schedule: 00 16 * * *
+machine-types:
   - name: qemu
     grace-period: 10s
   - name: boot
@@ -18,9 +20,12 @@ func TestParseConfigFile(t *testing.T) {
         labels:
           aaa: bbb
 `
-	machineTypes, err := parseConfig(strings.NewReader(fileContent))
+	shutdownSchedule, machineTypes, err := parseConfig(strings.NewReader(fileContent))
 	if err != nil {
 		t.Fatal(err)
+	}
+	if shutdownSchedule != "00 16 * * *" {
+		t.Errorf("shutdownSchedule != \"00 16 * * *\", actual \"%s\"", shutdownSchedule)
 	}
 	if len(machineTypes) != 2 {
 		t.Error("len(machineTypesMap) != 2, actual ", len(machineTypes))
@@ -32,7 +37,22 @@ func TestParseConfigFile(t *testing.T) {
 		t.Error("default value of GracePeriod is not set")
 	}
 
-	_, err = parseConfig(strings.NewReader("machine-types:"))
+	fileContent2 := `
+machine-types:
+  - name: qemu
+`
+	shutdownSchedule, machineTypes, err = parseConfig(strings.NewReader(fileContent2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shutdownSchedule != "" {
+		t.Errorf("shutdownSchedule != \"\", actual \"%s\"", shutdownSchedule)
+	}
+	if len(machineTypes) != 1 {
+		t.Error("len(machineTypesMap) != 1, actual ", len(machineTypes))
+	}
+
+	_, _, err = parseConfig(strings.NewReader("machine-types:"))
 	if err == nil {
 		t.Error(errors.New("it should be raised an error"))
 	}

--- a/pkg/sabakan-state-setter/necocommand.go
+++ b/pkg/sabakan-state-setter/necocommand.go
@@ -7,6 +7,8 @@ import (
 
 // NecoCmdExecutor is interface for the neco command
 type NecoCmdExecutor interface {
+	PowerStop(ctx context.Context, serial string) ([]byte, error)
+	PowerStatus(ctx context.Context, serial string) ([]byte, error)
 	TPMClear(ctx context.Context, serial string) ([]byte, error)
 }
 
@@ -14,6 +16,14 @@ type necoCmdExecutor struct{}
 
 func newNecoCmdExecutor() necoCmdExecutor {
 	return necoCmdExecutor{}
+}
+
+func (necoCmdExecutor) PowerStop(ctx context.Context, serial string) ([]byte, error) {
+	return exec.CommandContext(ctx, "neco", "power", "stop", serial).CombinedOutput()
+}
+
+func (necoCmdExecutor) PowerStatus(ctx context.Context, serial string) ([]byte, error) {
+	return exec.CommandContext(ctx, "neco", "power", "status", serial).CombinedOutput()
 }
 
 func (necoCmdExecutor) TPMClear(ctx context.Context, serial string) ([]byte, error) {

--- a/pkg/sabakan-state-setter/necocommand_mock.go
+++ b/pkg/sabakan-state-setter/necocommand_mock.go
@@ -2,24 +2,65 @@ package sss
 
 import (
 	"context"
+	"errors"
 )
 
 type necoCmdMockExecutor struct {
-	tpm map[string]int
+	powerState       map[string]string
+	powerStopCount   map[string]int
+	powerStatusCount map[string]int
+	tpmClearCount    map[string]int
 }
 
 func newMockNecoCmdExecutor() *necoCmdMockExecutor {
 	return &necoCmdMockExecutor{
-		tpm: map[string]int{},
+		powerState:       map[string]string{},
+		powerStopCount:   map[string]int{},
+		powerStatusCount: map[string]int{},
+		tpmClearCount:    map[string]int{},
 	}
 }
 
+func (e *necoCmdMockExecutor) PowerStop(ctx context.Context, serial string) ([]byte, error) {
+	e.powerStopCount[serial]++
+	if e.powerState[serial] == "Off" {
+		return []byte("log message"), errors.New("machine is already powered off")
+	}
+	e.powerState[serial] = "Off"
+	return []byte("log message"), nil
+}
+
+func (e *necoCmdMockExecutor) PowerStatus(ctx context.Context, serial string) ([]byte, error) {
+	e.powerStatusCount[serial]++
+	if state, ok := e.powerState[serial]; ok {
+		// When `neco power status` succeeds, only power status (e.g. "On", "Off") is output.
+		// But the command fails, it outputs some error logs.
+		return []byte(state + "\n"), nil
+	}
+	return []byte("log message"), errors.New("error")
+}
+
 func (e *necoCmdMockExecutor) TPMClear(ctx context.Context, serial string) ([]byte, error) {
-	e.tpm[serial]++
+	e.tpmClearCount[serial]++
 	return []byte("log message"), nil
 }
 
 // test function
+func (e *necoCmdMockExecutor) setPowerState(serial string, state string) {
+	e.powerState[serial] = state
+}
+
+// test function
+func (e *necoCmdMockExecutor) getPowerStopCount(serial string) int {
+	return e.powerStopCount[serial]
+}
+
+// test function
+func (e *necoCmdMockExecutor) getPowerStatusCount(serial string) int {
+	return e.powerStatusCount[serial]
+}
+
+// test function
 func (e *necoCmdMockExecutor) getTPMClearCount(serial string) int {
-	return e.tpm[serial]
+	return e.tpmClearCount[serial]
 }

--- a/pkg/sabakan-state-setter/sabakan_mock.go
+++ b/pkg/sabakan-state-setter/sabakan_mock.go
@@ -18,8 +18,18 @@ func newMockSabakanClient(machines []*machine) *sabakanMockClient {
 	}
 }
 
-func (c *sabakanMockClient) GetSabakanMachines(ctx context.Context) ([]*machine, error) {
+func (c *sabakanMockClient) GetAllMachines(ctx context.Context) ([]*machine, error) {
 	return c.machines, nil
+}
+
+func (c *sabakanMockClient) GetRetiredMachines(ctx context.Context) ([]*machine, error) {
+	var retired []*machine
+	for _, m := range c.machines {
+		if m.State == sabakan.StateRetired {
+			retired = append(retired, m)
+		}
+	}
+	return retired, nil
 }
 
 func (c *sabakanMockClient) UpdateSabakanState(ctx context.Context, serial string, state sabakan.MachineState) error {


### PR DESCRIPTION
Add a new feature to `sabakan-state-setter` to auto shutdown retired machines.
When this change is released, the retired machines will be shut down at 1:00 AM (JST) every day.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>