### PR TITLE
Use policy/v1 PodDisruptionBudget

### DIFF
--- a/dctest/squid_test.go
+++ b/dctest/squid_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 // testSquid test installed squid
@@ -34,7 +34,7 @@ func testSquid() {
 			return nil
 		}).Should(Succeed())
 		By("checking PodDisruptionBudget for squid Deployment")
-		pdb := policyv1beta1.PodDisruptionBudget{}
+		pdb := policyv1.PodDisruptionBudget{}
 		stdout, stderr, err := execAt(bootServers[0], "kubectl", "get", "poddisruptionbudgets", "squid-pdb", "-n", "internet-egress", "-o", "json")
 		if err != nil {
 			Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)

--- a/dctest/unbound_test.go
+++ b/dctest/unbound_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 // testUnbound test installed unbound
@@ -33,7 +33,7 @@ func testUnbound() {
 			return nil
 		}).Should(Succeed())
 		By("checking PodDisruptionBudget for unbound Deployment")
-		pdb := policyv1beta1.PodDisruptionBudget{}
+		pdb := policyv1.PodDisruptionBudget{}
 		stdout, stderr, err := execAt(bootServers[0], "kubectl", "get", "poddisruptionbudgets", "unbound-pdb", "-n", "internet-egress", "-o", "json")
 		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 		err = json.Unmarshal(stdout, &pdb)

--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -314,7 +314,7 @@ spec:
       port: 3128
       targetPort: 3128
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: squid-pdb

--- a/etc/unbound.yml
+++ b/etc/unbound.yml
@@ -256,7 +256,7 @@ spec:
       targetPort: 1053
       protocol: TCP
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: unbound-pdb


### PR DESCRIPTION
The policy/v1beta1 PodDisruptionBudget is deprecated. So I use `policy/v1`.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>