### PR TITLE
test neco reboot-worker for each role

### DIFF
--- a/dctest/reboot_test.go
+++ b/dctest/reboot_test.go
@@ -1,11 +1,13 @@
 package dctest
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // testRebootAllBootServers tests all boot servers are normal after reboot
@@ -45,8 +47,72 @@ func testRebootAllBootServers() {
 	})
 }
 
+// rebootQueueEntry is part of cke.RebootQueueEntry in github.com/cybozu-go/cke
+type rebootQueueEntry struct {
+	Node   string `json:"node"`
+	Status string `json:"status"`
+}
+
 // testRebootGracefully tests graceful reboot of workers
 func testRebootGracefully() {
+	It("can enqueue workers to reboot queue correctly", func() {
+		roles := []string{"", "cs", "ss"}
+
+		execSafeAt(bootServers[0], "ckecli", "rq", "disable")
+
+		for _, role := range roles {
+			kubectlCommand := []string{"kubectl", "get", "node", "-ojson"}
+			necoRebootWorkerOptions := ""
+			if role != "" {
+				kubectlCommand = append(kubectlCommand, "-lcke.cybozu.com/role="+role)
+				necoRebootWorkerOptions = "--role=" + role
+				By("trying to reboot " + role + " nodes")
+			} else {
+				By("trying to reboot all nodes")
+			}
+
+			var nodeList corev1.NodeList
+			nodeSet := map[string]bool{}
+			nodeListJson := execSafeAt(bootServers[0], kubectlCommand...)
+			err := json.Unmarshal(nodeListJson, &nodeList)
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range nodeList.Items {
+				nodeSet[node.Name] = true
+			}
+
+			execSafeAt(bootServers[0], "sh", "-c", "yes | neco reboot-worker "+necoRebootWorkerOptions)
+			rqe := []rebootQueueEntry{}
+			rqeJson := execSafeAt(bootServers[0], "ckecli", "rq", "list")
+			Expect(string(rqeJson)).NotTo(Equal("null"))
+			err = json.Unmarshal(rqeJson, &rqe)
+			Expect(err).NotTo(HaveOccurred())
+			// Every target kubernetes nodes are pushed to reboot queue exactly once.
+			for _, e := range rqe {
+				if e.Status == "cancelled" {
+					continue
+				}
+				Expect(nodeSet).To(HaveKey(e.Node))
+				delete(nodeSet, e.Node)
+			}
+			Expect(nodeSet).To(BeEmpty())
+
+			execSafeAt(bootServers[0], "ckecli", "rq", "cancel-all")
+		}
+
+		// make CKE dequeue cancelled entries
+		execSafeAt(bootServers[0], "ckecli", "rq", "enable")
+		Eventually(func() error {
+			stdout, stderr, err := execAt(bootServers[0], "ckecli", "rq", "list")
+			if err != nil {
+				return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+			if string(stdout) != "null\n" {
+				return fmt.Errorf("reboot-queue is not processed")
+			}
+			return nil
+		}, 30*time.Minute).Should(Succeed())
+	})
+
 	It("can reboot all workers gracefully", func() {
 		workersBefore, err := getSerfWorkerMembers()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
test `neco reboot-worker`'s queueing behavior with:
- without options
- with `--role=cs`
- with `--role=ss`

see also: https://github.com/cybozu-go/neco/pull/2247

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>