### PR TITLE
enable cpu pinning

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -132,6 +132,9 @@ options:
       cgroupDriver: systemd
       containerLogMaxSize: 10Mi
       containerLogMaxFiles: 10
+      cpuManagerPolicy: static
+      systemReserved:
+        cpu: "1"
       featureGates:
         EphemeralContainers: true
         MixedProtocolLBService: true

--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -129,6 +129,8 @@ systemd:
   - name: chrony-monitor.service
   - name: chrony-monitor.timer
     enabled: true
+  - name: remove-kubelet-state.service
+    enabled: true
 networkd:
   - 01-eth0.network
   - 01-eth1.network

--- a/ignitions/common/systemd/remove-kubelet-state.service
+++ b/ignitions/common/systemd/remove-kubelet-state.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Remove kubelet state files
+After=local-fs.target
+# Because kubelet run on docker, remove-kubelet-state.service starts before docker.service
+Before=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+ExecStart=/bin/rm -f /var/lib/kubelet/memory_manager_state
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1684

- change CPU manager policy to `static`
- reserve some CPUs for system
- remove kubelet state files before it starts

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>