### PR TITLE
Ignore error in kill-old-login-sessions

### DIFF
--- a/debian/usr/sbin/kill-old-login-sessions
+++ b/debian/usr/sbin/kill-old-login-sessions
@@ -1,18 +1,16 @@
 #!/bin/sh -e
 
-limit=86400 # 1 day
+limit="1day"
 now=$(date +%s)
 
-sessions=$(loginctl list-sessions --no-legend | sed -e 's/^ *//g' | cut -f 1 -d ' ')
-for session in $sessions
-do
-  timestamp=$(loginctl show-session -p Timestamp --value $session)
-  target=$(date +%s --date "$timestamp")
-  diff=$(( $now - $target ))
-  if [ $diff -gt $limit ]; then
+sessions=$(loginctl list-sessions -o json | jq -r ".[].session")
+for session in $sessions; do
+  timestamp=$(loginctl show-session -p Timestamp --value $session) || continue
+  expirationtime=$(date +%s --date "$timestamp + $limit")
+  if [ $now -gt $expirationtime ]; then
     echo "kill session:"
-    loginctl show-session $session
+    loginctl show-session $session || continue
     echo
-    loginctl kill-session --signal 9 $session
+    loginctl kill-session --signal 9 $session || continue
   fi
 done


### PR DESCRIPTION
Sometimes, kill-old-login-sessions.service is failed with the following error.
It seems that a session may disappear immediately after listing session IDs.
This PR ignores the error.

```
$ journalctl -u kill-old-login-sessions.service
-- Logs begin at Wed 2022-09-14 23:08:01 UTC, end at Thu 2022-09-15 07:20:54 UTC. --
Sep 15 00:00:00 gcp0-boot-2 systemd[1]: Starting kill old login sessions...
Sep 15 00:00:01 gcp0-boot-2 kill-old-login-sessions[57632]: Failed to get session path: No session '42' known
Sep 15 00:00:01 gcp0-boot-2 systemd[1]: kill-old-login-sessions.service: Main process exited, code=exited, status=1/FAILURE
Sep 15 00:00:01 gcp0-boot-2 systemd[1]: kill-old-login-sessions.service: Failed with result 'exit-code'.
Sep 15 00:00:01 gcp0-boot-2 systemd[1]: Failed to start kill old login sessions.
```


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>