### PR TITLE
Fix slow deb package build issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,12 +150,12 @@ jobs:
           name: Build deb package
           command: |
             VERSION=$(echo $CIRCLE_TAG | sed 's/^[^-]*-//')
-            time make deb SUDO="" DEBBUILD_FLAGS="" VERSION="$VERSION" TAGS=release FAKEROOT=
+            time make deb SUDO="" DEBBUILD_FLAGS="-Zxz" VERSION="$VERSION" TAGS=release FAKEROOT=
       - run:
           name: Build neco-operation-cli packages
           command: |
             VERSION=$(echo $CIRCLE_TAG | sed 's/^[^-]*-//')
-            time make tools SUDO="" DEBBUILD_FLAGS="" VERSION="$VERSION" TAGS=release FAKEROOT=
+            time make tools SUDO="" DEBBUILD_FLAGS="-Zxz" VERSION="$VERSION" TAGS=release FAKEROOT=
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
The default compression type of dpkg-deb 1.21.1 is zstd,
It doesn't work concurrently and leads to the timout error
This PR workaround this issue by spcifiying -zxz explicitly

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>