### PR TITLE
change settings for non-privilege users to use perf

### DIFF
--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -17,6 +17,7 @@ files:
   - /etc/systemd/coredump.conf
   - /etc/systemd/system.conf.d/50-cybozu.conf
   - /etc/systemd/system/rngd.service.d/non_vm.conf
+  - /etc/systemd/system/sys-kernel-tracing.mount.d/mode.conf
   - /etc/systemd/system/systemd-journald.service.d/oom_score_adj.conf
   - /opt/bin/load-containerd-image
   - /opt/bin/load-docker-image

--- a/ignitions/common/files/etc/sysctl.d/70-cybozu.conf
+++ b/ignitions/common/files/etc/sysctl.d/70-cybozu.conf
@@ -14,3 +14,5 @@ net.ipv4.tcp_keepalive_time = 600
 net.core.wmem_max = 16777216
 # Don't panic on hang up tasks (mainly for Ceph RBD)
 kernel.hung_task_panic = 0
+# Non-privilege users can use perf to gather kernel events.
+kernel.perf_event_paranoid = 1

--- a/ignitions/common/files/etc/systemd/system/sys-kernel-tracing.mount.d/mode.conf
+++ b/ignitions/common/files/etc/systemd/system/sys-kernel-tracing.mount.d/mode.conf
@@ -1,0 +1,3 @@
+[Mount]
+Options=nosuid,nodev,noexec,mode=755
+# original is Options=nosuid,nodev,noexec


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1694

- set `kernel.perf_event_paranoid` sysctl to `1`
- ~remount~ mount /sys/kernel/tracing with mode=755

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>