### PR TITLE
Modify cilium setting to add PDB and resource settings

### DIFF
--- a/cilium/kustomization.yaml
+++ b/cilium/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - upstream.yaml
   - aggregate_cluster_role.yaml
+  - pdb.yaml

--- a/cilium/pdb.yaml
+++ b/cilium/pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator

--- a/cilium/upstream.yaml
+++ b/cilium/upstream.yaml
@@ -710,6 +710,10 @@ spec:
             exec:
               command:
               - /cni-uninstall.sh
+        resources:
+          requests:
+            cpu: 100m
+            memory: 400Mi
         ports:
         - name: prometheus
           containerPort: 9090
@@ -913,6 +917,8 @@ spec:
   template:
     metadata:
       annotations:
+        # ensure pods roll when configmap updates
+        cilium.io/cilium-configmap-checksum: "aa37a3a353d9b7e9eed525a7c306e57416cabf31ac1305a845af0fec346ee6e5"
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -975,6 +981,10 @@ spec:
         - name: cilium-config-path
           mountPath: /tmp/cilium/config-map
           readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
       hostNetwork: true
       restartPolicy: Always
       priorityClassName: system-cluster-critical
@@ -1008,6 +1018,8 @@ spec:
   template:
     metadata:
       annotations:
+        # ensure pods roll when configmap updates
+        cilium.io/hubble-relay-configmap-checksum: "3923847b536fd40cdab5b8178c51a0210733dc7e36ac6d05c0996aecd37aa8d5"
       labels:
         k8s-app: hubble-relay
     spec:
@@ -1038,6 +1050,10 @@ spec:
           livenessProbe:
             tcpSocket:
               port: grpc
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
           volumeMounts:
           - name: hubble-sock-dir
             mountPath: /var/run/cilium

--- a/cilium/values.yaml
+++ b/cilium/values.yaml
@@ -8,12 +8,32 @@ enableIPv4Masquerade: false
 policyEnforcementMode: "default"
 policyAuditMode: true
 kubeProxyReplacement: "disabled"
+prometheus:
+  enabled: true
+rollOutCiliumPods: true
+resources:
+  requests:
+    cpu: 100m
+    memory: 400Mi
+operator:
+  rollOutPods: true
+  prometheus:
+    enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
 hubble:
   relay:
     enabled: true
     tls:
       server:
         enabled: true
+    rollOutPods: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 200Mi
   tls:
     auto:
       method: "cronJob"
@@ -25,9 +45,3 @@ hubble:
       - "flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip"
       - "icmp"
       - "http" 
-prometheus:
-  enabled: true
-operator:
-  prometheus:
-    enabled: true
-rollOutCiliumPods: true

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -496,6 +496,7 @@ spec:
   template:
     metadata:
       annotations:
+        cilium.io/cilium-configmap-checksum: aa37a3a353d9b7e9eed525a7c306e57416cabf31ac1305a845af0fec346ee6e5
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -552,6 +553,10 @@ spec:
           hostPort: 6942
           name: prometheus
           protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
@@ -586,7 +591,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations: null
+      annotations:
+        cilium.io/hubble-relay-configmap-checksum: 3923847b536fd40cdab5b8178c51a0210733dc7e36ac6d05c0996aecd37aa8d5
       labels:
         k8s-app: hubble-relay
     spec:
@@ -618,6 +624,10 @@ spec:
         readinessProbe:
           tcpSocket:
             port: grpc
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - mountPath: /var/run/cilium
           name: hubble-sock-dir
@@ -704,6 +714,21 @@ spec:
           serviceAccountName: hubble-generate-certs
       ttlSecondsAfterFinished: 1800
   schedule: 0 0 1 */4 *
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -832,6 +857,10 @@ spec:
           periodSeconds: 30
           successThreshold: 1
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 400Mi
         securityContext:
           privileged: true
         startupProbe:


### PR DESCRIPTION
This PR adds PDB and resource requests for hubble-relay and cilium-operator. Cilium's helm chart doesn't add PDB because of https://github.com/cilium/cilium/issues/18303. We will remove the PDB manifest once the fix would be released.
