### PR TITLE
Increase rate of etcd auto-compaction on boot servers

### DIFF
--- a/progs/etcd/templates.go
+++ b/progs/etcd/templates.go
@@ -61,7 +61,7 @@ log-outputs: [stderr]
 
 # auto compaction
 auto-compaction-mode: periodic
-auto-compaction-retention: "24"
+auto-compaction-retention: "1"
 
 # detect inconsistencies
 # etcd 3.5.[0-2] has data inconsistency issue.


### PR DESCRIPTION
This mitigates the rapid increase of etcd's storage consumption
on the boot servers, which is caused by frequent DHCP requests
from unconfigured servers.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>