### PR TITLE
Set ManageForeignRoutingPolicyRules and ManageForeignRoutes no

### DIFF
--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -15,6 +15,7 @@ files:
   - /etc/resolv.conf
   - /etc/sysctl.d/70-cybozu.conf
   - /etc/systemd/coredump.conf
+  - /etc/systemd/networkd.conf.d/01-cybozu.conf
   - /etc/systemd/system.conf.d/50-cybozu.conf
   - /etc/systemd/system/rngd.service.d/non_vm.conf
   - /etc/systemd/system/sys-kernel-tracing.mount.d/mode.conf

--- a/ignitions/common/files/etc/systemd/networkd.conf.d/01-cybozu.conf
+++ b/ignitions/common/files/etc/systemd/networkd.conf.d/01-cybozu.conf
@@ -1,0 +1,3 @@
+[Network]
+ManageForeignRoutingPolicyRules=no
+ManageForeignRoutes=no


### PR DESCRIPTION
Networkd drops foreign routing policy rules by default from systemd v248.
https://github.com/systemd/systemd/commit/0b81225e5791f660506f7db0ab88078cf296b771

We need to set ManageForeignRoutingPolicyRules=no and ManageForeignRoutes=no to protect foreign routing policy rules, otherwise networkd drops the rules created by Coil and Cilium. It leads to network disruption when one of the underlying interfaces on a node goes down.

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>