### PR TITLE
Improve power management of retired/retiring machines

### DIFF
--- a/pkg/neco/cmd/power.go
+++ b/pkg/neco/cmd/power.go
@@ -112,7 +112,8 @@ func power(ctx context.Context, action, bmcAddr string) error {
 	var resetType redfish.ResetType
 	switch action {
 	case "start":
-		resetType = redfish.ForceOnResetType
+		// Use 'ON' because some machines don't support 'ForceOn'.
+		resetType = redfish.OnResetType
 	case "stop":
 		resetType = redfish.ForceOffResetType
 	case "restart":

--- a/pkg/neco/cmd/power.go
+++ b/pkg/neco/cmd/power.go
@@ -112,9 +112,9 @@ func power(ctx context.Context, action, bmcAddr string) error {
 	var resetType redfish.ResetType
 	switch action {
 	case "start":
-		resetType = redfish.OnResetType
+		resetType = redfish.ForceOnResetType
 	case "stop":
-		resetType = redfish.GracefulShutdownResetType
+		resetType = redfish.ForceOffResetType
 	case "restart":
 		// Use 'ForceRestart' because some machines don't support 'GracefulRestart'.
 		resetType = redfish.ForceRestartResetType

--- a/pkg/neco/cmd/tpm_clear.go
+++ b/pkg/neco/cmd/tpm_clear.go
@@ -164,12 +164,14 @@ IP is one of the IP addresses owned by the machine.`,
 			machineType := machine.Spec.Labels[machineTypeLabelName]
 			logicType, ok := supportedMachineTypes[machineType]
 			if !ok {
+				err := power(ctx, "stop", machine.Spec.BMC.IPv4)
 				log.Warn("unknown machine type; shutdown", map[string]interface{}{
-					"serial":       machine.Spec.Serial,
-					"node":         machine.Spec.IPv4[0],
-					"machine_type": machineType,
+					"serial":       "machine.Spec.Serial",
+					"node":         "machine.Spec.IPv4[0]",
+					"machine_type": "machineType",
+					"result":       err,
 				})
-				return power(ctx, "stop", machine.Spec.BMC.IPv4)
+				return errors.New("unknown machine type")
 			}
 
 			switch logicType {
@@ -178,7 +180,7 @@ IP is one of the IP addresses owned by the machine.`,
 			case tpmClearLogicTypeDellRedfish:
 				return dellRedfishClearTpm(ctx, machine.Spec.BMC.IPv4)
 			default:
-				panic(fmt.Sprintf("unknown logic type: %d", logicType))
+				panic(fmt.Sprintf("unreachable; unknown logic type: %d", logicType))
 			}
 		})
 		well.Stop()

--- a/pkg/neco/cmd/tpm_clear.go
+++ b/pkg/neco/cmd/tpm_clear.go
@@ -17,20 +17,19 @@ import (
 const machineTypeLabelName = "machine-type"
 
 const (
-	tpmClearLogicTypeNotImplemented = iota
-	tpmClearLogicTypeNothing
+	tpmClearLogicTypePowerOff = iota // If clearing TPM is not supported, shutdown the machine.
 	tpmClearLogicTypeDellRedfish
 )
 
 var tpmClearForce bool
 
 var supportedMachineTypes = map[string]int{
-	"qemu":        tpmClearLogicTypeNothing,     // Placemat VM. Clear logic is not implemented on placemat.
-	"r640-boot-1": tpmClearLogicTypeNothing,     // Dell, TPM 1.2
+	"qemu":        tpmClearLogicTypePowerOff,    // Placemat VM. Clear logic is not implemented on placemat.
+	"r640-boot-1": tpmClearLogicTypePowerOff,    // Dell, TPM 1.2
 	"r640-boot-2": tpmClearLogicTypeDellRedfish, // Dell, TPM 2.0
-	"r640-cs-1":   tpmClearLogicTypeNothing,     // Dell, TPM 1.2
+	"r640-cs-1":   tpmClearLogicTypePowerOff,    // Dell, TPM 1.2
 	"r640-cs-2":   tpmClearLogicTypeDellRedfish, // Dell, TPM 2.0
-	"r740xd-ss-1": tpmClearLogicTypeNothing,     // Dell, TPM 1.2
+	"r740xd-ss-1": tpmClearLogicTypePowerOff,    // Dell, TPM 1.2
 	"r740xd-ss-2": tpmClearLogicTypeDellRedfish, // Dell, TPM 2.0
 }
 
@@ -165,19 +164,21 @@ IP is one of the IP addresses owned by the machine.`,
 			machineType := machine.Spec.Labels[machineTypeLabelName]
 			logicType, ok := supportedMachineTypes[machineType]
 			if !ok {
-				return fmt.Errorf("unknown machine type: machine-type=%s", machineType)
+				log.Warn("unknown machine type; shutdown", map[string]interface{}{
+					"serial":       machine.Spec.Serial,
+					"node":         machine.Spec.IPv4[0],
+					"machine_type": machineType,
+				})
+				return power(ctx, "stop", machine.Spec.BMC.IPv4)
 			}
 
 			switch logicType {
-			case tpmClearLogicTypeNotImplemented:
-				return fmt.Errorf("clear logic is not implemented: machine-type=%s", machineType)
-			case tpmClearLogicTypeNothing:
-				log.Info("nothing to do", nil)
-				return nil
+			case tpmClearLogicTypePowerOff:
+				return power(ctx, "stop", machine.Spec.BMC.IPv4)
 			case tpmClearLogicTypeDellRedfish:
 				return dellRedfishClearTpm(ctx, machine.Spec.BMC.IPv4)
 			default:
-				return fmt.Errorf("unknown logic type: %d", logicType)
+				panic(fmt.Sprintf("unknown logic type: %d", logicType))
 			}
 		})
 		well.Stop()

--- a/pkg/sabakan-state-setter/controller.go
+++ b/pkg/sabakan-state-setter/controller.go
@@ -414,9 +414,10 @@ func (c *Controller) machineRetire(ctx context.Context, machines []*machine) map
 			continue
 		}
 
-		log.Info("retirement; encryption keys have been deleted successfully", map[string]interface{}{
+		log.Info("retirement; deleting encryption keys has been executed successfully", map[string]interface{}{
 			"serial": m.Serial,
 			"ipv4":   m.IPv4Addr,
+			"cmdlog": string(cmdOutput),
 		})
 		newStateMap[m.Serial] = sabakan.StateRetired
 	}
@@ -473,9 +474,10 @@ func (c *Controller) machineShutdown(ctx context.Context) {
 			continue
 		}
 
-		log.Info("shutdown successfully", map[string]interface{}{
+		log.Info("shutdown has been executed successfully", map[string]interface{}{
 			"serial": m.Serial,
 			"ipv4":   m.IPv4Addr,
+			"cmdlog": string(cmdOutput),
 		})
 	}
 	if len(errorMachines) != 0 {


### PR DESCRIPTION
https://github.com/cybozu-go/neco/issues/1803

- Use `ForceOff` in `neco power stop`.
- Power off if clearing TPM is not supported in `neco tpm clear`.
- Output the result of `neco` command from `sabakan-state-setter`.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>