### PR TITLE
Ignore PDBs on developmental namespaces on reboot 

### DIFF
--- a/progs/cke/conf.go
+++ b/progs/cke/conf.go
@@ -52,8 +52,12 @@ func GenerateCKETemplate(ctx context.Context, st storage.Storage, name string, c
 	if name == "stage0" {
 		if r, ok := tmpl["reboot"].(map[string]interface{}); ok {
 			r["protected_namespaces"] = map[string]interface{}{
-				"matchLabels": map[string]interface{}{
-					"team": "neco",
+				"matchExpressions": []interface{}{
+					map[string]interface{}{
+						"key":      "development",
+						"operator": "NotIn",
+						"values":   []string{"true"},
+					},
 				},
 			}
 		}

--- a/progs/cke/conf_test.go
+++ b/progs/cke/conf_test.go
@@ -273,8 +273,10 @@ nodes:
 reboot:
   command: ["test"]
   protected_namespaces:
-    matchLabels:
-      team: neco
+    matchExpressions:
+      - key: development
+        operator: NotIn
+        values: ["true"]
 `
 	err = yaml.Unmarshal([]byte(expectedTemplate), &expected)
 	if err != nil {


### PR DESCRIPTION
This PR makes reboot follow only the PDBs on the namespaces:
- one does not have `development` label at all, or
- one has `development` label but its value is not `"true"`.

It is mandatory to merge cybozu-go/neco-apps#1721 in advance.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>