### PR TITLE
fix kernel.core_pattern in sysctl

### DIFF
--- a/ignitions/common/files/etc/sysctl.d/70-cybozu.conf
+++ b/ignitions/common/files/etc/sysctl.d/70-cybozu.conf
@@ -3,7 +3,6 @@ vm.dirty_expire_centisecs = 100
 vm.swappiness = 0
 fs.inotify.max_user_instances = 20000
 fs.xfs.xfssyncd_centisecs = 100
-kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %p %P %u %g %s %t %c %h %e
 vm.max_map_count = 262144
 # GC thresholds for ARP cache.
 net.ipv4.neigh.default.gc_thresh1 = 4096


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1677

This PR solves the problem that systemd-coredump does not retrieve the correct process information.

Use the default value of kernel.core_pattern, which is set by /usr/lib/sysctl.d/50-coredump.conf

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>