### PR TITLE
remove ETCDCTL_API variable

### DIFF
--- a/dctest/run_test.go
+++ b/dctest/run_test.go
@@ -214,7 +214,7 @@ func getVaultToken() string {
 }
 
 func execEtcdctlAt(host string, args ...string) ([]byte, []byte, error) {
-	execArgs := []string{"env", "ETCDCTL_API=3", "etcdctl", "--cert=/etc/neco/etcd.crt", "--key=/etc/neco/etcd.key"}
+	execArgs := []string{"etcdctl", "--cert=/etc/neco/etcd.crt", "--key=/etc/neco/etcd.key"}
 	execArgs = append(execArgs, args...)
 	return execAt(host, execArgs...)
 }

--- a/setup/etcd_backup.go
+++ b/setup/etcd_backup.go
@@ -16,7 +16,7 @@ var etcdBackupTmpl = template.Must(template.New("").Parse(`#!/bin/sh
 set -ue
 
 SNAPSHOT=snapshot-$(date '+%Y%m%d_%H%M%S')
-ETCDCTL="env ETCDCTL_API=3 /usr/local/bin/etcdctl --cert={{ .CertFile }} --key={{ .KeyFile }}"
+ETCDCTL="/usr/local/bin/etcdctl --cert={{ .CertFile }} --key={{ .KeyFile }}"
 
 $ETCDCTL snapshot save /var/lib/etcd-backup/${SNAPSHOT}
 tar --remove-files -cvzf /var/lib/etcd-backup/${SNAPSHOT}.tar.gz /var/lib/etcd-backup/${SNAPSHOT}


### PR DESCRIPTION
This PR removes `ETCDCTL_API=3`, that becomes default on etcd 3.4.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>