### PR TITLE
Add safety features to 'neco tpm clear'

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -8,7 +8,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "coil", Repository: "ghcr.io/cybozu-go/coil", Tag: "2.0.6", Private: false},
 		{Name: "bird", Repository: "quay.io/cybozu/bird", Tag: "2.0.7.5", Private: false},
 		{Name: "chrony", Repository: "quay.io/cybozu/chrony", Tag: "4.0.0.1", Private: false},
-		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.25.3", Private: false},
+		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.3.25.4", Private: false},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.5.6", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.9.5.2", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.7.1", Private: true},

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -15,6 +15,7 @@ Features include:
   - [Vault related functions](#vault-related-functions)
   - [BMC management functions](#bmc-management-functions)
   - [CKE related functions](#cke-related-functions)
+  - [TPM related functions](#tpm-related-functions)
   - [Miscellaneous](#miscellaneous)
 - [Configurations](#configurations)
   - [`env`](#env)
@@ -218,6 +219,18 @@ See details [Role and weights](https://github.com/cybozu-go/cke/blob/main/docs/s
 * `neco cke update`
 
     Update cke template using overriding weights. This is useful if administrator updates role and weights in the running Kubernetes cluster.
+
+### TPM related functions
+
+* `neco tpm clear SERIAL_OR_IP`
+
+Clear TPM devices on a machine having `SERIAL` or `IP` address.
+The command fails when the target machine's status is not retiring.
+`--force` option is explicitly required.
+
+* `neco tpm show SERIAL_OR_IP`
+
+Show TPM devices on a machine having `SERIAL` or `IP` address.
 
 ### Miscellaneous
 

--- a/pkg/sabakan-state-setter/controller.go
+++ b/pkg/sabakan-state-setter/controller.go
@@ -386,13 +386,13 @@ func (c *Controller) machineRetire(ctx context.Context, machines []*machine) map
 			continue
 		}
 
-		stderr, err := c.necoExecutor.TPMClear(ctx, m.Serial)
+		cmdOutput, err := c.necoExecutor.TPMClear(ctx, m.Serial)
 		if err != nil {
 			log.Warn("failed to clear TPM", map[string]interface{}{
 				log.FnError: err.Error(),
 				"serial":    m.Serial,
 				"ipv4":      m.IPv4Addr,
-				"stderr":    stderr,
+				"cmdlog":    string(cmdOutput),
 			})
 			continue
 		}

--- a/pkg/sabakan-state-setter/controller.go
+++ b/pkg/sabakan-state-setter/controller.go
@@ -386,12 +386,13 @@ func (c *Controller) machineRetire(ctx context.Context, machines []*machine) map
 			continue
 		}
 
-		err = c.necoExecutor.TPMClear(ctx, m.Serial)
+		stderr, err := c.necoExecutor.TPMClear(ctx, m.Serial)
 		if err != nil {
 			log.Warn("failed to clear TPM", map[string]interface{}{
 				log.FnError: err.Error(),
 				"serial":    m.Serial,
 				"ipv4":      m.IPv4Addr,
+				"stderr":    stderr,
 			})
 			continue
 		}

--- a/pkg/sabakan-state-setter/controller_test.go
+++ b/pkg/sabakan-state-setter/controller_test.go
@@ -396,7 +396,7 @@ func testControllerRetire(t *testing.T) {
 	for _, serial := range []string{"retired", "healthy"} {
 		newState, ok := stateMap[serial]
 		if ok {
-			t.Error(serial, "machine state will changed: %s", newState)
+			t.Error(serial, "machine state will be changed: "+newState)
 		}
 		if sabaMock.getCryptsDeleteCount(serial) != 0 {
 			t.Error(serial, "sabakan.CryptsDelete is called")

--- a/pkg/sabakan-state-setter/necocommand.go
+++ b/pkg/sabakan-state-setter/necocommand.go
@@ -1,14 +1,13 @@
 package sss
 
 import (
-	"bytes"
 	"context"
 	"os/exec"
 )
 
 // NecoCmdExecutor is interface for the neco command
 type NecoCmdExecutor interface {
-	TPMClear(ctx context.Context, serial string) (string, error)
+	TPMClear(ctx context.Context, serial string) ([]byte, error)
 }
 
 type necoCmdExecutor struct{}
@@ -17,17 +16,6 @@ func newNecoCmdExecutor() necoCmdExecutor {
 	return necoCmdExecutor{}
 }
 
-func execNeco(ctx context.Context, opts ...string) (string, string, error) {
-	cmd := exec.CommandContext(ctx, "neco", opts...)
-	outBuf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	cmd.Stdout = outBuf
-	cmd.Stderr = errBuf
-	err := cmd.Run()
-	return outBuf.String(), errBuf.String(), err
-}
-
-func (necoCmdExecutor) TPMClear(ctx context.Context, serial string) (string, error) {
-	_, stderr, err := execNeco(ctx, "tpm", "clear", "--force", serial)
-	return stderr, err
+func (necoCmdExecutor) TPMClear(ctx context.Context, serial string) ([]byte, error) {
+	return exec.CommandContext(ctx, "neco", "tpm", "clear", "--force", serial).CombinedOutput()
 }

--- a/pkg/sabakan-state-setter/necocommand.go
+++ b/pkg/sabakan-state-setter/necocommand.go
@@ -8,7 +8,7 @@ import (
 
 // NecoCmdExecutor is interface for the neco command
 type NecoCmdExecutor interface {
-	TPMClear(ctx context.Context, serial string) error
+	TPMClear(ctx context.Context, serial string) (string, error)
 }
 
 type necoCmdExecutor struct{}
@@ -17,15 +17,17 @@ func newNecoCmdExecutor() necoCmdExecutor {
 	return necoCmdExecutor{}
 }
 
-func execNeco(ctx context.Context, opts ...string) (string, error) {
+func execNeco(ctx context.Context, opts ...string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, "neco", opts...)
 	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
 	cmd.Stdout = outBuf
+	cmd.Stderr = errBuf
 	err := cmd.Run()
-	return outBuf.String(), err
+	return outBuf.String(), errBuf.String(), err
 }
 
-func (necoCmdExecutor) TPMClear(ctx context.Context, serial string) error {
-	_, err := execNeco(ctx, "tpm", "clear", serial)
-	return err
+func (necoCmdExecutor) TPMClear(ctx context.Context, serial string) (string, error) {
+	_, stderr, err := execNeco(ctx, "tpm", "clear", "--force", serial)
+	return stderr, err
 }

--- a/pkg/sabakan-state-setter/necocommand_mock.go
+++ b/pkg/sabakan-state-setter/necocommand_mock.go
@@ -14,9 +14,9 @@ func newMockNecoCmdExecutor() *necoCmdMockExecutor {
 	}
 }
 
-func (e *necoCmdMockExecutor) TPMClear(ctx context.Context, serial string) error {
+func (e *necoCmdMockExecutor) TPMClear(ctx context.Context, serial string) (string, error) {
 	e.tpm[serial]++
-	return nil
+	return "log message", nil
 }
 
 // test function

--- a/pkg/sabakan-state-setter/necocommand_mock.go
+++ b/pkg/sabakan-state-setter/necocommand_mock.go
@@ -14,9 +14,9 @@ func newMockNecoCmdExecutor() *necoCmdMockExecutor {
 	}
 }
 
-func (e *necoCmdMockExecutor) TPMClear(ctx context.Context, serial string) (string, error) {
+func (e *necoCmdMockExecutor) TPMClear(ctx context.Context, serial string) ([]byte, error) {
 	e.tpm[serial]++
-	return "log message", nil
+	return []byte("log message"), nil
 }
 
 // test function


### PR DESCRIPTION
- Add safety features to `neco tpm clear`. (same as [`sabactl crypts delete`](https://github.com/cybozu-go/sabakan/blob/main/docs/sabactl.md#sabactl-crypts-delete-serial))
    - The command fails when the target machine's status is not `Retiring`.
    - The command fails when `--force` option is not specified.
- Output failure messages of `neco tpm clear` in the sabakan-state-setter log.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>