### PR TITLE
add org-id (tenant-id) option to loki clients

### DIFF
--- a/progs/promtail/promtail.yaml.tmpl
+++ b/progs/promtail/promtail.yaml.tmpl
@@ -4,6 +4,7 @@ server:
 
 clients:
   - url: http://distributor.logging.svc:3100/loki/api/v1/push
+    tenant_id: fake
 
 positions:
   filename: /run/promtail/positions.yaml


### PR DESCRIPTION
part of https://github.com/cybozu-go/neco/issues/2214

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>