### PR TITLE
add `neco apply-firmware` command

### DIFF
--- a/docs/neco.md
+++ b/docs/neco.md
@@ -16,6 +16,7 @@ Features include:
   - [BMC management functions](#bmc-management-functions)
   - [CKE related functions](#cke-related-functions)
   - [TPM related functions](#tpm-related-functions)
+  - [Automated firmware application functions](#automated-firmware-application-functions)
   - [Miscellaneous](#miscellaneous)
 - [Configurations](#configurations)
   - [`env`](#env)
@@ -232,6 +233,14 @@ The command fails when the target machine's status is not retiring.
 * `neco tpm show SERIAL_OR_IP`
 
 Show TPM devices on a machine having `SERIAL` or `IP` address.
+
+### Automated firmware application functions
+
+* `neco apply-firmware UPDATER_FILE...`
+
+Send firmware updaters to BMC and schedule reboot.
+
+You can use `sabactl machines get`-like options to narrow down the machines to be updated.
 
 ### Miscellaneous
 

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -240,7 +240,7 @@ Show TPM devices on a machine having `SERIAL` or `IP` address.
 
 Send firmware updaters to BMC and schedule reboot.
 
-You can use `sabactl machines get`-like options to narrow down the machines to be updated.
+[`sabactl machines get`-like options](https://github.com/cybozu-go/sabakan/blob/main/docs/sabactl.md#sabactl-machines-get-query_param) can be used to narrow down the machines to be updated.
 
 ### Miscellaneous
 

--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -23,7 +23,7 @@ dns_service: internet-egress/unbound
 reboot:
   command: ["/usr/bin/neco", "reboot-and-wait", "-"]
   eviction_timeout_seconds: 1800
-  command_timeout_seconds: 1800
+  command_timeout_seconds: 3600
 options:
   kube-api:
     audit_log_enabled: true

--- a/pkg/neco/cmd/apply-firmware.go
+++ b/pkg/neco/cmd/apply-firmware.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/sabakan/v2"
+	"github.com/cybozu-go/sabakan/v2/client"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+	"github.com/tcnksm/go-input"
+	"github.com/vishvananda/netlink"
+)
+
+var applyFirmwareCmd = &cobra.Command{
+	Use:   "apply-firmware UPATER_FILE...",
+	Short: "initiate firmware application",
+	Long: `Send firmware updaters to BMCs and schedule reboot of workers.
+
+This uses CKE's function of graceful reboot for the nodes used by CKE.
+As for the other nodes, this reboots them immediately.
+If some nodes are already powered off, this command does not do anything to those nodes.`,
+
+	Args: cobra.MinimumNArgs(1),
+	Run:  applyFirmwareRun,
+}
+
+var applyFirmwareGetOpts sabakanMachinesGetOpts
+var applyFirmwareRebootOption bool
+
+func applyFirmwareRun(cmd *cobra.Command, args []string) {
+	ctx := context.Background()
+	filenames := args
+
+	machines, err := sabakanMachinesGet(ctx, &applyFirmwareGetOpts)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+	machinesWithoutBootServers := []sabakan.Machine{}
+	for _, m := range machines {
+		if m.Spec.Role != "boot" {
+			machinesWithoutBootServers = append(machinesWithoutBootServers, m)
+		}
+	}
+	machines = machinesWithoutBootServers
+	fmt.Printf("Applying to %d machines.\n", len(machines))
+
+	sabakanClient, err := client.NewClient(neco.SabakanLocalEndpoint, httpClient.Client)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+
+	hostAddr, err := getInterfaceAddress("node0")
+	if err != nil {
+		log.ErrorExit(err)
+	}
+	assetUrlRoot := "http://" + hostAddr.String() + ":10080/api/v1/assets/"
+	assetMeta := map[string]string{}
+	assetUrls := []string{}
+	for _, filename := range filenames {
+		name := filepath.Base(filename)
+		_, err := sabakanClient.AssetsUpload(ctx, name, filename, assetMeta)
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		assetUrl := assetUrlRoot + name
+		log.Info("asset uploaded", map[string]interface{}{
+			"file": filename,
+			"name": name,
+			"url":  assetUrl,
+		})
+		assetUrls = append(assetUrls, assetUrl)
+	}
+
+	var wg sync.WaitGroup
+	var mtx sync.Mutex
+	failedAddrs := []string{}
+	succeededAddrs := []string{}
+	succeededMachines := []sabakan.Machine{}
+	for _, machine := range machines {
+		wg.Add(1)
+		go func(machine sabakan.Machine) {
+			defer wg.Done()
+			addr := machine.Spec.IPv4[0]
+			cmdArgs := append([]string{"ssh", addr, "docker", "exec", "setup-hw", "setup-apply-firmware"}, assetUrls...)
+			output, err := well.CommandContext(ctx, neco.CKECLIBin, cmdArgs...).Output()
+
+			mtx.Lock()
+			defer mtx.Unlock()
+			if err != nil {
+				fmt.Print(string(output))
+				failedAddrs = append(failedAddrs, addr)
+			} else {
+				succeededAddrs = append(succeededAddrs, addr)
+				succeededMachines = append(succeededMachines, machine)
+			}
+		}(machine)
+	}
+	wg.Wait()
+
+	sort.Strings(succeededAddrs)
+	sort.Strings(failedAddrs)
+
+	fmt.Printf(`
+Total:     %d
+Succeeded: %d %v
+Failed:    %d %v
+
+`, len(machines), len(succeededAddrs), succeededAddrs, len(failedAddrs), failedAddrs)
+
+	if !applyFirmwareRebootOption {
+		return
+	}
+
+	ans, err := input.DefaultUI().Ask("reboot succeeded machines? ([y]es/[N]o)", &input.Options{
+		Default:     "N",
+		HideDefault: true,
+		HideOrder:   true,
+	})
+	if err != nil {
+		log.ErrorExit(err)
+	}
+	switch ans {
+	case "y", "Y", "yes":
+	default:
+		return
+	}
+
+	err = rebootMachines(succeededMachines)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+}
+
+func getInterfaceAddress(ifname string) (net.IP, error) {
+	link, err := netlink.LinkByName(ifname)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+	return addrs[0].IP, nil
+}
+
+func init() {
+	rootCmd.AddCommand(applyFirmwareCmd)
+	addSabakanMachinesGetOpts(applyFirmwareCmd, &applyFirmwareGetOpts)
+	applyFirmwareCmd.Flags().BoolVar(&applyFirmwareRebootOption, "reboot", false, "Schedule reboot")
+}

--- a/pkg/neco/cmd/apply-firmware.go
+++ b/pkg/neco/cmd/apply-firmware.go
@@ -19,7 +19,7 @@ import (
 )
 
 var applyFirmwareCmd = &cobra.Command{
-	Use:   "apply-firmware UPATER_FILE...",
+	Use:   "apply-firmware UPDATER_FILE...",
 	Short: "initiate firmware application",
 	Long: `Send firmware updaters to BMCs and schedule reboot of workers.
 
@@ -61,19 +61,18 @@ func applyFirmwareRun(cmd *cobra.Command, args []string) {
 		log.ErrorExit(err)
 	}
 	assetUrlRoot := "http://" + hostAddr.String() + ":10080/api/v1/assets/"
-	assetMeta := map[string]string{}
 	assetUrls := []string{}
 	for _, filename := range filenames {
 		name := filepath.Base(filename)
-		_, err := sabakanClient.AssetsUpload(ctx, name, filename, assetMeta)
+		_, err := sabakanClient.AssetsUpload(ctx, name, filename, nil)
 		if err != nil {
 			log.ErrorExit(err)
 		}
 		assetUrl := assetUrlRoot + name
 		log.Info("asset uploaded", map[string]interface{}{
-			"file": filename,
-			"name": name,
-			"url":  assetUrl,
+			"file":      filename,
+			"name":      name,
+			"asset_url": assetUrl,
 		})
 		assetUrls = append(assetUrls, assetUrl)
 	}


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1577

1. upload firmware updaters to sabakan as assets
2. run setup-apply-firmware on each worker
3. schedule reboot

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>