### PR TITLE
Fix ip of network equipment

### DIFF
--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -3,10 +3,10 @@ spec:
   ipam-config: ipam.json
   asn-base: 64600
   internet: 10.0.0.0/24
-  spine-tor: 10.0.1.0
-  core-spine: 10.0.2.0/31
-  core-external: 10.0.3.0/24
-  core-operation: 10.0.4.0/24
+  spine-tor: 10.72.1.0
+  core-spine: 10.72.2.0/31
+  core-external: 10.72.3.0/24
+  core-operation: 10.72.4.0/24
   proxy: 10.0.49.3
   ntp: ["172.16.4.65", "172.16.4.66"]
   pod: 10.64.0.0/14

--- a/dctest/menu.yml
+++ b/dctest/menu.yml
@@ -3,10 +3,10 @@ spec:
   ipam-config: ipam.json
   asn-base: 64600
   internet: 10.0.0.0/24
-  spine-tor: 10.0.1.0
-  core-spine: 10.0.2.0/31
-  core-external: 10.0.3.0/24
-  core-operation: 10.0.4.0/24
+  spine-tor: 10.72.1.0
+  core-spine: 10.72.2.0/31
+  core-external: 10.72.3.0/24
+  core-operation: 10.72.4.0/24
   proxy: 10.0.49.3
   ntp: ["172.16.4.65", "172.16.4.66"]
   pod: 10.64.0.0/14


### PR DESCRIPTION
Aligned the IP addresses of the network equipment in the Neco staging environment with the IP addresses of the network equipment in the dctest environment.
- Wanted to run some tests on network equipment with neco-apps.
- The IP address for neco's staging network equipment is `10.72.0.0/20`.

Signed-off-by: kouki <kouworld0123@gmail.com>