### PR TITLE
dctest: dcssh: pass identify file path via command line option

### DIFF
--- a/dctest/dcscp
+++ b/dctest/dcscp
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 SUDO=$(which sudo)
-CURRENT_DIR=$(cd $(dirname $0);pwd)
-chmod 600 "$CURRENT_DIR"/dctest_key
-${SUDO} ip netns exec operation scp -F ${CURRENT_DIR}/ssh_config $@
+SCRIPT_DIR=$(cd $(dirname $0);pwd)
+SSH_CONFIG=${SCRIPT_DIR}/ssh_config
+IDENTITY_FILE=${SCRIPT_DIR}/dctest_key
+
+chmod 600 ${IDENTITY_FILE}
+${SUDO} ip netns exec operation scp -F ${SSH_CONFIG} -i ${IDENTITY_FILE} $@

--- a/dctest/dcssh
+++ b/dctest/dcssh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 SUDO=$(which sudo)
-CURRENT_DIR=$(cd $(dirname $0);pwd)
-chmod 600 "$CURRENT_DIR"/dctest_key
-${SUDO} ip netns exec operation ssh -F ${CURRENT_DIR}/ssh_config $@
+SCRIPT_DIR=$(cd $(dirname $0);pwd)
+SSH_CONFIG=${SCRIPT_DIR}/ssh_config
+IDENTITY_FILE=${SCRIPT_DIR}/dctest_key
+
+chmod 600 ${IDENTITY_FILE}
+${SUDO} ip netns exec operation ssh -F ${SSH_CONFIG} -i ${IDENTITY_FILE} $@


### PR DESCRIPTION
We cannot use `dcssh` and `dcscp` unless the current working directory is `/path/to/neco/dctest` since the ssh config that these tools use requires the identity file `dctest_key` exists in the current working directory. This commit changes `dcssh` and `dcscp` to pass the absolute path of `dctest_key` to an inner ssh command so that these scripts can be run from everywhere.