### PR TITLE
installer: Update libssl package used in initial setup

### DIFF
--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,0 +1,3 @@
+images:
+  - repository: quay.io/cybozu/squid
+    versions: ["5.7.0.2"]

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -25,7 +25,7 @@ LIBSSH_URL = http://archive.ubuntu.com/ubuntu/pool/main/libs/libssh/libssh-gcryp
 LIBSSH_DEB = build/$(notdir $(LIBSSH_URL))
 # A seucrity fix with high rate has been released for libssl3, but libssl3 in the iso image is a version without the security fix applied.
 # We download and install the version with the security fix applied.
-LIBSSL3_URL = http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.7_amd64.deb
+LIBSSL3_URL = http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.8_amd64.deb
 LIBSSL3_DEB = build/$(notdir $(LIBSSL3_URL))
 DEBS = $(CHRONY_DEB) $(BIRD2_DEB) $(LIBSSH_DEB) $(LIBSSL3_DEB)
 


### PR DESCRIPTION
`installer/Makefile` downloads a libssl package with a hard-coded
URL.
This URL has been changed due to security update.
See https://packages.ubuntu.com/jammy/amd64/libssl3/download for
the new URL.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>