### PR TITLE
Enable hubble server tls

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -23,5 +23,5 @@ var CurrentArtifacts = ArtifactSet{
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.3.0"},
 	},
-	OSImage: OSImage{Channel: "stable", Version: "3033.2.0"},
+	OSImage: OSImage{Channel: "stable", Version: "3033.2.1"},
 }

--- a/cilium/upstream.yaml
+++ b/cilium/upstream.yaml
@@ -235,7 +235,8 @@ data:
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
-    disable-server-tls: true
+    tls-server-cert-file: /var/lib/hubble-relay/tls/server.crt
+    tls-server-key-file: /var/lib/hubble-relay/tls/server.key
 ---
 # Source: cilium/templates/cilium-agent/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -548,7 +549,7 @@ spec:
     k8s-app: hubble-relay
   ports:
   - protocol: TCP
-    port: 80
+    port: 443
     targetPort: 4245
 ---
 # Source: cilium/templates/hubble/metrics-service.yaml
@@ -1078,12 +1079,19 @@ spec:
                   path: client.crt
                 - key: tls.key
                   path: client.key
+          - secret:
+              name: hubble-relay-server-certs
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.key
+                  path: server.key
 ---
 # Source: cilium/templates/hubble/tls-cronjob/job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hubble-generate-certs-af8ec3c1b5
+  name: hubble-generate-certs-affc2980ae
   namespace: kube-system
   labels:
     k8s-app: hubble-generate-certs
@@ -1111,6 +1119,8 @@ spec:
             - "--hubble-server-cert-validity-duration=94608000s"
             - "--hubble-relay-client-cert-generate"
             - "--hubble-relay-client-cert-validity-duration=94608000s"
+            - "--hubble-relay-server-cert-generate"
+            - "--hubble-relay-server-cert-validity-duration=94608000s"
       hostNetwork: true
       serviceAccount: "hubble-generate-certs"
       serviceAccountName: "hubble-generate-certs"
@@ -1153,6 +1163,8 @@ spec:
                 - "--hubble-server-cert-validity-duration=94608000s"
                 - "--hubble-relay-client-cert-generate"
                 - "--hubble-relay-client-cert-validity-duration=94608000s"
+                - "--hubble-relay-server-cert-generate"
+                - "--hubble-relay-server-cert-validity-duration=94608000s"
           hostNetwork: true
           serviceAccount: "hubble-generate-certs"
           serviceAccountName: "hubble-generate-certs"

--- a/cilium/values.yaml
+++ b/cilium/values.yaml
@@ -11,6 +11,9 @@ kubeProxyReplacement: "disabled"
 hubble:
   relay:
     enabled: true
+    tls:
+      server:
+        enabled: true
   tls:
     auto:
       method: "cronJob"

--- a/dctest/cilium_test.go
+++ b/dctest/cilium_test.go
@@ -93,7 +93,7 @@ func checkHubbleRelayDeployment() {
 		}
 
 		stdout, _, err = execAt(bootServers[0], "hubble", "status", "-o", "json", "--server",
-			"hubble-relay.kube-system.svc:80")
+			"hubble-relay.kube-system.svc:443", "--tls", "--tls-allow-insecure")
 		if err != nil {
 			return err
 		}

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -409,8 +409,8 @@ data:
   config.yaml: "peer-service: unix:///var/run/cilium/hubble.sock\nlisten-address:
     :4245\ndial-timeout: \nretry-timeout: \nsort-buffer-len-max: \nsort-buffer-drain-timeout:
     \ntls-client-cert-file: /var/lib/hubble-relay/tls/client.crt\ntls-client-key-file:
-    /var/lib/hubble-relay/tls/client.key\ntls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt\ndisable-server-tls:
-    true\n"
+    /var/lib/hubble-relay/tls/client.key\ntls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt\ntls-server-cert-file:
+    /var/lib/hubble-relay/tls/server.crt\ntls-server-key-file: /var/lib/hubble-relay/tls/server.key\n"
 kind: ConfigMap
 metadata:
   name: hubble-relay-config
@@ -467,7 +467,7 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - port: 80
+  - port: 443
     protocol: TCP
     targetPort: 4245
   selector:
@@ -657,6 +657,13 @@ spec:
               - key: tls.key
                 path: client.key
               name: hubble-relay-client-certs
+          - secret:
+              items:
+              - key: tls.crt
+                path: server.crt
+              - key: tls.key
+                path: server.key
+              name: hubble-relay-server-certs
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -684,6 +691,8 @@ spec:
             - --hubble-server-cert-validity-duration=94608000s
             - --hubble-relay-client-cert-generate
             - --hubble-relay-client-cert-validity-duration=94608000s
+            - --hubble-relay-server-cert-generate
+            - --hubble-relay-server-cert-validity-duration=94608000s
             command:
             - /usr/bin/cilium-certgen
             image: quay.io/cybozu/cilium-certgen:0.1.5.1
@@ -988,7 +997,7 @@ kind: Job
 metadata:
   labels:
     k8s-app: hubble-generate-certs
-  name: hubble-generate-certs-af8ec3c1b5
+  name: hubble-generate-certs-affc2980ae
   namespace: kube-system
 spec:
   template:
@@ -1006,6 +1015,8 @@ spec:
         - --hubble-server-cert-validity-duration=94608000s
         - --hubble-relay-client-cert-generate
         - --hubble-relay-client-cert-validity-duration=94608000s
+        - --hubble-relay-server-cert-generate
+        - --hubble-relay-server-cert-validity-duration=94608000s
         command:
         - /usr/bin/cilium-certgen
         image: quay.io/cybozu/cilium-certgen:0.1.5.1


### PR DESCRIPTION
This PR enables TLS for the communication between hubble-relay and clients such as hubble-cli and hubble-ui-backend. Also it updates flatcar.