### PR TITLE
make systemd-pstore run after mounting pstore

### DIFF
--- a/debian/etc/systemd/system/systemd-pstore.service.d/after-local-fs-mount.conf
+++ b/debian/etc/systemd/system/systemd-pstore.service.d/after-local-fs-mount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# systemd-pstore should run after mounting /sys/fs/psotre, which is done in local-fs.target
+After=local-fs.target

--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -19,6 +19,7 @@ files:
   - /etc/systemd/system/rngd.service.d/non_vm.conf
   - /etc/systemd/system/sys-kernel-tracing.mount.d/mode.conf
   - /etc/systemd/system/systemd-journald.service.d/oom_score_adj.conf
+  - /etc/systemd/system/systemd-pstore.service.d/after-local-fs-mount.conf
   - /opt/bin/load-containerd-image
   - /opt/bin/load-docker-image
   - /opt/bin/wait-k8s-containerd-socket

--- a/ignitions/common/files/etc/systemd/system/systemd-pstore.service.d/after-local-fs-mount.conf
+++ b/ignitions/common/files/etc/systemd/system/systemd-pstore.service.d/after-local-fs-mount.conf
@@ -1,0 +1,3 @@
+[Unit]
+# systemd-pstore should run after mounting /sys/fs/psotre, which is done in local-fs.target
+After=local-fs.target


### PR DESCRIPTION
In some environment, systemd-pstore.service run **before** /sys/fs/pstore is mounted. I doesn't make sense.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>