### PR TITLE
enable Topology Manager

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -12,7 +12,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "promtail", Repository: "quay.io/cybozu/promtail", Tag: "2.3.0.1", Private: false},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.12.0", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.9.7.1", Private: false},
-		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.11.0", Private: true},
+		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.12.0", Private: true},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "5.4.1.1", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.8.2.1", Private: false},
 		{Name: "cilium", Repository: "quay.io/cybozu/cilium", Tag: "1.11.3.1", Private: false},

--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -133,6 +133,7 @@ options:
       containerLogMaxSize: 10Mi
       containerLogMaxFiles: 10
       cpuManagerPolicy: static
+      topologyManagerPolicy: best-effort
       systemReserved:
         cpu: "1"
       featureGates:


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/1684

enable Topology Manager and die-aware CPU pinning.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>