### PR TITLE
follow `neco recover` behavior to current neco-worker process.

### DIFF
--- a/docs/etcd.md
+++ b/docs/etcd.md
@@ -29,14 +29,14 @@ users in nodes.
 
 ## `<prefix>/contents/<target>`
 
-`<target>` is either `sabakan` or `cke`.
+`<target>` includes `sabakan`, `cke`, etc.
 
 The value is a JSON object with these fields:
 
-Name      | Type   | Description
-----      | ----   | -----------
-`version` | string | sabakan contents version (the same as `neco` package version).
-`success` | bool   | If `true`, update succeeded.
+| Name      | Type   | Description                                                    |
+| --------- | ------ | -------------------------------------------------------------- |
+| `version` | string | sabakan contents version (the same as `neco` package version). |
+| `success` | bool   | If `true`, update succeeded.                                   |
 
 ```json
 {
@@ -68,12 +68,12 @@ A leader of `neco-updater` creates and updates this key.
 
 The value is a JSON object with these fields:
 
-Name         | Type   | Description
-----         | ----   | -----------
-`version`    | string | Target `neco` version to be updated for all `servers`.
-`servers`    | []int  | LRNs of current available boot servers under update. This is created using `<prefix>/bootservers`.
-`stop`       | bool   | If `true`, `neco-worker` stops the update process.
-`started_at` | string | Updating start time.
+| Name         | Type   | Description                                                                                        |
+| ------------ | ------ | -------------------------------------------------------------------------------------------------- |
+| `version`    | string | Target `neco` version to be updated for all `servers`.                                             |
+| `servers`    | []int  | LRNs of current available boot servers under update. This is created using `<prefix>/bootservers`. |
+| `stop`       | bool   | If `true`, `neco-worker` stops the update process.                                                 |
+| `started_at` | string | Updating start time.                                                                               |
 
 ```json
 {
@@ -93,12 +93,12 @@ If `stop` becomes true, `neco-worker` should stop the ongoing update process imm
 
 The value is a JSON object with these fields:
 
-Name      | Type   | Description
-----      | ----   | -----------
-`version` | string | Target `neco` version to be updated.
-`step`    | int    | Current update step.
-`cond`    | int    | [`UpdateCondition`](https://godoc.org/github.com/cybozu-go/neco#UpdateCondition)
-`message` | string | Description of an error.
+| Name      | Type   | Description                                                                      |
+| --------- | ------ | -------------------------------------------------------------------------------- |
+| `version` | string | Target `neco` version to be updated.                                             |
+| `step`    | int    | Current update step.                                                             |
+| `cond`    | int    | [`UpdateCondition`](https://godoc.org/github.com/cybozu-go/neco#UpdateCondition) |
+| `message` | string | Description of an error.                                                         |
 
 ```json
 {
@@ -177,9 +177,9 @@ Token for accessing to teleport auth server
 
 A JSON object with these fields:
 
-Name     | Type  | Description
-----     | ----  | -----------
-`<ROLE>` | float | A role of weight.
+| Name     | Type  | Description       |
+| -------- | ----- | ----------------- |
+| `<ROLE>` | float | A role of weight. |
 
 This is used when `neco-worker` and `neco init-data` run `ckecli sabakan set-template`.
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -165,7 +165,7 @@ Updater updates container image and restart `sabakan` in any timing.
 3. Check if each sabakan content can be updated. If so, download artifacts, then upload them to sabakan.
 4. Put `<prefix>/contents/sabakan` with value.
 
-If on failure, `neco recover` command removes also this key.
+If on failure, run `neco recover` to recover. This command removes `<prefix>/contents/*` keys in addition to `<prefix>/status/*` keys.
 
 ### CKE contents
 

--- a/pkg/neco/cmd/recover.go
+++ b/pkg/neco/cmd/recover.go
@@ -22,7 +22,7 @@ var recoverCmd = &cobra.Command{
 		defer etcd.Close()
 		st := storage.NewStorage(etcd)
 
-		well.Go(st.ClearStatus)
+		well.Go(st.ClearStatusAndContents)
 		well.Stop()
 		err = well.Wait()
 		if err != nil {

--- a/storage/keys.go
+++ b/storage/keys.go
@@ -17,6 +17,7 @@ const (
 	KeyStatusPrefix             = "status/"
 	KeyCurrent                  = "status/current"
 	KeyWorkerStatusPrefix       = "status/bootservers/"
+	KeyContentsPrefix           = "contents/"
 	KeySabakanContents          = "contents/sabakan"
 	KeyCKEContents              = "contents/cke"
 	KeyDHCPJSONContents         = "contents/dhcp.json"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -103,7 +103,7 @@ func inputStatus(lrn int, status *neco.UpdateStatus, wait bool) testInput {
 
 func inputClear() testInput {
 	return func(ctx context.Context, st storage.Storage, bch <-chan struct{}) error {
-		return st.ClearStatus(ctx)
+		return st.ClearStatusAndContents(ctx)
 	}
 }
 


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1727

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>