### PR TITLE
Use GITHUB_TOKEN when downloading deb file

### DIFF
--- a/dctest/Makefile
+++ b/dctest/Makefile
@@ -26,6 +26,12 @@ export PLACEMAT GINKGO SUITE MACHINES_FILE ADDRESS_POOLS_FILE SUDO
 CUSTOM_UBUNTU = cybozu-ubuntu-20.04-server-cloudimg-amd64.img
 FLATCAR_IMAGE := flatcar_production_qemu_image.img
 
+GITHUB_TOKEN_FILE = $(CURDIR)/../github-token
+ifneq ("$(wildcard $(GITHUB_TOKEN_FILE))","")
+  GITHUB_TOKEN := $(shell cat $(GITHUB_TOKEN_FILE))
+  export GITHUB_TOKEN
+endif
+
 # non-configuration variables
 SABAKAN_DIR = $(OUTPUT)/sabakan
 DHCP_JSON = $(SABAKAN_DIR)/dhcp.json

--- a/generator/generate.go
+++ b/generator/generate.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"text/template"
@@ -17,7 +16,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/hashicorp/go-version"
-	"golang.org/x/oauth2"
 )
 
 var imageRepos = []string{
@@ -221,14 +219,7 @@ OUTER:
 }
 
 func getLatestDeb(ctx context.Context, name string, ignoreVersions []string) (*neco.DebianPackage, error) {
-	var hc *http.Client
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: token},
-		)
-		hc = oauth2.NewClient(ctx, ts)
-	}
-	client := neco.NewGitHubClient(hc)
+	client := neco.NewDefaultGitHubClient()
 	releases, resp, err := client.Repositories.ListReleases(ctx, "cybozu-go", name, nil)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {

--- a/github.go
+++ b/github.go
@@ -1,9 +1,12 @@
 package neco
 
 import (
+	"context"
 	"net/http"
+	"os"
 
 	"github.com/google/go-github/v48/github"
+	"golang.org/x/oauth2"
 )
 
 // NewGitHubClient returns a properly configured *github.Client.
@@ -11,4 +14,17 @@ func NewGitHubClient(c *http.Client) *github.Client {
 	gh := github.NewClient(c)
 	gh.UserAgent = NecoUserAgent
 	return gh
+}
+
+// NewDefaultGitHubClient reads GitHub personal access token from GITHUB_TOKEN environment variable.
+// And creates a properly configured *github.Client.
+func NewDefaultGitHubClient() *github.Client {
+	var hc *http.Client
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		src := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		hc = oauth2.NewClient(context.Background(), src)
+	}
+	return NewGitHubClient(hc)
 }

--- a/pkg/download-neco-deb/main.go
+++ b/pkg/download-neco-deb/main.go
@@ -24,7 +24,8 @@ func main() {
 	}
 	datacenter := os.Args[1]
 
-	client := updater.NewReleaseClient(neco.GitHubRepoOwner, neco.GitHubRepoName, http.DefaultClient)
+	ghClient := neco.NewDefaultGitHubClient()
+	client := updater.NewReleaseClient(neco.GitHubRepoOwner, neco.GitHubRepoName, ghClient)
 
 	var getTag func(context.Context) (string, error)
 	switch datacenter {
@@ -42,14 +43,13 @@ func main() {
 			return err
 		}
 
-		github := neco.NewGitHubClient(http.DefaultClient)
 		deb := &neco.DebianPackage{
 			Name:       neco.NecoPackageName,
 			Repository: neco.GitHubRepoName,
 			Owner:      neco.GitHubRepoOwner,
 			Release:    "release-" + tag,
 		}
-		downloadURL, err := worker.GetGitHubDownloadURL(ctx, github, deb)
+		downloadURL, err := worker.GetGitHubDownloadURL(ctx, ghClient, deb)
 		if err != nil {
 			return err
 		}

--- a/pkg/find-installed-release/main.go
+++ b/pkg/find-installed-release/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/cybozu-go/neco"
@@ -22,7 +21,8 @@ func main() {
 	}
 	datacenter := os.Args[1]
 
-	client := updater.NewReleaseClient(neco.GitHubRepoOwner, neco.GitHubRepoName, http.DefaultClient)
+	ghClient := neco.NewDefaultGitHubClient()
+	client := updater.NewReleaseClient(neco.GitHubRepoOwner, neco.GitHubRepoName, ghClient)
 
 	var getTag func(context.Context) (string, error)
 	switch datacenter {

--- a/updater/release_checker.go
+++ b/updater/release_checker.go
@@ -3,30 +3,30 @@ package updater
 import (
 	"context"
 	"errors"
-	"net/http"
 	"time"
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/neco"
 	"github.com/cybozu-go/neco/storage"
+	"github.com/google/go-github/v48/github"
 )
 
 // ReleaseChecker checks newer GitHub releases by polling
 type ReleaseChecker struct {
 	storage   storage.Storage
 	leaderKey string
-	ghClient  *http.Client
+	ghClient  *github.Client
 
 	check   func(context.Context) (string, error)
 	current string
 }
 
 // NewReleaseChecker returns a new ReleaseChecker
-func NewReleaseChecker(st storage.Storage, leaderKey string, ghc *http.Client) ReleaseChecker {
+func NewReleaseChecker(st storage.Storage, leaderKey string, ghClient *github.Client) ReleaseChecker {
 	return ReleaseChecker{
 		storage:   st,
 		leaderKey: leaderKey,
-		ghClient:  ghc,
+		ghClient:  ghClient,
 	}
 }
 

--- a/updater/server.go
+++ b/updater/server.go
@@ -63,11 +63,12 @@ RETRY:
 		return s.runLoop(ctx, leaderKey)
 	})
 
-	ghc, err := ext.GitHubHTTPClient(ctx, s.storage)
+	ghHttpClient, err := ext.GitHubHTTPClient(ctx, s.storage)
 	if err != nil {
 		return err
 	}
-	checker := NewReleaseChecker(s.storage, leaderKey, ghc)
+	ghClient := neco.NewGitHubClient(ghHttpClient)
+	checker := NewReleaseChecker(s.storage, leaderKey, ghClient)
 	env.Go(checker.Run)
 	env.Stop()
 	err = env.Wait()

--- a/worker/deb.go
+++ b/worker/deb.go
@@ -18,10 +18,8 @@ import (
 // InstallDebianPackage installs a debian package
 // client uses for downloading a debian package.
 // ghClient uses for getting download URL by GitHub API.
-func InstallDebianPackage(ctx context.Context, client *http.Client, ghClient *http.Client, pkg *neco.DebianPackage, background bool) error {
-	gh := neco.NewGitHubClient(ghClient)
-
-	downloadURL, err := GetGitHubDownloadURL(ctx, gh, pkg)
+func InstallDebianPackage(ctx context.Context, client *http.Client, ghClient *github.Client, pkg *neco.DebianPackage, background bool) error {
+	downloadURL, err := GetGitHubDownloadURL(ctx, ghClient, pkg)
 	if err != nil {
 		return err
 	}

--- a/worker/operator.go
+++ b/worker/operator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cybozu-go/neco/ext"
 	"github.com/cybozu-go/neco/storage"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-github/v48/github"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -36,7 +37,7 @@ type operator struct {
 	mylrn            int
 	ec               *clientv3.Client
 	storage          storage.Storage
-	ghClient         *http.Client
+	ghClient         *github.Client
 	proxyClient      *http.Client
 	localClient      *http.Client
 	fetcher          neco.ImageFetcher
@@ -51,10 +52,11 @@ func NewOperator(ctx context.Context, ec *clientv3.Client, mylrn int) (Operator,
 	if err != nil {
 		return nil, err
 	}
-	ghClient, err := ext.GitHubHTTPClient(ctx, st)
+	ghHttpClient, err := ext.GitHubHTTPClient(ctx, st)
 	if err != nil {
 		return nil, err
 	}
+	ghClient := neco.NewGitHubClient(ghHttpClient)
 	proxy, err := st.GetProxyConfig(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I updated `download-neco-deb` commnad to read PAT from GITHUB_TOKEN environment variable.
Also updated `find-installed-release` too.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>