### PR TITLE
Revert "enable xdp acceleration"

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -191,7 +191,7 @@ data:
   enable-auto-protect-node-port-range: "true"
   bpf-lb-mode: "dsr"
   bpf-lb-algorithm: "maglev"
-  bpf-lb-acceleration: "native"
+  bpf-lb-acceleration: "disabled"
   bpf-lb-maglev-hash-seed: "3HCx6JennjWtot2U"
   enable-session-affinity: "true"
   enable-l2-neigh-discovery: "true"
@@ -627,7 +627,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "cf4d09170c1d4fc1320468d792cf16975f351ebd24a2be9a450e626c63e319a9"
+        cilium.io/cilium-configmap-checksum: "27e2fa4fbcb9b18d162c6531b4bc8160031da83e4e99c6eab77f4cfd89d443de"
       labels:
         k8s-app: cilium
     spec:
@@ -958,7 +958,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "cf4d09170c1d4fc1320468d792cf16975f351ebd24a2be9a450e626c63e319a9"
+        cilium.io/cilium-configmap-checksum: "27e2fa4fbcb9b18d162c6531b4bc8160031da83e4e99c6eab77f4cfd89d443de"
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -44,7 +44,8 @@ k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"
 loadBalancer:
-  acceleration: native
+  # We can't enable XDP Acceleration because of the issue https://github.com/cilium/cilium/issues/19453
+  acceleration: disabled
   algorithm: maglev
   mode: dsr
 maglev:

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -354,7 +354,7 @@ data:
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"
-  bpf-lb-acceleration: native
+  bpf-lb-acceleration: disabled
   bpf-lb-algorithm: maglev
   bpf-lb-external-clusterip: "false"
   bpf-lb-maglev-hash-seed: 3HCx6JennjWtot2U
@@ -549,7 +549,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: cf4d09170c1d4fc1320468d792cf16975f351ebd24a2be9a450e626c63e319a9
+        cilium.io/cilium-configmap-checksum: 27e2fa4fbcb9b18d162c6531b4bc8160031da83e4e99c6eab77f4cfd89d443de
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -800,7 +800,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: cf4d09170c1d4fc1320468d792cf16975f351ebd24a2be9a450e626c63e319a9
+        cilium.io/cilium-configmap-checksum: 27e2fa4fbcb9b18d162c6531b4bc8160031da83e4e99c6eab77f4cfd89d443de
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
       labels:


### PR DESCRIPTION
Reverts cybozu-go/neco#2063. The XDP acceleration will be applied after the k8s upgrade is released to be on the safe side. Releasing both can make our trouble shooting harder.