### PR TITLE
Run chrony-monitor.timer after chrony-wait.service

### DIFF
--- a/ignitions/common/systemd/chrony-monitor.service
+++ b/ignitions/common/systemd/chrony-monitor.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=export chrony metrics
-Requires=chronyd.service chrony-wait.service
-After=chronyd.service chrony-wait.service
 
 [Service]
 Type=oneshot

--- a/ignitions/common/systemd/chrony-monitor.timer
+++ b/ignitions/common/systemd/chrony-monitor.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=monitor chrony periodically
+Wants=chronyd.service chrony-wait.service
+After=chronyd.service chrony-wait.service
 
 [Timer]
 OnActiveSec=30


### PR DESCRIPTION
Previously, `chrony-monitor.service` did not run after `chrony-wait.service`.
This PR fixes the order.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>