### PR TITLE
serf: Set broadcast timeout to one minute

### DIFF
--- a/dctest/before_test.go
+++ b/dctest/before_test.go
@@ -68,7 +68,7 @@ func runBeforeSuiteInstall() {
 		for _, host := range allBootServers {
 			_, _, err := execAt(host, "test -f /tmp/auto-config-done")
 			if err != nil {
-				return err
+				return fmt.Errorf("auto-config has not been completed. host: %s, err: %v", host, err)
 			}
 		}
 		return nil

--- a/ignitions/common/files/opt/sbin/setup-serf-conf
+++ b/ignitions/common/files/opt/sbin/setup-serf-conf
@@ -19,6 +19,7 @@ cat >/etc/serf/serf.json <<EOF
     "reconnect_interval": "30s",
     "reconnect_timeout": "24h",
     "tombstone_timeout": "24h",
+    "broadcast_timeout": "1m",
     "retry_join": [
       "${sabakan_addr}"
     ],

--- a/ignitions/common/systemd/setup-serf-tags.timer
+++ b/ignitions/common/systemd/setup-serf-tags.timer
@@ -4,7 +4,7 @@ Wants=serf.service
 After=serf.service
 
 [Timer]
-OnCalendar=*-*-* *:*:0/20
+OnCalendar=minutely
 
 [Install]
 WantedBy=multi-user.target

--- a/progs/serf/conf.go
+++ b/progs/serf/conf.go
@@ -32,6 +32,7 @@ func GenerateConf(w io.Writer, lrns []int, osName, osVersion, serial string) err
 		ReconnectInterval: "30s",
 		ReconnectTimeout:  "24h",
 		TombstoneTimeout:  "24h",
+		BroadcastTimeout:  "1m",
 		RetryJoin:         endpoints,
 		RetryMaxAttempts:  0,
 		RetryInterval:     "30s",

--- a/progs/serf/conf_test.go
+++ b/progs/serf/conf_test.go
@@ -30,6 +30,7 @@ func TestGenerateConf(t *testing.T) {
 		ReconnectInterval: "30s",
 		ReconnectTimeout:  "24h",
 		TombstoneTimeout:  "24h",
+		BroadcastTimeout:  "1m",
 		RetryJoin:         expectedRetryJoin,
 		RetryMaxAttempts:  0,
 		RetryInterval:     "30s",

--- a/progs/serf/templates.go
+++ b/progs/serf/templates.go
@@ -15,6 +15,7 @@ type serfConfig struct {
 	ReconnectInterval string   `json:"reconnect_interval"`
 	ReconnectTimeout  string   `json:"reconnect_timeout"`
 	TombstoneTimeout  string   `json:"tombstone_timeout"`
+	BroadcastTimeout  string   `json:"broadcast_timeout"`
 	RetryJoin         []string `json:"retry_join"`
 	RetryMaxAttempts  int      `json:"retry_max_attempts"`
 	RetryInterval     string   `json:"retry_interval"`

--- a/worker/setup_serf_tags.go
+++ b/worker/setup_serf_tags.go
@@ -33,7 +33,7 @@ Wants=serf.service
 After=serf.service
 
 [Timer]
-OnCalendar=*-*-* *:*:0/20
+OnCalendar=minutely
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Serf fails to update tags without a longer broadcast timeout in a large cluster.
https://github.com/hashicorp/consul/issues/8435

This PR extends the timeout to one minute.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>