### PR TITLE
node-distribute internet-egress Pods

### DIFF
--- a/etc/squid.yml
+++ b/etc/squid.yml
@@ -191,6 +191,14 @@ spec:
           - 127.0.0.1
       affinity:
         podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - squid
+            topologyKey: "kubernetes.io/hostname"
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:

--- a/etc/unbound.yml
+++ b/etc/unbound.yml
@@ -171,6 +171,14 @@ spec:
           operator: Exists
       affinity:
         podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - unbound
+            topologyKey: "kubernetes.io/hostname"
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/2036

The original manifest has soft inter-rack distribution. However, multiple replicas can run on same node and their eviction will fail due to its corresponding PDB. Hard inter-node distribution should be configured.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>