### PR TITLE
increase number of disks and kubelet LV size on dctest

### DIFF
--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -45,7 +45,7 @@ type: cs
 spec:
   cpu: 10
   memory: 20G
-  disk-count: 4
+  disk-count: 6
   tpm: true
 ---
 kind: Node
@@ -53,5 +53,5 @@ type: ss
 spec:
   cpu: 4
   memory: 10G
-  disk-count: 8
+  disk-count: 10
   tpm: true

--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -6,7 +6,7 @@ LVLIST="k8s-containerd docker kubelet systemd coredump"
 # these values are for qemu (dctest env). see below for real machines.
 CONTAINERD_SIZE=20g
 DOCKER_SIZE=10g
-KUBELET_SIZE=10g
+KUBELET_SIZE=40g
 SYSTEMD_SIZE=1g
 COREDUMP_SIZE=1g
 
@@ -79,7 +79,7 @@ find_boss() {
 
 if ls /dev/mapper/crypt-vd* >/dev/null 2>&1; then
     # for qemu
-    PVS="/dev/mapper/crypt-vda /dev/mapper/crypt-vdb"
+    PVS=$(ls /dev/mapper/crypt-vd[abcd])
     prepare_lv
 elif ls /dev/mapper/crypt-nvme* >/dev/null 2>&1; then
     # for compute node
@@ -94,6 +94,7 @@ else
     PVS=$(find_boss)
     CONTAINERD_SIZE=50g
     DOCKER_SIZE=50g
+    KUBELET_SIZE=10g
     COREDUMP_SIZE=20g
     prepare_lv
 fi


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1647

increase kubelet LV size to increase ephemeral storage capacity.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>