### PR TITLE
Check auto-generated files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
       - checkout
       - run: time make SUDO="" setup
-      - run: time make check-coil-version
+      - run: time make check-generate
       - run: time make test
       - setup-tools
       - run: time make deb SUDO="" FAKEROOT=

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,12 @@ test:
 	RUN_COMPACTION_TEST=yes go test -tags='$(GOTAGS)' -race -v -run=TestEtcdCompaction ./worker/
 	go vet -tags='$(GOTAGS)' ./...
 
-.PHONY: check-coil-version
-check-coil-version:
-	grep -F $(COIL_VERSION) etc/coil.yaml
+.PHONY: check-generate
+check-generate:
+	$(MAKE) update-coil
+	$(MAKE) update-cilium
+	go mod tidy
+	git diff --exit-code --name-only
 
 .PHONY: deb
 deb: $(DEB)

--- a/cilium/upstream.yaml
+++ b/cilium/upstream.yaml
@@ -1141,7 +1141,7 @@ spec:
   ttlSecondsAfterFinished: 1800
 ---
 # Source: cilium/templates/hubble/tls-cronjob/cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hubble-generate-certs

--- a/coil/kustomization.yaml
+++ b/coil/kustomization.yaml
@@ -4,3 +4,16 @@ resources:
   - ../v2
 patchesStrategicMerge:
   - daemonset.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: coil-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/tolerations/-
+        value:
+          effect: NoExecute
+          key: node.cybozu.io/cluster-not-ready
+          operator: Exists

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -672,7 +672,7 @@ spec:
                 path: server.key
               name: hubble-relay-server-certs
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/etc/coil.yaml
+++ b/etc/coil.yaml
@@ -8046,8 +8046,8 @@ spec:
         key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
-      - key: node.cybozu.io/cluster-not-ready
-        effect: NoExecute
+      - effect: NoExecute
+        key: node.cybozu.io/cluster-not-ready
         operator: Exists
       volumes:
       - name: cert


### PR DESCRIPTION
Check auto-generated files in CI. And re-generate manifests.

1. The API version of CronJob in cillium manifests are changed from `batch/v1beta1` to `batch/v1` with the upgrade of the helm command.
The API version is changed by the build-in parameter  (`.Capabilities.KubeVersion.Version`) of the helm command.
https://github.com/cilium/cilium/blob/v1.11.4/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml#L2
https://github.com/cilium/cilium/blob/v1.11.4/install/kubernetes/cilium/templates/_helpers.tpl#L83-L92

2. The coil manifest may be updated manually in the following PR. So I update the source file.
https://github.com/cybozu-go/neco/pull/1980.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>