### PR TITLE
Extend bpf-policy-map-max to 65536

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -107,7 +107,7 @@ data:
   enable-host-legacy-routing: "true"
   # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
-  bpf-policy-map-max: "16384"
+  bpf-policy-map-max: "65536"
   # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
   # backend and affinity maps.
   bpf-lb-map-max: "65536"
@@ -630,7 +630,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7"
+        cilium.io/cilium-configmap-checksum: "5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8"
       labels:
         k8s-app: cilium
     spec:
@@ -994,7 +994,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7"
+        cilium.io/cilium-configmap-checksum: "5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8"
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -4,6 +4,7 @@ bgp:
   enabled: true
 bpf:
   hostRouting: true
+  policyMapMax: 65536
 cni:
   chainingMode: "generic-veth"
   customConf: true

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -107,7 +107,7 @@ data:
   enable-host-legacy-routing: "true"
   # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
-  bpf-policy-map-max: "16384"
+  bpf-policy-map-max: "65536"
   # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
   # backend and affinity maps.
   bpf-lb-map-max: "65536"
@@ -630,7 +630,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7"
+        cilium.io/cilium-configmap-checksum: "5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8"
       labels:
         k8s-app: cilium
     spec:
@@ -994,7 +994,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7"
+        cilium.io/cilium-configmap-checksum: "5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8"
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -4,6 +4,7 @@ bgp:
   enabled: true
 bpf:
   hostRouting: true
+  policyMapMax: 65536
 cni:
   chainingMode: "generic-veth"
   customConf: true

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -367,7 +367,7 @@ data:
   bpf-lb-mode: dsr
   bpf-lb-sock-hostns-only: "true"
   bpf-map-dynamic-size-ratio: "0.0025"
-  bpf-policy-map-max: "16384"
+  bpf-policy-map-max: "65536"
   cgroup-root: /run/cilium/cgroupv2
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: ""
@@ -554,7 +554,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7
+        cilium.io/cilium-configmap-checksum: 5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -807,7 +807,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7
+        cilium.io/cilium-configmap-checksum: 5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
       labels:

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -367,7 +367,7 @@ data:
   bpf-lb-mode: dsr
   bpf-lb-sock-hostns-only: "true"
   bpf-map-dynamic-size-ratio: "0.0025"
-  bpf-policy-map-max: "16384"
+  bpf-policy-map-max: "65536"
   cgroup-root: /run/cilium/cgroupv2
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: ""
@@ -554,7 +554,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7
+        cilium.io/cilium-configmap-checksum: 5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
       labels:
@@ -807,7 +807,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 524831b7166a9c65aa8784cd2a73b8a4d9c223461991487e4aacc68c046031b7
+        cilium.io/cilium-configmap-checksum: 5c0a79a8faad6e6ae4efd0647a44e2ac39c3bb09942225b1f404480dd7f260a8
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
       labels:


### PR DESCRIPTION
- Update values.yaml for Cilium Chart
    - Add `bpf.policyMapMax: 65536`
- Build manifests
    - Run `make update-cilium CILIUM_PRE=true` and `make update-cilium`

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>