### PR TITLE
Add script for watch podlogs without via GCP

### DIFF
--- a/bin/watch_podlogs_directly
+++ b/bin/watch_podlogs_directly
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+tail_once() {
+    host="$1"
+    sudo ip netns exec operation ssh -F ssh_config \
+        ${host} "test -f .kube/config" || return
+    sudo ip netns exec operation ssh -F ssh_config \
+        ${host} -- stern --all-namespaces '.*'
+}
+
+tail_forever() {
+    host="$1"
+
+    while true; do
+        tail_once $host || continue
+        sleep 3
+    done
+}
+
+chmod 600 ./dctest/dctest_key
+cp ./dctest/dctest_key .
+cp ./dctest/ssh_config .
+
+tail_forever boot-0


### PR DESCRIPTION
Currently, there is a script `bin/watch_podlogs` that outputs logs of pods in a cluster via GCP. 
However, I wanted a script that directly outputs logs of pods in a cluster without via GCP, so I created a new script.

Signed-off-by: kouki <kouworld0123@gmail.com>