### PR TITLE
add `neco isoreboot` subcommand

### DIFF
--- a/docs/neco.md
+++ b/docs/neco.md
@@ -236,6 +236,12 @@ Show TPM devices on a machine having `SERIAL` or `IP` address.
 
 ### Automated firmware application functions
 
+* `neco isoreboot ISO_FILE`
+
+Connect iso file to Virtual DVD and schedule reboot.
+
+[`sabactl machines get`-like options](https://github.com/cybozu-go/sabakan/blob/main/docs/sabactl.md#sabactl-machines-get-query_param) can be used to narrow down the machines to be updated.
+
 * `neco apply-firmware UPDATER_FILE...`
 
 Send firmware updaters to BMC and schedule reboot.

--- a/pkg/neco/cmd/isoreboot.go
+++ b/pkg/neco/cmd/isoreboot.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+var isoRebootCmd = &cobra.Command{
+	Use:   "isoreboot ISO_FILE",
+	Short: "initiate reboot from a ISO image",
+	Long: `Connect iso file to virtual DVD and schedule reboot of workers.
+
+This uses CKE's function of graceful reboot for the nodes used by CKE.
+As for the other nodes, this reboots them immediately.
+If some nodes are already powered off, this command does not do anything to those nodes.`,
+
+	Args: cobra.ExactArgs(1),
+	Run:  isoRebootRun,
+}
+
+var isoRebootGetOpts sabakanMachinesGetOpts
+
+func isoRebootRun(cmd *cobra.Command, args []string) {
+	ctx := context.Background()
+
+	uploadAssetsAndRunCommandOnWorkers(ctx, &isoRebootGetOpts, args, []string{"docker", "exec", "setup-hw", "setup-isoreboot"}, true)
+}
+
+func init() {
+	rootCmd.AddCommand(isoRebootCmd)
+	addSabakanMachinesGetOpts(isoRebootCmd, &isoRebootGetOpts)
+}


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1578

1. upload the iso file as a asset
2. run setup-isoreboot on each worker
3. schedule reboot

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>