### PR TITLE
Skip boot server status check in dctest whose rack ID is over 2

### DIFF
--- a/dctest/sabakan_state_setter_test.go
+++ b/dctest/sabakan_state_setter_test.go
@@ -56,7 +56,7 @@ func testSabakanStateSetter() {
 				return err
 			}
 			for _, m := range machines {
-				if m.Spec.Rack == 3 && m.Spec.Role == "boot" {
+				if m.Spec.Rack >= 3 && m.Spec.Role == "boot" {
 					continue
 				}
 				if m.Status.State.String() != "healthy" {


### PR DESCRIPTION
By default, dctest starts with 3 racks.
When we would like to increase the number of racks, the status check for boot servers in added racks fails and prevents the start up proess.

In this PR, the boot server status check is skipped for racks whose rack ID is over 2.

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
Co-authored-by: ESASHIKA Kaoru <kaoru-esashika@cybozu.co.jp>