### PR TITLE
Update cilium to 1.11.3

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -15,9 +15,9 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.10.1", Private: true},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "5.4.1.1", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.8.2.1", Private: false},
-		{Name: "cilium", Repository: "quay.io/cybozu/cilium", Tag: "1.11.2.2", Private: false},
-		{Name: "cilium-operator-generic", Repository: "quay.io/cybozu/cilium-operator-generic", Tag: "1.11.2.1", Private: false},
-		{Name: "hubble-relay", Repository: "quay.io/cybozu/hubble-relay", Tag: "1.11.2.1", Private: false},
+		{Name: "cilium", Repository: "quay.io/cybozu/cilium", Tag: "1.11.3.1", Private: false},
+		{Name: "cilium-operator-generic", Repository: "quay.io/cybozu/cilium-operator-generic", Tag: "1.11.3.1", Private: false},
+		{Name: "hubble-relay", Repository: "quay.io/cybozu/hubble-relay", Tag: "1.11.3.1", Private: false},
 		{Name: "cilium-certgen", Repository: "quay.io/cybozu/cilium-certgen", Tag: "0.1.5.1", Private: false},
 	},
 	Debs: []DebianPackage{

--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,3 +1,6 @@
 osImage:
 - channel: stable
   versions: ["2905.2.0", "2905.2.1"]
+images:
+  - repository: quay.io/cybozu/cilium-certgen
+    versions: ["0.1.8.1"]

--- a/cilium/upstream.yaml
+++ b/cilium/upstream.yaml
@@ -187,7 +187,7 @@ data:
   enable-health-checking: "true"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"
-  policy-audit-mode: "true"
+  policy-audit-mode: "false"
   operator-api-serve-addr: "127.0.0.1:9234"
   # Enable Hubble gRPC service.
   enable-hubble: "true"
@@ -593,7 +593,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4"
+        cilium.io/cilium-configmap-checksum: "bd8df9a51a7545c71869e89e2c8f3615ee5ae2aac6ad558d3099a95dce718e04"
         # This annotation plus the CriticalAddonsOnly toleration makes
         # cilium to be a critical pod in the cluster, which ensures cilium
         # gets priority scheduling.
@@ -915,7 +915,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4"
+        cilium.io/cilium-configmap-checksum: "bd8df9a51a7545c71869e89e2c8f3615ee5ae2aac6ad558d3099a95dce718e04"
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/upstream.yaml
+++ b/cilium/upstream.yaml
@@ -275,18 +275,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list
@@ -631,7 +627,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cilium-agent
-        image: "quay.io/cybozu/cilium:1.11.2.2"
+        image: "quay.io/cybozu/cilium:1.11.3.1"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -760,7 +756,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "quay.io/cybozu/cilium:1.11.2.2"
+        image: "quay.io/cybozu/cilium:1.11.3.1"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -787,7 +783,7 @@ spec:
         securityContext:
           privileged: true
       - name: clean-cilium-state
-        image: "quay.io/cybozu/cilium:1.11.2.2"
+        image: "quay.io/cybozu/cilium:1.11.3.1"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -940,7 +936,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cilium-operator
-        image: quay.io/cybozu/cilium-operator-generic:1.11.2.1
+        image: quay.io/cybozu/cilium-operator-generic:1.11.3.1
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1036,7 +1032,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: hubble-relay
-          image: "quay.io/cybozu/hubble-relay:1.11.2.1"
+          image: "quay.io/cybozu/hubble-relay:1.11.3.1"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay

--- a/cilium/values.yaml
+++ b/cilium/values.yaml
@@ -7,7 +7,7 @@ tunnel: "disabled"
 enableIPv4Masquerade: false
 enableIdentityMark: false
 policyEnforcementMode: "default"
-policyAuditMode: true
+policyAuditMode: false
 kubeProxyReplacement: "disabled"
 prometheus:
   enabled: true

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -114,18 +114,14 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
   - pods/finalizers
   verbs:
-  - get
-  - list
-  - watch
   - update
-  - delete
 - apiGroups:
   - ""
   resources:
   - nodes
+  - pods
   verbs:
   - get
   - list
@@ -537,7 +533,7 @@ spec:
               key: debug
               name: cilium-config
               optional: true
-        image: quay.io/cybozu/cilium-operator-generic:1.11.2.1
+        image: quay.io/cybozu/cilium-operator-generic:1.11.3.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -613,7 +609,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cybozu/hubble-relay:1.11.2.1
+        image: quay.io/cybozu/hubble-relay:1.11.3.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:
@@ -805,7 +801,7 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: quay.io/cybozu/cilium:1.11.2.2
+        image: quay.io/cybozu/cilium:1.11.3.1
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -914,7 +910,7 @@ spec:
           value: /run/cilium/cgroupv2
         - name: BIN_PATH
           value: /opt/cni/bin
-        image: quay.io/cybozu/cilium:1.11.2.2
+        image: quay.io/cybozu/cilium:1.11.3.1
         imagePullPolicy: IfNotPresent
         name: mount-cgroup
         securityContext:
@@ -939,7 +935,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cybozu/cilium:1.11.2.2
+        image: quay.io/cybozu/cilium:1.11.3.1
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -390,7 +390,7 @@ data:
   node-port-bind-protection: "true"
   operator-api-serve-addr: 127.0.0.1:9234
   operator-prometheus-serve-addr: :6942
-  policy-audit-mode: "true"
+  policy-audit-mode: "false"
   preallocate-bpf-maps: "false"
   prometheus-serve-addr: :9090
   proxy-prometheus-port: "9095"
@@ -493,7 +493,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4
+        cilium.io/cilium-configmap-checksum: bd8df9a51a7545c71869e89e2c8f3615ee5ae2aac6ad558d3099a95dce718e04
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -741,7 +741,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: a65df20fd48e52f6cdb115f9551d890f7c829e1003a463956c95349f11ac74d4
+        cilium.io/cilium-configmap-checksum: bd8df9a51a7545c71869e89e2c8f3615ee5ae2aac6ad558d3099a95dce718e04
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ""


### PR DESCRIPTION
This PR includes
- Update cilium to 1.11.3
- Set PolicyAuditMode false

Cilium v1.11.3 helm chart hasn't supported certgen v0.1.8. So ignore it for now.