### PR TITLE
Update artifacts

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -23,5 +23,5 @@ var CurrentArtifacts = ArtifactSet{
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.3.0"},
 	},
-	OSImage: OSImage{Channel: "stable", Version: "3033.2.1"},
+	OSImage: OSImage{Channel: "stable", Version: "3033.2.2"},
 }


### PR DESCRIPTION
Update Flatcar Container Linux to 3033.2.2.
This branch has also been tested against neco-apps.
https://app.circleci.com/pipelines/github/cybozu-go/neco-apps/9138/workflows/ad01f74a-c33a-4256-bd67-b69f6a89c083

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
