### PR TITLE
Enable registry mirror

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -14,7 +14,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.9.7.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.12.0", Private: true},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "5.4.1.1", Private: false},
-		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.11.0.1", Private: false},
+		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.11.3.1", Private: false},
 		{Name: "cilium", Repository: "quay.io/cybozu/cilium", Tag: "1.11.6.2", Private: false},
 		{Name: "cilium-operator-generic", Repository: "quay.io/cybozu/cilium-operator-generic", Tag: "1.11.6.1", Private: false},
 		{Name: "hubble-relay", Repository: "quay.io/cybozu/hubble-relay", Tag: "1.11.6.1", Private: false},

--- a/ignition-template/settings.json
+++ b/ignition-template/settings.json
@@ -325,6 +325,7 @@
       "files": [
         "/etc/k8s-containerd/config.toml",
         "/etc/k8s-containerd/conf.d/ghcr.io/hosts.toml",
+        "/etc/k8s-containerd/conf.d/docker.elastic.co/hosts.toml",
         "/etc/k8s-containerd/conf.d/docker.io/hosts.toml",
         "/etc/k8s-containerd/conf.d/localhost:5050/hosts.toml",
         "/etc/k8s-containerd/conf.d/registry-local.registry.gcp0.dev-ne.co/hosts.toml"
@@ -335,6 +336,7 @@
       "files": [
         "/etc/k8s-containerd/config.toml",
         "/etc/k8s-containerd/conf.d/ghcr.io/hosts.toml",
+        "/etc/k8s-containerd/conf.d/docker.elastic.co/hosts.toml",
         "/etc/k8s-containerd/conf.d/docker.io/hosts.toml",
         "/etc/k8s-containerd/conf.d/localhost:5050/hosts.toml",
         "/etc/k8s-containerd/conf.d/registry-local.registry.stage0.cybozu-ne.co/hosts.toml"

--- a/ignitions/common/common-gcp0.yml
+++ b/ignitions/common/common-gcp0.yml
@@ -3,6 +3,7 @@ include: common.yml
 files:
   - /etc/k8s-containerd/config.toml
   - /etc/k8s-containerd/conf.d/ghcr.io/hosts.toml
+  - /etc/k8s-containerd/conf.d/docker.elastic.co/hosts.toml
   - /etc/k8s-containerd/conf.d/docker.io/hosts.toml
   - /etc/k8s-containerd/conf.d/localhost:5050/hosts.toml
   - /etc/k8s-containerd/conf.d/registry-local.registry.gcp0.dev-ne.co/hosts.toml

--- a/ignitions/common/common-stage0.yml
+++ b/ignitions/common/common-stage0.yml
@@ -3,6 +3,7 @@ include: common.yml
 files:
   - /etc/k8s-containerd/config.toml
   - /etc/k8s-containerd/conf.d/ghcr.io/hosts.toml
+  - /etc/k8s-containerd/conf.d/docker.elastic.co/hosts.toml
   - /etc/k8s-containerd/conf.d/docker.io/hosts.toml
   - /etc/k8s-containerd/conf.d/localhost:5050/hosts.toml
   - /etc/k8s-containerd/conf.d/registry-local.registry.stage0.cybozu-ne.co/hosts.toml

--- a/ignitions/common/files/etc/k8s-containerd/conf.d/docker.elastic.co/hosts.toml
+++ b/ignitions/common/files/etc/k8s-containerd/conf.d/docker.elastic.co/hosts.toml
@@ -1,0 +1,7 @@
+server = "https://docker.elastic.co"
+
+[host."http://registry-elastic.registry.svc:5000"]
+  capabilities = ["pull", "resolve"]
+
+[host."https://docker.elastic.co"]
+  capabilities = ["pull", "resolve"]


### PR DESCRIPTION
Add setting to enable docker.elastic.co registry mirror.
Signed-off-by: Taichi Takemura [taichi-takemura@cybozu.co.jp](mailto:taichi-takemura@cybozu.co.jp)