### PR TITLE
Add some CLI to neco-operation-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ OP_MAC_ZIP = neco-operation-cli-mac_$(VERSION)_amd64.zip
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker
-OPDEB_BINNAMES = argocd kubectl kubeseal logcli stern tsh kubectl-moco kubectl-accurate amtool yq
-OPDEB_DOCNAMES = argocd kubectl kubeseal logcli stern teleport moco alertmanager yq
+OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt kubectl kubeseal logcli stern tsh kubectl-moco kubectl-accurate amtool yq
+OPDEB_DOCNAMES = argocd hubble jsonnet kubectl kubeseal logcli stern teleport moco accurate alertmanager yq
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ OP_MAC_ZIP = neco-operation-cli-mac_$(VERSION)_amd64.zip
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker
-OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt kubectl kubeseal logcli stern tsh kubectl-moco kubectl-accurate amtool yq
-OPDEB_DOCNAMES = argocd hubble jsonnet kubectl kubeseal logcli stern teleport moco accurate alertmanager yq
+OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq
+OPDEB_DOCNAMES = argocd hubble jsonnet kubectl kubeseal kustomize logcli stern teleport moco accurate alertmanager yq
 
 .PHONY: all
 all:

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -164,7 +164,7 @@ $(KUBECTL_DOWNLOAD):
 	mkdir -p $(KUBECTL_DLDIR)
 	$(WGET) -O $(KUBECTL_DLDIR)/kubectl-linux-amd64 https://storage.googleapis.com/kubernetes-release/release/v$(K8S_VERSION)/bin/linux/amd64/kubectl
 	$(WGET) -O $(KUBECTL_DLDIR)/kubectl.exe https://storage.googleapis.com/kubernetes-release/release/v$(K8S_VERSION)/bin/windows/amd64/kubectl.exe
-	$(WGET) -O $(KUBECTL_DLDIR)/kubect-darwin-amd64 https://storage.googleapis.com/kubernetes-release/release/v$(K8S_VERSION)/bin/darwin/amd64/kubectl
+	$(WGET) -O $(KUBECTL_DLDIR)/kubectl-darwin-amd64 https://storage.googleapis.com/kubernetes-release/release/v$(K8S_VERSION)/bin/darwin/amd64/kubectl
 	$(WGET_GITHUB) -O $(KUBECTL_DLDIR)/LICENSE   https://raw.githubusercontent.com/kubernetes/kubernetes/v$(K8S_VERSION)/LICENSE
 	$(WGET_GITHUB) -O $(KUBECTL_DLDIR)/README.md https://raw.githubusercontent.com/kubernetes/kubernetes/v$(K8S_VERSION)/README.md
 	touch $@
@@ -179,7 +179,7 @@ kubectl: $(KUBECTL_DOWNLOAD)
 	cp $(KUBECTL_DLDIR)/kubectl.exe $(WINDOWS_BINDIR)/kubectl.exe
 	cp $(KUBECTL_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 	cp $(KUBECTL_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
-	cp $(KUBECTL_DLDIR)/kubect-darwin-amd64 $(MAC_BINDIR)/kubectl
+	cp $(KUBECTL_DLDIR)/kubectl-darwin-amd64 $(MAC_BINDIR)/kubectl
 	chmod +x $(MAC_BINDIR)/kubectl
 	cp $(KUBECTL_DLDIR)/LICENSE $(MAC_DOCDIR)/$@/LICENSE
 	cp $(KUBECTL_DLDIR)/README.md $(MAC_DOCDIR)/$@/README.md
@@ -254,8 +254,9 @@ $(JSONNET_DOWNLOAD):
 jsonnet: $(JSONNET_DOWNLOAD)
 	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/ $(MAC_BINDIR) $(MAC_DOCDIR)/$@/
 	cp $(JSONNET_DLDIR)/linux_amd64/jsonnet $(BINDIR)/jsonnet
-	cp $(JSONNET_DLDIR)/linux_amd64/jsonnetfmt $(BINDIR)/jsonnet
+	cp $(JSONNET_DLDIR)/linux_amd64/jsonnetfmt $(BINDIR)/jsonnetfmt
 	chmod +x $(BINDIR)/jsonnet
+	chmod +x $(BINDIR)/jsonnetfmt
 	cp $(JSONNET_DLDIR)/linux_amd64/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(JSONNET_DLDIR)/README.md $(DOCDIR)/$@/README.md
 	cp $(JSONNET_DLDIR)/windows_amd64/jsonnet.exe $(WINDOWS_BINDIR)/jsonnet.exe
@@ -450,16 +451,10 @@ $(CILIUM_CLI_DOWNLOAD):
 
 .PHONY: cilium-cli
 cilium-cli: $(CILIUM_CLI_DOWNLOAD)
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/ $(MAC_BINDIR) $(MAC_DOCDIR)/$@/
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/
 	tar xzf $(CILIUM_CLI_DLDIR)/cilium-linux-amd64.tar.gz -C $(BINDIR) cilium
-	tar xzf $(CILIUM_CLI_DLDIR)/cilium-windows-amd64.tar.gz -C $(WINDOWS_BINDIR) cilium.exe
-	tar xzf $(CILIUM_CLI_DLDIR)/cilium-darwin-amd64.tar.gz  -C $(MAC_BINDIR) cilium
 	cp $(CILIUM_CLI_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
-	cp $(CILIUM_CLI_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
-	cp $(CILIUM_CLI_DLDIR)/LICENSE $(MAC_DOCDIR)/$@/LICENSE
 	cp $(CILIUM_CLI_DLDIR)/README.md $(DOCDIR)/$@/README.md
-	cp $(CILIUM_CLI_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
-	cp $(CILIUM_CLI_DLDIR)/README.md $(MAC_DOCDIR)/$@/README.md
 
 $(HUBBLE_DOWNLOAD):
 	mkdir -p $(HUBBLE_DLDIR)

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -229,18 +229,28 @@ stern: $(STERN_DOWNLOAD)
 	cp $(STERN_DLDIR)/README.md $(MAC_DOCDIR)/$@/README.md
 
 $(KUSTOMIZE_DOWNLOAD):
-	mkdir -p $(KUSTOMIZE_DLDIR)
-	$(WGET_GITHUB) -O $(KUSTOMIZE_DLDIR)/kustomize-linux-amd64.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz
+	mkdir -p $(KUSTOMIZE_DLDIR)/linux_amd64 $(KUSTOMIZE_DLDIR)/windows_amd64 $(KUSTOMIZE_DLDIR)/darwin_amd64
+	$(WGET_GITHUB) -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz | tar xvzf - -C $(KUSTOMIZE_DLDIR)/linux_amd64
+	$(WGET_GITHUB) -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_windows_amd64.tar.gz | tar xvzf - -C $(KUSTOMIZE_DLDIR)/windows_amd64
+	$(WGET_GITHUB) -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_darwin_amd64.tar.gz | tar xvzf - -C $(KUSTOMIZE_DLDIR)/darwin_amd64
 	$(WGET_GITHUB) -O $(KUSTOMIZE_DLDIR)/LICENSE   https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v${KUSTOMIZE_VERSION}/LICENSE
 	$(WGET_GITHUB) -O $(KUSTOMIZE_DLDIR)/README.md https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v${KUSTOMIZE_VERSION}/README.md
 	touch $@
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE_DOWNLOAD)
-	mkdir -p $(BINDIR) $(DOCDIR)/$@/
-	tar xzf $(KUSTOMIZE_DLDIR)/kustomize-linux-amd64.tar.gz -C $(BINDIR)
+	mkdir -p $(BINDIR) $(DOCDIR)/$@/ $(WINDOWS_BINDIR) $(WINDOWS_DOCDIR)/$@/ $(MAC_BINDIR) $(MAC_DOCDIR)/$@/
+	cp $(KUSTOMIZE_DLDIR)/linux_amd64/kustomize $(BINDIR)/kustomize
+	chmod +x $(BINDIR)/kustomize
 	cp $(KUSTOMIZE_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
 	cp $(KUSTOMIZE_DLDIR)/README.md $(DOCDIR)/$@/README.md
+	cp $(KUSTOMIZE_DLDIR)/windows_amd64/kustomize.exe $(WINDOWS_BINDIR)/kustomize.exe
+	cp $(KUSTOMIZE_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
+	cp $(KUSTOMIZE_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
+	cp $(KUSTOMIZE_DLDIR)/darwin_amd64/kustomize $(MAC_BINDIR)/kustomize
+	chmod +x $(MAC_BINDIR)/kustomize
+	cp $(KUSTOMIZE_DLDIR)/LICENSE $(MAC_DOCDIR)/$@/LICENSE
+	cp $(KUSTOMIZE_DLDIR)/README.md $(MAC_DOCDIR)/$@/README.md
 
 $(JSONNET_DOWNLOAD):
 	mkdir -p $(JSONNET_DLDIR)/linux_amd64 $(JSONNET_DLDIR)/windows_amd64 $(JSONNET_DLDIR)/darwin_amd64


### PR DESCRIPTION
Add hubble, jsonnet, jsonnetfmt and kustomize to neco-operation-cli.
Remove cillium-cli from neco-operation-cli.

Signed-off-by: kouki <kouworld0123@gmail.com>