### PR TITLE
Promtail v2.5.0

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -9,7 +9,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "bird", Repository: "quay.io/cybozu/bird", Tag: "2.0.9.1", Private: false},
 		{Name: "chrony", Repository: "quay.io/cybozu/chrony", Tag: "4.2.0.1", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.5.4.1", Private: false},
-		{Name: "promtail", Repository: "quay.io/cybozu/promtail", Tag: "2.3.0.1", Private: false},
+		{Name: "promtail", Repository: "quay.io/cybozu/promtail", Tag: "2.5.0.1", Private: false},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.13.0", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.9.7.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.12.0", Private: true},

--- a/progs/promtail/promtail.yaml.tmpl
+++ b/progs/promtail/promtail.yaml.tmpl
@@ -2,8 +2,8 @@ server:
   log_level: info
   http_listen_port: 3101
 
-client:
-  url: http://distributor.logging.svc:3100/loki/api/v1/push
+clients:
+  - url: http://distributor.logging.svc:3100/loki/api/v1/push
 
 positions:
   filename: /run/promtail/positions.yaml


### PR DESCRIPTION
Update promtail to v2.5.0.

I change the `clients` config instead of the `client` config, in addition to updating the image.
The `client` config seems to be deprecated.

https://github.com/grafana/loki/blob/v2.5.0/clients/pkg/promtail/config/config.go#L22-L24
https://github.com/grafana/loki/pull/536

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>