### PR TITLE
Extend CT lifetimes for non-TCP

### DIFF
--- a/cilium/pre/configmap.yaml
+++ b/cilium/pre/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  bpf-ct-timeout-regular-any: 1h0m0s
+  bpf-ct-timeout-service-any: 1h0m0s

--- a/cilium/pre/kustomization.yaml
+++ b/cilium/pre/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../base
   - bgp_config.yaml
   - upstream.yaml
+patchesStrategicMerge:
+  - configmap.yaml

--- a/cilium/prod/configmap.yaml
+++ b/cilium/prod/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cilium-config
+  namespace: kube-system
+data:
+  bpf-ct-timeout-regular-any: 1h0m0s
+  bpf-ct-timeout-service-any: 1h0m0s

--- a/cilium/prod/kustomization.yaml
+++ b/cilium/prod/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../base
   - bgp_config.yaml
   - upstream.yaml
+patchesStrategicMerge:
+  - configmap.yaml

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -354,6 +354,8 @@ data:
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"
+  bpf-ct-timeout-regular-any: 1h0m0s
+  bpf-ct-timeout-service-any: 1h0m0s
   bpf-lb-acceleration: disabled
   bpf-lb-algorithm: maglev
   bpf-lb-external-clusterip: "false"

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -354,6 +354,8 @@ data:
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"
+  bpf-ct-timeout-regular-any: 1h0m0s
+  bpf-ct-timeout-service-any: 1h0m0s
   bpf-lb-acceleration: disabled
   bpf-lb-algorithm: maglev
   bpf-lb-external-clusterip: "false"


### PR DESCRIPTION
This PR extends CT lifetimes for non-tcp connections to fix an issue that long-life connections through coil-egress nat are disrupted. 

It seems that Cilium helm chart doesn't support bpf-ct-timeout-*, so I patched the cilium-config cm generated with `helm template` instead. We need to restart cilium-agent manually because the check-sum in the cilium ds manifest is not modified.