### PR TITLE
Export chrony metrics

### DIFF
--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -24,6 +24,7 @@ files:
   - /opt/bin/load-docker-image
   - /opt/bin/wait-k8s-containerd-socket
   - /opt/sbin/bird-wait
+  - /opt/sbin/chrony-monitor
   - /opt/sbin/chrony-wait
   - /opt/sbin/neco-wait-dhcp-online
   - /opt/sbin/setup-bmc-user
@@ -114,6 +115,9 @@ systemd:
     enabled: true
   - name: udev-trigger.service
   - name: udev-trigger.timer
+    enabled: true
+  - name: chrony-monitor.service
+  - name: chrony-monitor.timer
     enabled: true
 networkd:
   - 01-eth0.network

--- a/ignitions/common/files/opt/sbin/chrony-monitor
+++ b/ignitions/common/files/opt/sbin/chrony-monitor
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+mkdir -p /var/lib/textfile-collector
+SYSTEM_TIME=$(docker exec chrony chronyc -c tracking | awk -F',' '{print $5}')
+
+echo '# TYPE chrony_monitor_tracking_system_time gauge' > /var/lib/textfile-collector/chrony-monitor.prom.$$
+echo "chrony_monitor_tracking_system_time ${SYSTEM_TIME}" > /var/lib/textfile-collector/chrony-monitor.prom.$$
+mv /var/lib/textfile-collector/chrony-monitor.prom.$$ /var/lib/textfile-collector/chrony-monitor.prom

--- a/ignitions/common/files/opt/sbin/chrony-monitor
+++ b/ignitions/common/files/opt/sbin/chrony-monitor
@@ -3,6 +3,5 @@
 mkdir -p /var/lib/textfile-collector
 SYSTEM_TIME=$(docker exec chrony chronyc -c tracking | awk -F',' '{print $5}')
 
-echo '# TYPE chrony_monitor_tracking_system_time gauge' > /var/lib/textfile-collector/chrony-monitor.prom.$$
-echo "chrony_monitor_tracking_system_time ${SYSTEM_TIME}" > /var/lib/textfile-collector/chrony-monitor.prom.$$
+printf '# TYPE chrony_monitor_tracking_system_time gauge\nchrony_monitor_tracking_system_time %s\n' ${SYSTEM_TIME} > /var/lib/textfile-collector/chrony-monitor.prom.$$
 mv /var/lib/textfile-collector/chrony-monitor.prom.$$ /var/lib/textfile-collector/chrony-monitor.prom

--- a/ignitions/common/files/opt/sbin/chrony-monitor
+++ b/ignitions/common/files/opt/sbin/chrony-monitor
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash -e
+
+set -o pipefail
 
 mkdir -p /var/lib/textfile-collector
 SYSTEM_TIME=$(docker exec chrony chronyc -c tracking | awk -F',' '{print $5}')

--- a/ignitions/common/systemd/chrony-monitor.service
+++ b/ignitions/common/systemd/chrony-monitor.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=export chrony metrics
+Requires=chronyd.service chrony-wait.service
+After=chronyd.service chrony-wait.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/sbin/chrony-monitor

--- a/ignitions/common/systemd/chrony-monitor.timer
+++ b/ignitions/common/systemd/chrony-monitor.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=monitor chrony periodically
+
+[Timer]
+OnActiveSec=30
+OnUnitActiveSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/ignitions/common/systemd/node-exporter.service
+++ b/ignitions/common/systemd/node-exporter.service
@@ -6,7 +6,7 @@ After=setup-node-exporter.service
 [Service]
 Type=simple
 Restart=always
-ExecStart=/opt/sbin/node_exporter
+ExecStart=/opt/sbin/node_exporter --collector.textfile.directory=/var/lib/textfile-collector
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR exports chrony metrics using Textfile Collector provided by node_exporter.

1. Add `chrony-monitor.service` and `chrony-monitor.timer` that periodically writes chrony metrics to `/var/lib/textfile-collector`.
  The metrics file should be written atomically.
  https://github.com/prometheus/node_exporter#textfile-collector
2. Add to node_exporter `--collector.textfile.directory` option to enable Textfile Collector.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>