### PR TITLE
Add crypt-vdc to udev rule

### DIFF
--- a/dctest/ignitions_test.go
+++ b/dctest/ignitions_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	systemDiskCount = 2
+	systemDiskCount = 3
 
 	cryptDiskDir = "/dev/crypt-disk/by-path/"
 )

--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -79,7 +79,9 @@ find_boss() {
 
 if ls /dev/mapper/crypt-vd* >/dev/null 2>&1; then
     # for qemu
-    PVS=$(ls /dev/mapper/crypt-vd[abcd])
+    # Modify 99-neco.rules as well if you change this line
+    # See https://github.com/cybozu-go/neco/blob/cf1fbc99aeb62d37e37c5c2c69f12e319622b6cd/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules#L4
+    PVS=$(ls /dev/mapper/crypt-vd[abc])
     prepare_lv
 elif ls /dev/mapper/crypt-nvme* >/dev/null 2>&1; then
     # for compute node

--- a/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules
+++ b/ignitions/roles/ss/files/etc/udev/rules.d/99-neco.rules
@@ -1,7 +1,7 @@
 KERNEL!="dm-*", GOTO="neco_end"
 ENV{DM_NAME}!="crypt-*", GOTO="neco_end"
 # Skip the qemu's system disks
-ENV{DM_NAME}=="crypt-vda|crypt-vdb", GOTO="neco_end"
+ENV{DM_NAME}=="crypt-vda|crypt-vdb|crypt-vdc", GOTO="neco_end"
 
 IMPORT{program}="/etc/udev/crypt-base-path $name $env{DM_UUID}", SYMLINK+="crypt-disk/by-path/$env{CRYPT_BASE_PATH}"
 


### PR DESCRIPTION
Confirmed that neco-apps reboot suite(make dctest-reboot SUITE=prepare) has passed in my environment.

FYI, bootstrap-with-neco-branch has also passsed.
https://app.circleci.com/pipelines/github/cybozu-go/neco-apps/9829/workflows/c3c9f2d5-b7e6-4f54-996f-037c23ddc88f/jobs/33230