### PR TITLE
bind mount /var/log to /var/lib/kubelet/varlog

### DIFF
--- a/ignitions/common/files/etc/fstab
+++ b/ignitions/common/files/etc/fstab
@@ -1,5 +1,6 @@
-/dev/vg1/k8s-containerd /var/lib/k8s-containerd ext4 x-systemd.device-timeout=600 0 0
-/dev/vg1/docker         /var/lib/docker         ext4 x-systemd.device-timeout=600 0 0
-/dev/vg1/kubelet        /var/lib/kubelet        ext4 x-systemd.device-timeout=600 0 0
-/dev/vg1/systemd        /var/lib/systemd        ext4 x-systemd.device-timeout=600 0 0
-none                    /var/lib/rook           tmpfs defaults                    0 0
+/dev/vg1/k8s-containerd /var/lib/k8s-containerd ext4  x-systemd.device-timeout=600 0 0
+/dev/vg1/docker         /var/lib/docker         ext4  x-systemd.device-timeout=600 0 0
+/dev/vg1/kubelet        /var/lib/kubelet        ext4  x-systemd.device-timeout=600 0 0
+/dev/vg1/systemd        /var/lib/systemd        ext4  x-systemd.device-timeout=600 0 0
+none                    /var/lib/rook           tmpfs defaults                     0 0
+/var/lib/kubelet/varlog /var/log                none  bind                         0 0

--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -24,6 +24,15 @@ lvsize() {
     esac
 }
 
+always_mkfs() {
+    case $1 in
+    kubelet)
+        return 0
+        ;;
+    esac
+    return 1
+}
+
 prepare_lv() {
     # enable COW volume auto extension
     lvmconfig --config activation/snapshot_autoextend_threshold=70 \
@@ -91,7 +100,7 @@ for label in $LVLIST; do
         sleep 1
     done
 
-    if [ $label != "$(lsblk -n -o LABEL $DEVICE)" ]; then
+    if always_mkfs $label || [ $label != "$(lsblk -n -o LABEL $DEVICE)" ]; then
         mkfs.ext4 -L $label $DEVICE
     fi
 done


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1647

- bind mount
- always re-mkfs /var/lib/kubelet to make it "volatile"

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>