### PR TITLE
Update Ubuntu from 20.04 to 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ The virtual data center implements the aforementioned leaf-spine networks with B
 To create the virtual data center, run the following commands on Ubuntu 22.04:
 
 ```console
-$ wget -O - https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
+$ curl -o /etc/apt/keyrings/docker-key.asc -fsSL https://download.docker.com/linux/ubuntu/gpg 
+$ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker-key.asc] https://download.docker.com/linux/ubuntu jammy stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 $ sudo apt update
 $ sudo apt install -y build-essential systemd-container lldpd qemu qemu-kvm socat picocom swtpm cloud-utils bird2 squid chrony dnsmasq jq freeipmi-tools unzip skopeo fakeroot docker-ce docker-ce-cli containerd.io
 $ wget https://github.com/qemu/qemu/raw/master/pc-bios/bios.bin

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Since Neco is the system to bootstrap and maintain an on-premise data center, th
 To simulate an on-premise data center, we have created [placemat][], a tool to construct a virtual data center using containers, virtual machines and Linux network stacks.
 
 The virtual data center implements the aforementioned leaf-spine networks with BGP routers.
-To create the virtual data center, run the following commands on Ubuntu 20.04:
+To create the virtual data center, run the following commands on Ubuntu 22.04:
 
 ```console
 $ wget -O - https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -161,7 +161,7 @@ $ make test
 - To login a boot server in the virtual data center, run `./dcssh boot-0`.
 - To stop and delete the virtual data center, run `make stop`.
 
-The setup commands above are examined on a GCP VM based on the Ubuntu 20.04 disk image.
+The setup commands above are examined on a GCP VM based on the Ubuntu 22.04 disk image.
 Some more setup steps are needed for the GCP environment.
 
 - [Enable nested virtualization by creating a custom image](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances).

--- a/README.md
+++ b/README.md
@@ -142,18 +142,15 @@ The virtual data center implements the aforementioned leaf-spine networks with B
 To create the virtual data center, run the following commands on Ubuntu 20.04:
 
 ```console
-$ sudo add-apt-repository ppa:smoser/swtpm
-$ echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-$ curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg > /dev/null
 $ wget -O - https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
+$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
 $ sudo apt update
 $ sudo apt install -y build-essential systemd-container lldpd qemu qemu-kvm socat picocom swtpm cloud-utils bird2 squid chrony dnsmasq jq freeipmi-tools unzip skopeo fakeroot docker-ce docker-ce-cli containerd.io
 $ wget https://github.com/qemu/qemu/raw/master/pc-bios/bios.bin
 $ wget https://github.com/qemu/qemu/raw/master/pc-bios/bios-256k.bin
 $ sudo install -m 0644 -b bios.bin bios-256k.bin /usr/share/seabios/
-$ wget https://github.com/cybozu-go/placemat/releases/download/v2.2.0/placemat2_2.2.0_amd64.deb
-$ sudo dpkg -i ./placemat2_2.2.0_amd64.deb
+$ wget https://github.com/cybozu-go/placemat/releases/download/v2.3.1/placemat2_2.3.1_amd64.deb
+$ sudo dpkg -i ./placemat2_2.3.1_amd64.deb
 $ git clone https://github.com/cybozu-go/neco
 $ cd neco/dctest
 $ make setup

--- a/README.md
+++ b/README.md
@@ -142,15 +142,15 @@ The virtual data center implements the aforementioned leaf-spine networks with B
 To create the virtual data center, run the following commands on Ubuntu 22.04:
 
 ```console
-$ curl -o /etc/apt/keyrings/docker-key.asc -fsSL https://download.docker.com/linux/ubuntu/gpg 
+$ sudo curl -o /etc/apt/keyrings/docker-key.asc -fsSL https://download.docker.com/linux/ubuntu/gpg 
 $ echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker-key.asc] https://download.docker.com/linux/ubuntu jammy stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 $ sudo apt update
 $ sudo apt install -y build-essential systemd-container lldpd qemu qemu-kvm socat picocom swtpm cloud-utils bird2 squid chrony dnsmasq jq freeipmi-tools unzip skopeo fakeroot docker-ce docker-ce-cli containerd.io
 $ wget https://github.com/qemu/qemu/raw/master/pc-bios/bios.bin
 $ wget https://github.com/qemu/qemu/raw/master/pc-bios/bios-256k.bin
 $ sudo install -m 0644 -b bios.bin bios-256k.bin /usr/share/seabios/
-$ wget https://github.com/cybozu-go/placemat/releases/download/v2.3.1/placemat2_2.3.1_amd64.deb
-$ sudo dpkg -i ./placemat2_2.3.1_amd64.deb
+$ wget https://github.com/cybozu-go/placemat/releases/download/v2.4.0/placemat2_2.4.0_amd64.deb
+$ sudo dpkg -i ./placemat2_2.4.0_amd64.deb
 $ git clone https://github.com/cybozu-go/neco
 $ cd neco/dctest
 $ make setup

--- a/constants.go
+++ b/constants.go
@@ -122,6 +122,12 @@ const (
 	BashCompletionDir = "/etc/bash_completion.d"
 )
 
+// APT params
+const (
+	KeyringsDir    = "/etc/apt/keyrings/"
+	SourceslistDir = "/etc/apt/sources.list.d/"
+)
+
 // File locations
 var (
 	RackFile        = filepath.Join(NecoDir, "rack")
@@ -190,4 +196,7 @@ var (
 	PromtailConfFile = filepath.Join(PromtailDir, "promtail.yaml")
 
 	IgnitionDirectory = filepath.Join(NecoDataDir, "ignitions")
+
+	DockerKeyringFile    = filepath.Join(KeyringsDir, "docker-key.asc")
+	DockerSourceListFile = filepath.Join(SourceslistDir, "docker.list")
 )

--- a/dctest/Makefile
+++ b/dctest/Makefile
@@ -23,7 +23,7 @@ CT := $(shell pwd)/bin/ct
 
 export PLACEMAT GINKGO SUITE MACHINES_FILE ADDRESS_POOLS_FILE SUDO
 
-CUSTOM_UBUNTU = cybozu-ubuntu-20.04-server-cloudimg-amd64.img
+CUSTOM_UBUNTU = cybozu-ubuntu-22.04-server-cloudimg-amd64.img
 FLATCAR_IMAGE := flatcar_production_qemu_image.img
 
 # non-configuration variables

--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -30,7 +30,7 @@ spec:
 ---
 kind: Image
 name: custom-ubuntu-image
-file: cybozu-ubuntu-20.04-server-cloudimg-amd64.img
+file: cybozu-ubuntu-22.04-server-cloudimg-amd64.img
 ---
 kind: Image
 name: flatcar

--- a/dctest/menu.yml
+++ b/dctest/menu.yml
@@ -29,7 +29,7 @@ spec:
 ---
 kind: Image
 name: custom-ubuntu-image
-file: cybozu-ubuntu-20.04-server-cloudimg-amd64.img
+file: cybozu-ubuntu-22.04-server-cloudimg-amd64.img
 ---
 kind: Image
 name: flatcar

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -23,7 +23,11 @@ BIRD2_URL = http://archive.ubuntu.com/ubuntu/pool/universe/b/bird2/bird2_2.0.8-2
 BIRD2_DEB = build/$(notdir $(BIRD2_URL))
 LIBSSH_URL = http://archive.ubuntu.com/ubuntu/pool/main/libs/libssh/libssh-gcrypt-4_0.9.6-2build1_amd64.deb
 LIBSSH_DEB = build/$(notdir $(LIBSSH_URL))
-DEBS = $(CHRONY_DEB) $(BIRD2_DEB) $(LIBSSH_DEB)
+# A seucrity fix with high rate has been released for libssl3, but libssl3 in the iso image is a version without the security fix applied.
+# We download and install the version with the security fix applied.
+LIBSSL3_URL = http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.7_amd64.deb
+LIBSSL3_DEB = build/$(notdir $(LIBSSL3_URL))
+DEBS = $(CHRONY_DEB) $(BIRD2_DEB) $(LIBSSH_DEB) $(LIBSSL3_DEB)
 
 .PHONY: help
 help:
@@ -58,6 +62,10 @@ $(BIRD2_DEB):
 $(LIBSSH_DEB):
 	mkdir -p build
 	cd build; curl -O -fsSL $(LIBSSH_URL)
+
+$(LIBSSL3_DEB):
+	mkdir -p build
+	cd build; curl -O -fsSL $(LIBSSL3_URL)
 
 $(CUSTOM_ISO_PATH): $(ORIGINAL_ISO_PATH) $(DEBS) cluster.json
 	rm -rf $(SRC_DIR_PATH)

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -2,7 +2,7 @@
 
 SUDO = sudo
 
-UBUNTU_VERSION = 20.04.3
+UBUNTU_VERSION = 22.04.1
 BUILD_DEPS := xorriso qemu-utils qemu-kvm ovmf curl ca-certificates cloud-image-utils gdisk kpartx
 
 ORIGINAL_ISO_NAME = ubuntu-$(UBUNTU_VERSION)-live-server-amd64.iso
@@ -10,18 +10,18 @@ ORIGINAL_ISO_PATH = build/$(ORIGINAL_ISO_NAME)
 CUSTOM_ISO_PATH = build/cybozu-$(ORIGINAL_ISO_NAME)
 SRC_DIR_PATH = build/src
 
-ORIGINAL_CLOUD_IMAGE = ubuntu-20.04-server-cloudimg-amd64.img
+ORIGINAL_CLOUD_IMAGE = ubuntu-22.04-server-cloudimg-amd64.img
 ORIGINAL_CLOUD_PATH = build/$(ORIGINAL_CLOUD_IMAGE)
 CUSTOM_CLOUD_PATH = build/cybozu-$(ORIGINAL_CLOUD_IMAGE)
 
 PREVIEW_IMG = build/ubuntu.img
 LOCALDS_IMG = build/seed.img
 
-CHRONY_URL = http://archive.ubuntu.com/ubuntu/pool/main/c/chrony/chrony_3.5-6ubuntu6.2_amd64.deb
+CHRONY_URL = http://archive.ubuntu.com/ubuntu/pool/main/c/chrony/chrony_4.2-2ubuntu2_amd64.deb
 CHRONY_DEB = build/$(notdir $(CHRONY_URL))
-BIRD2_URL = http://archive.ubuntu.com/ubuntu/pool/universe/b/bird2/bird2_2.0.7-2_amd64.deb
+BIRD2_URL = http://archive.ubuntu.com/ubuntu/pool/universe/b/bird2/bird2_2.0.10-2_amd64.deb
 BIRD2_DEB = build/$(notdir $(BIRD2_URL))
-LIBSSH_URL = http://archive.ubuntu.com/ubuntu/pool/main/libs/libssh/libssh-gcrypt-4_0.9.3-2ubuntu2.2_amd64.deb
+LIBSSH_URL = http://archive.ubuntu.com/ubuntu/pool/main/libs/libssh/libssh-gcrypt-4_0.9.6-2build1_amd64.deb
 LIBSSH_DEB = build/$(notdir $(LIBSSH_URL))
 DEBS = $(CHRONY_DEB) $(BIRD2_DEB) $(LIBSSH_DEB)
 
@@ -83,9 +83,10 @@ $(CUSTOM_ISO_PATH): $(ORIGINAL_ISO_PATH) $(DEBS) cluster.json
 
 	# Build an ISO file
 	xorriso -as mkisofs -r -V "neco-ubuntu-$(UBUNTU_VERSION)" \
-		-R -l -b isolinux/isolinux.bin \
-		-c isolinux/boot.cat -no-emul-boot \
-		-e boot/grub/efi.img \
+		-R -l -b '/boot/grub/i386-pc/eltorito.img' \
+		-c /boot.catalog -no-emul-boot \
+		-append_partition 2 28732ac11ff8d211ba4b00a0c93ec93b --interval:local_fs:2871452d-2879947d::'$(ORIGINAL_ISO_PATH)' \
+		-e '--interval:appended_partition_2_start_1782357s_size_8496d:all::'  \
 		-eltorito-alt-boot \
 		-boot-load-size 4 -boot-info-table \
 		-isohybrid-gpt-basdat \
@@ -106,7 +107,7 @@ cloud: $(CUSTOM_CLOUD_PATH)
 
 $(ORIGINAL_CLOUD_PATH):
 	mkdir -p build
-	curl -o $@ -fsSL https://cloud-images.ubuntu.com/releases/20.04/release/$(ORIGINAL_CLOUD_IMAGE)
+	curl -o $@ -fsSL https://cloud-images.ubuntu.com/releases/22.04/release/$(ORIGINAL_CLOUD_IMAGE)
 
 $(CUSTOM_CLOUD_PATH): $(ORIGINAL_CLOUD_PATH) $(DEBS) cluster.json
 	cp $< $@

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -82,6 +82,8 @@ $(CUSTOM_ISO_PATH): $(ORIGINAL_ISO_PATH) $(DEBS) cluster.json
 	cp -a autoinstall $(SRC_DIR_PATH)
 
 	# Build an ISO file
+	# See below url for the meaning of the xorriso command option
+	# https://askubuntu.com/questions/1403546/ubuntu-22-04-build-iso-both-mbr-and-efi
 	xorriso -as mkisofs -r -V "neco-ubuntu-$(UBUNTU_VERSION)" \
 		-R -l -b '/boot/grub/i386-pc/eltorito.img' \
 		-c /boot.catalog -no-emul-boot \

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -19,7 +19,7 @@ LOCALDS_IMG = build/seed.img
 
 CHRONY_URL = http://archive.ubuntu.com/ubuntu/pool/main/c/chrony/chrony_4.2-2ubuntu2_amd64.deb
 CHRONY_DEB = build/$(notdir $(CHRONY_URL))
-BIRD2_URL = http://archive.ubuntu.com/ubuntu/pool/universe/b/bird2/bird2_2.0.10-2_amd64.deb
+BIRD2_URL = http://archive.ubuntu.com/ubuntu/pool/universe/b/bird2/bird2_2.0.8-2_amd64.deb
 BIRD2_DEB = build/$(notdir $(BIRD2_URL))
 LIBSSH_URL = http://archive.ubuntu.com/ubuntu/pool/main/libs/libssh/libssh-gcrypt-4_0.9.6-2build1_amd64.deb
 LIBSSH_DEB = build/$(notdir $(LIBSSH_URL))

--- a/installer/README.md
+++ b/installer/README.md
@@ -25,8 +25,8 @@ To test built images, QEMU/KVM is used.
 3. Run `make setup`.  This is a one-time procedure.
 4. Run `make all` to build everything.
 
-- `build/cybozu-ubuntu-20.04-live-server-amd64.iso` is the custom ISO installer.
-- `build/cybozu-ubuntu-20.04-server-cloudimg-amd64.img` is the custom cloud image.
+- `build/cybozu-ubuntu-22.04-live-server-amd64.iso` is the custom ISO installer.
+- `build/cybozu-ubuntu-22.04-server-cloudimg-amd64.img` is the custom cloud image.
 
 ## Test
 

--- a/installer/autoinstall/user-data
+++ b/installer/autoinstall/user-data
@@ -31,7 +31,7 @@ autoinstall:
   - "curtin in-target --target=/target -- dpkg -r --force-depends systemd-timesyncd >> /var/log/installer/late-commands.log 2>&1"
   - "mkdir -p /target/etc/systemd/networkd.conf.d"
   - |
-    cat <<EOF | sudo tee /target/etc/systemd/networkd.conf.d/01-cybozu.conf
+    tee /target/etc/systemd/networkd.conf.d/01-cybozu.conf << EOF >/dev/null
     [Network]
     ManageForeignRoutingPolicyRules=no
     ManageForeignRoutes=no

--- a/installer/autoinstall/user-data
+++ b/installer/autoinstall/user-data
@@ -29,5 +29,12 @@ autoinstall:
   - "curtin in-target --target=/target -- systemctl disable systemd-resolved.service > /var/log/installer/late-commands.log 2>&1"
   - "rm -f /target/etc/resolv.conf"
   - "curtin in-target --target=/target -- dpkg -r --force-depends systemd-timesyncd >> /var/log/installer/late-commands.log 2>&1"
+  - "mkdir -p /target/etc/systemd/networkd.conf.d"
+  - |
+    cat <<EOF | sudo tee /target/etc/systemd/networkd.conf.d/01-cybozu.conf
+    [Network]
+    ManageForeignRoutingPolicyRules=no
+    ManageForeignRoutes=no
+    EOF
   - "curtin in-target --target=/target -- sh -c 'dpkg -i /extras/*.deb' >> /var/log/installer/late-commands.log 2>&1"
   - "true   Done.  You can reboot now."

--- a/installer/customize-cloud-image
+++ b/installer/customize-cloud-image
@@ -39,7 +39,7 @@ rm -f /mnt/etc/resolv.conf
 chroot /mnt sed -i '/127.0.0.1 localhost/a 127.0.1.1 boot' /etc/hosts
 chroot /mnt dpkg -r --force-depends systemd-timesyncd
 chroot /mnt mkdir -p /etc/systemd/networkd.conf.d
-cat <<EOF | tee /mnt/etc/systemd/networkd.conf.d/01-cybozu.conf
+tee /mnt/etc/systemd/networkd.conf.d/01-cybozu.conf  << EOF >/dev/null
 [Network]
 ManageForeignRoutingPolicyRules=no
 ManageForeignRoutes=no

--- a/installer/customize-cloud-image
+++ b/installer/customize-cloud-image
@@ -38,13 +38,18 @@ chroot /mnt systemctl disable systemd-resolved.service
 rm -f /mnt/etc/resolv.conf
 chroot /mnt sed -i '/127.0.0.1 localhost/a 127.0.1.1 boot' /etc/hosts
 chroot /mnt dpkg -r --force-depends systemd-timesyncd
+# We should prevent foreign routing policy rules and routes from being dropped.
+# ref. https://github.com/cybozu-go/neco/issues/1918
 chroot /mnt mkdir -p /etc/systemd/networkd.conf.d
 tee /mnt/etc/systemd/networkd.conf.d/01-cybozu.conf  << EOF >/dev/null
 [Network]
 ManageForeignRoutingPolicyRules=no
 ManageForeignRoutes=no
 EOF
-chroot /mnt sh -c "dpkg -i /extras/*.deb"
+# There is a bug that fails to load kernel modules by 9pnet at starts up. 
+# So we should force to load kernel modules.
+# ref. https://bugzilla.redhat.com/show_bug.cgi?id=1499896
 chroot /mnt sh -c "echo 9pnet_virtio > /etc/modules-load.d/9pnet_virtio.conf"
+chroot /mnt sh -c "dpkg -i /extras/*.deb"
 sync
 umount /mnt

--- a/installer/customize-cloud-image
+++ b/installer/customize-cloud-image
@@ -38,6 +38,13 @@ chroot /mnt systemctl disable systemd-resolved.service
 rm -f /mnt/etc/resolv.conf
 chroot /mnt sed -i '/127.0.0.1 localhost/a 127.0.1.1 boot' /etc/hosts
 chroot /mnt dpkg -r --force-depends systemd-timesyncd
+chroot /mnt mkdir -p /etc/systemd/networkd.conf.d
+cat <<EOF | tee /mnt/etc/systemd/networkd.conf.d/01-cybozu.conf
+[Network]
+ManageForeignRoutingPolicyRules=no
+ManageForeignRoutes=no
+EOF
 chroot /mnt sh -c "dpkg -i /extras/*.deb"
+chroot /mnt sh -c "echo 9pnet_virtio > /etc/modules-load.d/9pnet_virtio.conf"
 sync
 umount /mnt

--- a/installer/patch/grub.cfg
+++ b/installer/patch/grub.cfg
@@ -13,6 +13,8 @@ set menu_color_highlight=black/light-gray
 set timeout=5
 menuentry "Install Ubuntu Server" {
 	set gfxpayload=keep
+	# fsck.mode=skip avoids slow startup and cloud-init failures.
+	# ref. https://bugs.launchpad.net/subiquity/+bug/1969919
 	linux	/casper/vmlinuz fsck.mode=skip quiet autoinstall "ds=nocloud;s=/cdrom/autoinstall/" ---
 	initrd	/casper/initrd
 }

--- a/installer/patch/grub.cfg
+++ b/installer/patch/grub.cfg
@@ -13,9 +13,8 @@ set menu_color_highlight=black/light-gray
 set timeout=5
 menuentry "Install Ubuntu Server" {
 	set gfxpayload=keep
-	# As of Ubuntu 20.04.2, Intel E810-XXV 25GbE Adapter is supported only by HWE kernel.
-	linux	/casper/hwe-vmlinuz   quiet autoinstall "ds=nocloud;s=/cdrom/autoinstall/" ---
-	initrd	/casper/hwe-initrd
+	linux	/casper/vmlinuz fsck.mode=skip quiet autoinstall "ds=nocloud;s=/cdrom/autoinstall/" ---
+	initrd	/casper/initrd
 }
 grub_platform
 if [ "$grub_platform" = "efi" ]; then

--- a/installer/setup/docker.go
+++ b/installer/setup/docker.go
@@ -51,8 +51,8 @@ Environment="HTTPS_PROXY=%s"
 		return fmt.Errorf("failed to read Docker PGP key: %w", err)
 	}
 
-	if os.WriteFile(neco.DockerKeyringFile, data, 0644); err != nil {
-		return fmt.Errorf("failed to create%s: %w", neco.DockerKeyringFile, err)
+	if err := os.WriteFile(neco.DockerKeyringFile, data, 0644); err != nil {
+		return fmt.Errorf("failed to create %s: %w", neco.DockerKeyringFile, err)
 	}
 
 	cmd := exec.Command("lsb_release", "-cs")
@@ -63,8 +63,8 @@ Environment="HTTPS_PROXY=%s"
 
 	codename := strings.TrimSuffix(string(out), "\n")
 	repo := fmt.Sprintf("deb [arch=amd64 signed-by=%s] https://download.docker.com/linux/ubuntu %s stable\n", neco.DockerKeyringFile, codename)
-	if os.WriteFile(neco.DockerSourceListFile, []byte(repo), 0644); err != nil {
-		return fmt.Errorf("failed to create%s: %w", neco.DockerSourceListFile, err)
+	if err := os.WriteFile(neco.DockerSourceListFile, []byte(repo), 0644); err != nil {
+		return fmt.Errorf("failed to create %s: %w", neco.DockerSourceListFile, err)
 	}
 
 	if err := runCmd("apt-get", "update"); err != nil {


### PR DESCRIPTION
- Update ISO/QEMU custom installer for the boot server to Ubuntu 22.04
- Updated OS image used by dctest to Ubuntu22.04


Signed-off-by: zeroalphat <taichi-takemura@cybozu.co.jp>