### PR TITLE
Update Flatcar release JSON URL and flatcar version

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -19,5 +19,5 @@ var CurrentArtifacts = ArtifactSet{
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.2.1"},
 	},
-	OSImage: OSImage{Channel: "stable", Version: "2905.2.3"},
+	OSImage: OSImage{Channel: "stable", Version: "2983.2.0"},
 }

--- a/generator/generate.go
+++ b/generator/generate.go
@@ -48,7 +48,7 @@ var debRepos = []string{
 
 var templ = template.Must(template.New("").Parse(artifactSetTemplate))
 
-const osImageFeed = "https://kinvolk.io/flatcar-container-linux/releases-json/releases-stable.json"
+const osImageFeed = "https://www.flatcar-linux.org/releases-json/releases-stable.json"
 
 func render(w io.Writer, release bool, images []*neco.ContainerImage, debs []*neco.DebianPackage, osImage *neco.OSImage) error {
 	var data struct {


### PR DESCRIPTION
The new version is 2983.2.0 that brings a lot of changes
including cgroup v2 and cryptsetup 2.3.6 and Intel E800 driver.