### PR TITLE
generate-artifacts: replace flatcar-release url with the proper one

### DIFF
--- a/generator/generate.go
+++ b/generator/generate.go
@@ -48,7 +48,7 @@ var debRepos = []string{
 
 var templ = template.Must(template.New("").Parse(artifactSetTemplate))
 
-const coreOSFeed = "https://www.flatcar-linux.org/releases-json/releases-stable.json"
+const coreOSFeed = "https://kinvolk.io/flatcar-container-linux/releases-json/releases-stable.json"
 
 func render(w io.Writer, release bool, images []*neco.ContainerImage, debs []*neco.DebianPackage, coreos *neco.CoreOSImage) error {
 	var data struct {


### PR DESCRIPTION
Implemented #1536 

Old CoreOSFeed URL("https://www.flatcar-linux.org/releases-json/releases-stable.json") doesn't contain the new release version.
So I replace with proper URL ("https://kinvolk.io/flatcar-container-linux/releases-json/releases-stable.json").
This URL is found in "https://kinvolk.io/flatcar-container-linux/releases/"
