### PR TITLE
Enable LB IPIP CNI mode on staging

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -194,6 +194,8 @@ data:
   bpf-lb-mode: "dsr"
   bpf-lb-algorithm: "maglev"
   bpf-lb-acceleration: "disabled"
+  bpf-lb-dsr-l4-xlate: "backend"
+  bpf-lb-dsr-dispatch: "ipipcni"
   bpf-lb-maglev-hash-seed: "3HCx6JennjWtot2U"
   enable-session-affinity: "true"
   enable-svc-source-range-check: "true"
@@ -744,7 +746,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6"
+        cilium.io/cilium-configmap-checksum: "e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1233,7 +1235,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6"
+        cilium.io/cilium-configmap-checksum: "e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -49,6 +49,8 @@ loadBalancer:
   # We can't enable XDP Acceleration because rolling restart Cilium with XDP enabled disrupts in-cluster connectivity
   acceleration: disabled
   algorithm: maglev
+  dsrDispatch: ipipcni
+  dsrL4Translate: backend
   mode: dsr
 maglev:
   hashSeed: 3HCx6JennjWtot2U

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -452,6 +452,8 @@ data:
   bpf-ct-timeout-service-any: 1h0m0s
   bpf-lb-acceleration: disabled
   bpf-lb-algorithm: maglev
+  bpf-lb-dsr-dispatch: ipipcni
+  bpf-lb-dsr-l4-xlate: backend
   bpf-lb-external-clusterip: "false"
   bpf-lb-maglev-hash-seed: 3HCx6JennjWtot2U
   bpf-lb-map-max: "65536"
@@ -662,7 +664,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6
+        cilium.io/cilium-configmap-checksum: e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -913,7 +915,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6
+        cilium.io/cilium-configmap-checksum: e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e
         container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined


### PR DESCRIPTION
The update-cilium target retrieves Cilium v1.12.4 source code, patch 18449, and renders Cilium manifest with it because patch 18449 contains modifications for the helm chart.
https://github.com/cilium/cilium/compare/v1.12.4...ysksuzuki:cilium:v1.12.4-with-18449