### PR TITLE
Increase controller-manager's QPS to use while talking with apiserver

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -79,6 +79,7 @@ options:
       - "--leader-elect-retry-period=5s"
       - "--leader-elect-renew-deadline=15s"
       - "--leader-elect-lease-duration=20s"
+      - "--kube-api-qps=50"
   kube-proxy:
     disable: true
     # For local-proxy running on boot servers


### PR DESCRIPTION
This parameter probably solve performance issues.
ref. https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/

Signed-off-by: zoetrope <a.ikezoe@gmail.com>