### PR TITLE
Add node.cilium.io/agent-not-ready taint

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -23,5 +23,5 @@ var CurrentArtifacts = ArtifactSet{
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.3.0"},
 	},
-	OSImage: OSImage{Channel: "stable", Version: "3033.2.1"},
+	OSImage: OSImage{Channel: "stable", Version: "3033.2.2"},
 }

--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -122,6 +122,10 @@ options:
       - "--leader-elect-renew-deadline=15s"
       - "--leader-elect-lease-duration=20s"
   kubelet:
+    boot_taints:
+      - key: node.cilium.io/agent-not-ready
+        value: "true"
+        effect: NoExecute
     config:
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration


### PR DESCRIPTION
Workaround for https://github.com/cilium/cilium/issues/18819

Confirmed reboot and manual-dctest-with-neco-feature-branch have passed.
https://app.circleci.com/pipelines/github/cybozu-go/neco-apps?branch=add-boot-taints-cilium&filter=all