### PR TITLE
Distribute Neco operation CLI commands for Teleport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ setup-files-for-deb: setup-tools
 	GOBIN=$(BINDIR) go install -tags='$(GOTAGS)' $(BIN_PKGS)
 	go build -o $(BINDIR)/sabakan-state-setter -tags='$(GOTAGS)' ./pkg/sabakan-state-setter/cmd
 	GOBIN=$(SBINDIR) go install -tags='$(GOTAGS)' $(SBIN_PKGS)
+	tar -c -f $(LIBEXECDIR)/neco-operation-cli.tgz -z -C $(BINDIR) $(OPDEB_BINNAMES)
 	cp etc/* $(SHAREDIR)
 	cp -a ignitions $(SHAREDIR)
 	cp README.md LICENSE $(DOCDIR)/neco

--- a/dctest/ignitions_test.go
+++ b/dctest/ignitions_test.go
@@ -2,6 +2,7 @@ package dctest
 
 import (
 	"bufio"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -87,5 +88,24 @@ func testIgnitions() {
 			cryptDev := parentDev(string(stdout))
 			Expect(cryptDev).To(Equal(i.diskDev))
 		}
+	})
+
+	It("should download Neco operation CLI commands on CS Node", func() {
+		By("getting CS Node IP address")
+		machines, err := getMachinesSpecifiedRole("cs")
+		Expect(err).NotTo(HaveOccurred())
+		csNodeIP := machines[0].Spec.IPv4[0]
+
+		By("checking /opt/neco-operation-cli/bin")
+		Eventually(func() error {
+			stdout, stderr, err := execAt(bootServers[0], "ckecli", "ssh", "cybozu@"+csNodeIP, "--", "ls", "/opt/neco-operation-cli/bin")
+			if err != nil {
+				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+			if len(stdout) == 0 {
+				return fmt.Errorf("/opt/neco-operation-cli/bin is empty on %s", csNodeIP)
+			}
+			return nil
+		}).Should(Succeed())
 	})
 }

--- a/dctest/ignitions_test.go
+++ b/dctest/ignitions_test.go
@@ -61,14 +61,12 @@ func parentDev(str string) string {
 
 // testIgnitions tests for ignitions functions.
 func testIgnitions() {
-	var ssNodeIP string
-	It("should get SS Node IP address", func() {
+	It("should create by-path based symlinks for encrypted devices on SS Node", func() {
+		By("getting SS Node IP address")
 		machines, err := getMachinesSpecifiedRole("ss")
 		Expect(err).NotTo(HaveOccurred())
-		ssNodeIP = machines[0].Spec.IPv4[0]
-	})
+		ssNodeIP := machines[0].Spec.IPv4[0]
 
-	It("should create by-path based symlinks for encrypted devices", func() {
 		By("checking the number of symlinks")
 		stdout, stderr, err := execAt(bootServers[0], "ckecli", "ssh", "cybozu@"+ssNodeIP, "--", "ls", "-l", "/sys/block/")
 		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)

--- a/ignitions/roles/cs/files/opt/sbin/update-neco-operation-cli
+++ b/ignitions/roles/cs/files/opt/sbin/update-neco-operation-cli
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+TOPDIR=/opt/neco-operation-cli
+ARCHIVE=neco-operation-cli.tgz
+
+mkdir -p ${TOPDIR}/bin
+
+for i in $(seq 20); do
+    if curl -sfSL --remote-time --time-cond ${TOPDIR}/${ARCHIVE} -o ${TOPDIR}/${ARCHIVE}.new {{ MyURL }}/api/v1/assets/${ARCHIVE}; then
+        break
+    fi
+    sleep 5
+done
+
+if [ ! -e ${TOPDIR}/${ARCHIVE}.new ]; then
+    exit
+fi
+
+mv ${TOPDIR}/${ARCHIVE}.new ${TOPDIR}/${ARCHIVE}
+
+rm -rf ${TOPDIR}/work
+mkdir -p ${TOPDIR}/work
+tar -x -f ${TOPDIR}/${ARCHIVE} -z -C ${TOPDIR}/work
+chown -R root:root ${TOPDIR}/work
+for f in $(ls ${TOPDIR}/work); do
+    mv ${TOPDIR}/work/$f ${TOPDIR}/bin/
+done

--- a/ignitions/roles/cs/site.yml
+++ b/ignitions/roles/cs/site.yml
@@ -1,1 +1,7 @@
 include: ../../common/common.yml
+files:
+  - /opt/sbin/update-neco-operation-cli
+systemd:
+  - name: update-neco-operation-cli.service
+  - name: update-neco-operation-cli.timer
+    enabled: true

--- a/ignitions/roles/cs/systemd/update-neco-operation-cli.service
+++ b/ignitions/roles/cs/systemd/update-neco-operation-cli.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Update Neco operation CLI commands
+
+[Service]
+Type=oneshot
+ExecStart=/opt/sbin/update-neco-operation-cli

--- a/ignitions/roles/cs/systemd/update-neco-operation-cli.timer
+++ b/ignitions/roles/cs/systemd/update-neco-operation-cli.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Update Neco operation CLI commands periodically
+Wants=network-online.target
+After=network-online.target
+
+[Timer]
+OnActiveSec=0
+OnUnitActiveSec=1 day
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit enables distribution of Neco operation CLI commands
via Sabakan to worker nodes.
The distributed commands are to be used by Teleport node Pods.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>