### PR TITLE
Enable TTLAfterFinished feature gate

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -58,7 +58,7 @@ options:
         - level: RequestResponse
     extra_args:
       - "--enable-admission-plugins=PodSecurityPolicy"
-      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"
+      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true"
       - "--audit-log-maxage=1"
       - "--audit-log-maxsize=10"
       - "--audit-log-maxbackup=10"
@@ -68,11 +68,11 @@ options:
         read_only: false
   kube-controller-manager:
     extra_args:
-      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"
+      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true"
   kube-proxy:
     extra_args:
       - "--ipvs-strict-arp=true"
-      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"
+      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true"
   kube-scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1beta1
@@ -105,7 +105,7 @@ options:
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: ScheduleAnyway
     extra_args:
-      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"
+      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true"
   kubelet:
     config:
       apiVersion: kubelet.config.k8s.io/v1beta1
@@ -115,7 +115,7 @@ options:
     cri_endpoint: unix:///var/run/k8s-containerd.sock
     extra_args:
       - "--containerd=/var/run/k8s-containerd.sock"
-      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true"
+      - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true"
     extra_binds:
       - source: /var/lib/k8s-containerd
         destination: /var/lib/k8s-containerd


### PR DESCRIPTION
This feature gate enables TTL controller for expired Jobs.
https://v1-19.docs.kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/