### PR TITLE
Disable the cgroup v2 auto-mount

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -9,7 +9,7 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "bird", Repository: "quay.io/cybozu/bird", Tag: "2.0.10.1", Private: false},
 		{Name: "chrony", Repository: "quay.io/cybozu/chrony", Tag: "4.3.0.1", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.5.6.1", Private: false},
-		{Name: "promtail", Repository: "quay.io/cybozu/promtail", Tag: "2.6.1.1", Private: false},
+		{Name: "promtail", Repository: "quay.io/cybozu/promtail", Tag: "2.7.1.1", Private: false},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.13.1", Private: false},
 		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.10.0.1", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.13.0", Private: true},

--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -245,7 +245,7 @@ data:
   enable-bgp-control-plane: "false"
   procfs: "/host/proc"
   bpf-root: "/sys/fs/bpf"
-  cgroup-root: "/run/cilium/cgroupv2"
+  cgroup-root: "/sys/fs/cgroup"
   enable-k8s-terminating-endpoint: "true"
   remove-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
@@ -746,14 +746,12 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e"
+        cilium.io/cilium-configmap-checksum: "6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
       labels:
         k8s-app: cilium
     spec:
@@ -920,6 +918,9 @@ spec:
           # is privileged and set the mount propagation from host to container
           # in Cilium.
           mountPropagation: HostToContainer
+        # Check for duplicate mounts before mounting
+        - name: cilium-cgroup
+          mountPath: /sys/fs/cgroup
         - name: cilium-run
           mountPath: /var/run/cilium
         - name: cni-path
@@ -945,90 +946,6 @@ spec:
           mountPath: /var/lib/cilium/tls/hubble
           readOnly: true
       initContainers:
-      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
-      # We use nsenter command with host's cgroup and mount namespaces enabled.
-      - name: mount-cgroup
-        image: "quay.io/cybozu/cilium:1.12.4.1"
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: CGROUP_ROOT
-          value: /run/cilium/cgroupv2
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        command:
-        - sh
-        - -ec
-        # The statically linked Go program binary is invoked to avoid any
-        # dependency on utilities like sh and mount that can be missing on certain
-        # distros installed on the underlying host. Copy the binary to the
-        # same directory where we install cilium cni plugin so that exec permissions
-        # are available.
-        - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-          rm /hostbin/cilium-mount
-        volumeMounts:
-        - name: hostproc
-          mountPath: /hostproc
-        - name: cni-path
-          mountPath: /hostbin
-        terminationMessagePolicy: FallbackToLogsOnError
-        securityContext:
-          seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
-          capabilities:
-            drop:
-              - ALL
-            add:
-              # Only used for 'mount' cgroup
-              - SYS_ADMIN
-              # Used for nsenter
-              - SYS_CHROOT
-              - SYS_PTRACE
-      - name: apply-sysctl-overwrites
-        image: "quay.io/cybozu/cilium:1.12.4.1"
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        command:
-        - sh
-        - -ec
-        # The statically linked Go program binary is invoked to avoid any
-        # dependency on utilities like sh that can be missing on certain
-        # distros installed on the underlying host. Copy the binary to the
-        # same directory where we install cilium cni plugin so that exec permissions
-        # are available.
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        volumeMounts:
-        - name: hostproc
-          mountPath: /hostproc
-        - name: cni-path
-          mountPath: /hostbin
-        terminationMessagePolicy: FallbackToLogsOnError
-        securityContext:
-          seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
-          capabilities:
-            drop:
-              - ALL
-            add:
-              # Required in order to access host's /etc/sysctl.d dir
-              - SYS_ADMIN
-              # Used for nsenter
-              - SYS_CHROOT
-              - SYS_PTRACE
       # Mount the bpf fs if it is not mounted. We will perform this task
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
@@ -1106,7 +1023,7 @@ spec:
           mountPath: /sys/fs/bpf
           # Required to mount cgroup filesystem from the host to cilium agent pod
         - name: cilium-cgroup
-          mountPath: /run/cilium/cgroupv2
+          mountPath: /sys/fs/cgroup
           mountPropagation: HostToContainer
         - name: cilium-run
           mountPath: /var/run/cilium
@@ -1142,15 +1059,10 @@ spec:
         hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
-      # To mount cgroup2 filesystem on the host
-      - name: hostproc
-        hostPath:
-          path: /proc
-          type: Directory
       # To keep state between restarts / upgrades for cgroup2 filesystem
       - name: cilium-cgroup
         hostPath:
-          path: /run/cilium/cgroupv2
+          path: /sys/fs/cgroup
           type: DirectoryOrCreate
       # To install cilium cni plugin in the host
       - name: cni-path
@@ -1235,7 +1147,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e"
+        cilium.io/cilium-configmap-checksum: "6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -5,6 +5,10 @@ bgp:
 bpf:
   hostLegacyRouting: true
   policyMapMax: 65536
+cgroup:
+  autoMount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
 cni:
   chainingMode: "generic-veth"
   customConf: true

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -243,7 +243,7 @@ data:
   enable-bgp-control-plane: "false"
   procfs: "/host/proc"
   bpf-root: "/sys/fs/bpf"
-  cgroup-root: "/run/cilium/cgroupv2"
+  cgroup-root: "/sys/fs/cgroup"
   enable-k8s-terminating-endpoint: "true"
   remove-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
@@ -744,14 +744,12 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6"
+        cilium.io/cilium-configmap-checksum: "a0d78575e1d78abe586228f6ba454b89c167f5b8a8b167ea2adcd56d3ba2a636"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
         container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
       labels:
         k8s-app: cilium
     spec:
@@ -918,6 +916,9 @@ spec:
           # is privileged and set the mount propagation from host to container
           # in Cilium.
           mountPropagation: HostToContainer
+        # Check for duplicate mounts before mounting
+        - name: cilium-cgroup
+          mountPath: /sys/fs/cgroup
         - name: cilium-run
           mountPath: /var/run/cilium
         - name: cni-path
@@ -943,90 +944,6 @@ spec:
           mountPath: /var/lib/cilium/tls/hubble
           readOnly: true
       initContainers:
-      # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
-      # We use nsenter command with host's cgroup and mount namespaces enabled.
-      - name: mount-cgroup
-        image: "quay.io/cybozu/cilium:1.12.4.1"
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: CGROUP_ROOT
-          value: /run/cilium/cgroupv2
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        command:
-        - sh
-        - -ec
-        # The statically linked Go program binary is invoked to avoid any
-        # dependency on utilities like sh and mount that can be missing on certain
-        # distros installed on the underlying host. Copy the binary to the
-        # same directory where we install cilium cni plugin so that exec permissions
-        # are available.
-        - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-          rm /hostbin/cilium-mount
-        volumeMounts:
-        - name: hostproc
-          mountPath: /hostproc
-        - name: cni-path
-          mountPath: /hostbin
-        terminationMessagePolicy: FallbackToLogsOnError
-        securityContext:
-          seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
-          capabilities:
-            drop:
-              - ALL
-            add:
-              # Only used for 'mount' cgroup
-              - SYS_ADMIN
-              # Used for nsenter
-              - SYS_CHROOT
-              - SYS_PTRACE
-      - name: apply-sysctl-overwrites
-        image: "quay.io/cybozu/cilium:1.12.4.1"
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        command:
-        - sh
-        - -ec
-        # The statically linked Go program binary is invoked to avoid any
-        # dependency on utilities like sh that can be missing on certain
-        # distros installed on the underlying host. Copy the binary to the
-        # same directory where we install cilium cni plugin so that exec permissions
-        # are available.
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        volumeMounts:
-        - name: hostproc
-          mountPath: /hostproc
-        - name: cni-path
-          mountPath: /hostbin
-        terminationMessagePolicy: FallbackToLogsOnError
-        securityContext:
-          seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
-          capabilities:
-            drop:
-              - ALL
-            add:
-              # Required in order to access host's /etc/sysctl.d dir
-              - SYS_ADMIN
-              # Used for nsenter
-              - SYS_CHROOT
-              - SYS_PTRACE
       # Mount the bpf fs if it is not mounted. We will perform this task
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
@@ -1104,7 +1021,7 @@ spec:
           mountPath: /sys/fs/bpf
           # Required to mount cgroup filesystem from the host to cilium agent pod
         - name: cilium-cgroup
-          mountPath: /run/cilium/cgroupv2
+          mountPath: /sys/fs/cgroup
           mountPropagation: HostToContainer
         - name: cilium-run
           mountPath: /var/run/cilium
@@ -1140,15 +1057,10 @@ spec:
         hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
-      # To mount cgroup2 filesystem on the host
-      - name: hostproc
-        hostPath:
-          path: /proc
-          type: Directory
       # To keep state between restarts / upgrades for cgroup2 filesystem
       - name: cilium-cgroup
         hostPath:
-          path: /run/cilium/cgroupv2
+          path: /sys/fs/cgroup
           type: DirectoryOrCreate
       # To install cilium cni plugin in the host
       - name: cni-path
@@ -1233,7 +1145,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6"
+        cilium.io/cilium-configmap-checksum: "a0d78575e1d78abe586228f6ba454b89c167f5b8a8b167ea2adcd56d3ba2a636"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -5,6 +5,10 @@ bgp:
 bpf:
   hostLegacyRouting: true
   policyMapMax: 65536
+cgroup:
+  autoMount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
 cni:
   chainingMode: "generic-veth"
   customConf: true

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -463,7 +463,7 @@ data:
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "65536"
   bpf-root: /sys/fs/bpf
-  cgroup-root: /run/cilium/cgroupv2
+  cgroup-root: /sys/fs/cgroup
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: "0"
   cluster-name: default
@@ -664,7 +664,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e
+        cilium.io/cilium-configmap-checksum: 6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -915,11 +915,9 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: e4b2ebd6e96218c0e1b14b78006abe26966cce693ed7ea87cc929a6aeefb157e
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
+        cilium.io/cilium-configmap-checksum: 6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
       labels:
@@ -1069,6 +1067,8 @@ spec:
         - mountPath: /sys/fs/bpf
           mountPropagation: HostToContainer
           name: bpf-maps
+        - mountPath: /sys/fs/cgroup
+          name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -1094,68 +1094,6 @@ spec:
           readOnly: true
       hostNetwork: true
       initContainers:
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-          rm /hostbin/cilium-mount
-        env:
-        - name: CGROUP_ROOT
-          value: /run/cilium/cgroupv2
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: quay.io/cybozu/cilium:1.12.4.1
-        imagePullPolicy: IfNotPresent
-        name: mount-cgroup
-        securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: quay.io/cybozu/cilium:1.12.4.1
-        imagePullPolicy: IfNotPresent
-        name: apply-sysctl-overwrites
-        securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
       - args:
         - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
         command:
@@ -1214,7 +1152,7 @@ spec:
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
-        - mountPath: /run/cilium/cgroupv2
+        - mountPath: /sys/fs/cgroup
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
@@ -1238,11 +1176,7 @@ spec:
           type: DirectoryOrCreate
         name: bpf-maps
       - hostPath:
-          path: /proc
-          type: Directory
-        name: hostproc
-      - hostPath:
-          path: /run/cilium/cgroupv2
+          path: /sys/fs/cgroup
           type: DirectoryOrCreate
         name: cilium-cgroup
       - hostPath:

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -461,7 +461,7 @@ data:
   bpf-map-dynamic-size-ratio: "0.0025"
   bpf-policy-map-max: "65536"
   bpf-root: /sys/fs/bpf
-  cgroup-root: /run/cilium/cgroupv2
+  cgroup-root: /sys/fs/cgroup
   cilium-endpoint-gc-interval: 5m0s
   cluster-id: "0"
   cluster-name: default
@@ -662,7 +662,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6
+        cilium.io/cilium-configmap-checksum: a0d78575e1d78abe586228f6ba454b89c167f5b8a8b167ea2adcd56d3ba2a636
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -913,11 +913,9 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: fa12f53950a3c06f4133efea90393b3c09b0cc301c71f77b6aad230c0805a8e6
-        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: unconfined
+        cilium.io/cilium-configmap-checksum: a0d78575e1d78abe586228f6ba454b89c167f5b8a8b167ea2adcd56d3ba2a636
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
-        container.apparmor.security.beta.kubernetes.io/mount-cgroup: unconfined
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
       labels:
@@ -1067,6 +1065,8 @@ spec:
         - mountPath: /sys/fs/bpf
           mountPropagation: HostToContainer
           name: bpf-maps
+        - mountPath: /sys/fs/cgroup
+          name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -1092,68 +1092,6 @@ spec:
           readOnly: true
       hostNetwork: true
       initContainers:
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-mount /hostbin/cilium-mount;
-          nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-mount" $CGROUP_ROOT;
-          rm /hostbin/cilium-mount
-        env:
-        - name: CGROUP_ROOT
-          value: /run/cilium/cgroupv2
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: quay.io/cybozu/cilium:1.12.4.1
-        imagePullPolicy: IfNotPresent
-        name: mount-cgroup
-        securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
-      - command:
-        - sh
-        - -ec
-        - |
-          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
-          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
-          rm /hostbin/cilium-sysctlfix
-        env:
-        - name: BIN_PATH
-          value: /opt/cni/bin
-        image: quay.io/cybozu/cilium:1.12.4.1
-        imagePullPolicy: IfNotPresent
-        name: apply-sysctl-overwrites
-        securityContext:
-          capabilities:
-            add:
-            - SYS_ADMIN
-            - SYS_CHROOT
-            - SYS_PTRACE
-            drop:
-            - ALL
-          seLinuxOptions:
-            level: s0
-            type: spc_t
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /hostproc
-          name: hostproc
-        - mountPath: /hostbin
-          name: cni-path
       - args:
         - mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf
         command:
@@ -1212,7 +1150,7 @@ spec:
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
-        - mountPath: /run/cilium/cgroupv2
+        - mountPath: /sys/fs/cgroup
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
@@ -1236,11 +1174,7 @@ spec:
           type: DirectoryOrCreate
         name: bpf-maps
       - hostPath:
-          path: /proc
-          type: Directory
-        name: hostproc
-      - hostPath:
-          path: /run/cilium/cgroupv2
+          path: /sys/fs/cgroup
           type: DirectoryOrCreate
         name: cilium-cgroup
       - hostPath:


### PR DESCRIPTION
The cgroup v2 auto-mount is no longer needed because the cgroup v2 has been enabled in our worker nodes.


https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/#kubeproxy-free

> Cilium will automatically mount cgroup v2 filesystem required to attach BPF cgroup programs by default at the path /run/cilium/cgroupv2. To do that, it needs to mount the host /proc inside an init container launched by the DaemonSet temporarily. If you need to disable the auto-mount, specify --set cgroup.autoMount.enabled=false, and set the host mount point where cgroup v2 filesystem is already mounted by using --set cgroup.hostRoot. For example, if not already mounted, you can mount cgroup v2 filesystem by running the below command on the host, and specify --set cgroup.hostRoot=/sys/fs/cgroup.
