### PR TITLE
Mount .kube directory by tmpfs

### DIFF
--- a/dctest/cke_test.go
+++ b/dctest/cke_test.go
@@ -107,7 +107,6 @@ func testCKE() {
 
 	It("wait for Kubernetes cluster to become ready", func() {
 		By("generating kubeconfig for cluster admin")
-		execSafeAt(bootServers[0], "mkdir", "-p", ".kube")
 		Eventually(func() error {
 			_, stderr, err := execAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
 			if err != nil {

--- a/dctest/reboot_test.go
+++ b/dctest/reboot_test.go
@@ -32,6 +32,16 @@ func testRebootAllBootServers() {
 			}
 			return nil
 		}).Should(Succeed())
+
+		// .kube directory is mounted by tmpfs, so reissuing config file is necessary
+		By("generating kubeconfig for cluster admin")
+		Eventually(func() error {
+			_, stderr, err := execAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
+			if err != nil {
+				return fmt.Errorf("err: %v, stderr: %s", err, stderr)
+			}
+			return nil
+		}).Should(Succeed())
 	})
 }
 

--- a/dctest/setup_test.go
+++ b/dctest/setup_test.go
@@ -12,6 +12,31 @@ import (
 
 // testSetup tests "neco setup"
 func testSetup() {
+	//  kubectl caches the results, but it takes time to write
+	//  To speed up this caching, mount the directory to be cached by tmpfs.
+	It("should create mount service", func() {
+		mountUnit := `
+[Unit]
+Description=Mount .kube directory by tmpfs
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/mkdir -p /home/cybozu/.kube
+ExecStart=mount -t tmpfs -o size=5M tmpfs /home/cybozu/.kube`
+		mountServicePath := "/lib/systemd/system/mount.service"
+
+		for _, v := range bootServers {
+			stdout, stderr, err := execAtWithInput(v, []byte(mountUnit), "sudo", "tee", mountServicePath)
+			Expect(err).NotTo(HaveOccurred(), "host=%s, stdout=%s, stderr=%s, err=%v", v, stdout, stderr, err)
+			execSafeAt(v, "test", "-f", mountServicePath)
+			execSafeAt(v, "sudo", "systemctl", "enable", "mount")
+			execSafeAt(v, "sudo", "systemctl", "start", "mount")
+			execSafeAt(v, "systemctl", "-q", "is-active", "mount")
+		}
+	})
+
 	It("should complete on all boot servers", func() {
 		env := well.NewEnvironment(context.Background())
 		env.Go(func(ctx context.Context) error {

--- a/dctest/setup_test.go
+++ b/dctest/setup_test.go
@@ -17,23 +17,28 @@ func testSetup() {
 	It("should create mount service", func() {
 		mountUnit := `
 [Unit]
-Description=Mount .kube directory by tmpfs
+Description=mount ,kube directory by tmpfs
 Wants=network-online.target
 After=network-online.target
 
-[Service]
-Type=oneshot
-ExecStartPre=/bin/mkdir -p /home/cybozu/.kube
-ExecStart=mount -t tmpfs -o size=5M tmpfs /home/cybozu/.kube`
-		mountServicePath := "/lib/systemd/system/mount.service"
+[Mount]
+What=tmpfs
+Where=/home/cybozu/.kube
+DirectoryMode=0777
+Type=tmpfs
+Options=strictatime,nosuid,nodev
+
+[Install]
+WantedBy=multi-user.target`
+		mountServicePath := "/lib/systemd/system/home-cybozu-.kube.mount"
 
 		for _, v := range bootServers {
 			stdout, stderr, err := execAtWithInput(v, []byte(mountUnit), "sudo", "tee", mountServicePath)
 			Expect(err).NotTo(HaveOccurred(), "host=%s, stdout=%s, stderr=%s, err=%v", v, stdout, stderr, err)
 			execSafeAt(v, "test", "-f", mountServicePath)
-			execSafeAt(v, "sudo", "systemctl", "enable", "mount")
-			execSafeAt(v, "sudo", "systemctl", "start", "mount")
-			execSafeAt(v, "systemctl", "-q", "is-active", "mount")
+			execSafeAt(v, "sudo", "systemctl", "enable", "home-cybozu-.kube.mount")
+			execSafeAt(v, "sudo", "systemctl", "start", "home-cybozu-.kube.mount")
+			execSafeAt(v, "systemctl", "-q", "is-active", "home-cybozu-.kube.mount")
 		}
 	})
 

--- a/dctest/upgrade_test.go
+++ b/dctest/upgrade_test.go
@@ -162,7 +162,6 @@ func testUpgrade() {
 		Expect(err).ShouldNot(HaveOccurred(), "data=%s", stdout)
 
 		By("generating kubeconfig for cluster admin")
-		execSafeAt(bootServers[0], "mkdir", "-p", ".kube")
 		Eventually(func() error {
 			_, stderr, err := execAt(bootServers[0], "ckecli", "kubernetes", "issue", ">", ".kube/config")
 			if err != nil {


### PR DESCRIPTION
`kubectl` is sometimes very slow due to its caching.
To speed it up, this PR mounts `.kube` directory by tmpfs.

This PR was tested with neco-apps [here](https://app.circleci.com/pipelines/github/cybozu-go/neco-apps/6509/workflows/3c5f6877-5651-4145-a6e8-78db8f2ccf26).

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>