### PR TITLE
Update CKE to 1.20.3

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 # tool versions used for both local bin and deb/zip packages
 
 ## These should be updated when Kubernetes is updated
-CKE_VERSION = 1.20.2
+CKE_VERSION = 1.20.3
 CONTAINERD_VERSION = 1.5.2
 CRITOOLS_VERSION = 1.20.0
 RUNC_VERSION = 1.0.0-rc95


### PR DESCRIPTION
Update CKE to 1.20.3.
It triggers upgrade of the etcd cluster for k8s to v3.4.16.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>