### PR TITLE
Record all k8s events in the audit log

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -45,6 +45,10 @@ options:
           verbs: ["get", "watch", "list"]
         - level: Metadata
           verbs: ["delete", "deletecollection"]
+        - level: RequestResponse
+          resources:
+            - group: ""
+              resources: ["events"]
         - level: None
           userGroups:
             - system:nodes


### PR DESCRIPTION
This PR records all the k8s events in the audit log.
They are recorded using `create` and `patch` verbs; read and delete operations of the events are not recorded.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>