### PR TITLE
Modify the IP settings of dctest

### DIFF
--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -12,8 +12,8 @@ spec:
   pod: 10.64.0.0/14
   exposed:
     loadbalancer: 10.72.32.0/20
-    bastion: 10.72.48.0/26
-    ingress: 10.72.48.64/26
+    bastion: 10.72.48.0/24
+    ingress: 10.72.49.0/26
     global: 172.19.0.0/24
 ---
 kind: Inventory

--- a/dctest/menu.yml
+++ b/dctest/menu.yml
@@ -12,8 +12,8 @@ spec:
   pod: 10.64.0.0/14
   exposed:
     loadbalancer: 10.72.32.0/20
-    bastion: 10.72.48.0/26
-    ingress: 10.72.48.64/26
+    bastion: 10.72.48.0/24
+    ingress: 10.72.49.0/26
     global: 172.19.0.0/24
 ---
 kind: Inventory


### PR DESCRIPTION
Modify the IP settings of dctest to be the same as stage-0 because it does not match the GlobalNetWorkPolicy settings.

[manual-dctest-with-neco-feature-branch](https://app.circleci.com/pipelines/github/cybozu-go/neco-apps/6520/workflows/f6bd8b6f-16ad-47e8-9a23-8e1b3ca3dc9c/jobs/22047) passed