### PR TITLE
Ignore coil 2.0.12

### DIFF
--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,3 +1,6 @@
 osImage:
 - channel: stable
   versions: ["2905.2.0", "2905.2.1"]
+images:
+- repository: ghcr.io/cybozu-go/coil
+  versions: ["2.0.12"]


### PR DESCRIPTION
Ignore Coil v2.0.12 because it doesn't work with Neco environment.