### PR TITLE
check the length of none-ss nodes before selecting for reboot

### DIFF
--- a/pkg/neco/cmd/reboot_worker.go
+++ b/pkg/neco/cmd/reboot_worker.go
@@ -190,7 +190,7 @@ func rebootMachines(machines []sabakan.Machine) error {
 		// enqueue nodes so that SSs and non-SSs alternate as much as possible
 		for i := 0; i < len(ss)+len(nonss); i++ {
 			var address string
-			if nonssIndex*len(ss) <= ssIndex*len(nonss) {
+			if nonssIndex*len(ss) <= ssIndex*len(nonss) && len(nonss) > 0 {
 				address = nonss[nonssIndex]
 				nonssIndex++
 			} else {


### PR DESCRIPTION
When we try to exec `neco reboot-worker` with only ss nodes, the neco command crashes.
This is due to the following check.
https://github.com/cybozu-go/neco/blob/4b3f01eff5d608075493b34277cce32b68119a56/pkg/neco/cmd/reboot_worker.go#L193

Because both `nonssIndex` and `ssIndex` is initialized with 0, the condition holds for the first loop, and the empty slice `nonss` is accessed.

To fix this bug, I added a check for the length of the none-ss nodes.