### PR TITLE
add support env vars for logcli

### DIFF
--- a/debian/etc/profile.d/loki-env.sh
+++ b/debian/etc/profile.d/loki-env.sh
@@ -1,0 +1,2 @@
+export LOKI_ADDR="http://query-frontend.logging.svc:3100/"
+export LOKI_ORG_ID="fake"


### PR DESCRIPTION
step1 part of https://github.com/cybozu-go/neco/issues/2214

- `LOKI_ADDR` points the loki in logging NS.
- `LOKI_ORG_ID` is `fake`, the default org-id that a single-tenant loki uses.

see also https://github.com/cybozu/neco-containers/pull/968

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>