### PR TITLE
Extend lease params for kube-scheduler and controller-manager

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -72,6 +72,9 @@ options:
   kube-controller-manager:
     extra_args:
       - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true,CronJobControllerV2=true,MixedProtocolLBService=true,ServiceLBNodePortControl=true"
+      - "--leader-elect-retry-period=5s"
+      - "--leader-elect-renew-deadline=15s"
+      - "--leader-elect-lease-duration=20s"
   kube-proxy:
     config:
       apiVersion: kubeproxy.config.k8s.io/v1alpha1
@@ -119,6 +122,9 @@ options:
               whenUnsatisfiable: ScheduleAnyway
     extra_args:
       - "--feature-gates=EphemeralContainers=true,GenericEphemeralVolume=true,TTLAfterFinished=true,CronJobControllerV2=true,MixedProtocolLBService=true,ServiceLBNodePortControl=true"
+      - "--leader-elect-retry-period=5s"
+      - "--leader-elect-renew-deadline=15s"
+      - "--leader-elect-lease-duration=20s"
   kubelet:
     config:
       apiVersion: kubelet.config.k8s.io/v1beta1
@@ -142,6 +148,16 @@ options:
       - source: /var/lib/rook
         destination: /var/lib/rook
         read_only: false
+  rivers:
+    extra_args:
+      - "--dial-timeout=4s"
+      - "--dial-keep-alive=6s"
+      - "--check-interval=5s"
+  etcd-rivers:
+    extra_args:
+      - "--dial-timeout=4s"
+      - "--dial-keep-alive=6s"
+      - "--check-interval=5s"
   etcd:
     extra_args:
       - "--listen-metrics-urls=http://0.0.0.0:2381"


### PR DESCRIPTION
Due to the lease timeout, `controller-manager` and `kube-scheduler` sometimes become unstable.
To fix this issue, this PR modified the related flags listed below
- `--leader-elect-retry-period`
- `--leader-elect-renew-deadline`
- `--leader-elect-lease-duration`

Also, as the etcd-rivers and rivers are connecting to the unhealthy api-server due to the long health check interval,  this PR shortened the interval too.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>