### PR TITLE
Revert "ci: Re-run setup to upgrade Ginkgo"

### DIFF
--- a/bin/run-dctest-suite.sh
+++ b/bin/run-dctest-suite.sh
@@ -23,8 +23,6 @@ fi
 
 # Run dctest
 cd \${GOPATH}/src/github.com/cybozu-go/neco/dctest
-## re-run setup to upgrade ginkgo
-make setup
 exec make test TAGS=${TAG_NAME} SUITE=${SUITE_NAME} MACHINES_FILE=\${MACHINES_FILE}
 EOF
 chmod +x run.sh


### PR DESCRIPTION
This reverts commit 0e91abab32cab4712460afbd5947d2606cde2305.

Re-run was necessary to upgrade Ginkgo from V1 to V2.
The next upgrade from V2 to V3 will not occur for a while.