### PR TITLE
Set enableIdentityMark false

### DIFF
--- a/cilium/upstream.yaml
+++ b/cilium/upstream.yaml
@@ -156,6 +156,7 @@ data:
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   cni-chaining-mode: generic-veth
+  enable-identity-mark: "false"
   # Disable the PodCIDR route to the cilium_host interface as it is not
   # required. While chaining, it is the responsibility of the underlying plugin
   # to enable routing.
@@ -596,7 +597,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "aa37a3a353d9b7e9eed525a7c306e57416cabf31ac1305a845af0fec346ee6e5"
+        cilium.io/cilium-configmap-checksum: "a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
@@ -918,7 +919,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "aa37a3a353d9b7e9eed525a7c306e57416cabf31ac1305a845af0fec346ee6e5"
+        cilium.io/cilium-configmap-checksum: "a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4"
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/values.yaml
+++ b/cilium/values.yaml
@@ -5,6 +5,7 @@ cni:
 datapathMode: "veth"
 tunnel: "disabled"
 enableIPv4Masquerade: false
+enableIdentityMark: false
 policyEnforcementMode: "default"
 policyAuditMode: true
 kubeProxyReplacement: "disabled"

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -358,6 +358,7 @@ data:
   enable-health-check-nodeport: "true"
   enable-health-checking: "true"
   enable-hubble: "true"
+  enable-identity-mark: "false"
   enable-ipv4: "true"
   enable-ipv4-masquerade: "false"
   enable-ipv6: "false"
@@ -496,7 +497,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: aa37a3a353d9b7e9eed525a7c306e57416cabf31ac1305a845af0fec346ee6e5
+        cilium.io/cilium-configmap-checksum: a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -744,7 +745,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: aa37a3a353d9b7e9eed525a7c306e57416cabf31ac1305a845af0fec346ee6e5
+        cilium.io/cilium-configmap-checksum: a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ""


### PR DESCRIPTION
EnableIdentityMark needs to be disabled to avoid conflicting identity marks when Cilium is configured with CNI-chaining.

https://github.com/cilium/cilium/blob/bcb2db046b49dede753f91799552f31ec687f7e0/pkg/option/config.go#L303

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>