### PR TITLE
Set GitHub Token for bootstrap test

### DIFF
--- a/dctest/setup_test.go
+++ b/dctest/setup_test.go
@@ -3,6 +3,7 @@ package dctest
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cybozu-go/log"
@@ -47,8 +48,9 @@ WantedBy=multi-user.target`
 	It("should complete on all boot servers", func() {
 		env := well.NewEnvironment(context.Background())
 		env.Go(func(ctx context.Context) error {
-			stdout, stderr, err := execAt(
-				bootServers[0], "sudo", "neco", "setup", "--no-revoke", "--proxy="+proxy, "0", "1", "2")
+			stdout, stderr, err := execAtWithInput(
+				bootServers[0], []byte(os.Getenv("GITHUB_TOKEN")), "sudo", "neco", "setup", "--no-revoke",
+				"--proxy="+proxy, "0", "1", "2")
 			if err != nil {
 				log.Error("neco setup failed", map[string]interface{}{
 					"host":   "boot-0",
@@ -60,8 +62,9 @@ WantedBy=multi-user.target`
 			return nil
 		})
 		env.Go(func(ctx context.Context) error {
-			stdout, stderr, err := execAt(
-				bootServers[1], "sudo", "neco", "setup", "--no-revoke", "--proxy="+proxy, "0", "1", "2")
+			stdout, stderr, err := execAtWithInput(
+				bootServers[1], []byte(os.Getenv("GITHUB_TOKEN")), "sudo", "neco", "setup", "--no-revoke",
+				"--proxy="+proxy, "0", "1", "2")
 			if err != nil {
 				log.Error("neco setup failed", map[string]interface{}{
 					"host":   "boot-1",
@@ -73,8 +76,9 @@ WantedBy=multi-user.target`
 			return nil
 		})
 		env.Go(func(ctx context.Context) error {
-			stdout, stderr, err := execAt(
-				bootServers[2], "sudo", "neco", "setup", "--no-revoke", "--proxy="+proxy, "0", "1", "2")
+			stdout, stderr, err := execAtWithInput(
+				bootServers[2], []byte(os.Getenv("GITHUB_TOKEN")), "sudo", "neco", "setup", "--no-revoke",
+				"--proxy="+proxy, "0", "1", "2")
 			if err != nil {
 				log.Error("neco setup failed", map[string]interface{}{
 					"host":   "boot-2",

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Setup installs and configures etcd and vault cluster.
-func Setup(ctx context.Context, lrns []int, revoke bool, proxy string) error {
+func Setup(ctx context.Context, lrns []int, revoke bool, proxy, ghToken string) error {
 	rt, err := neco.GetContainerRuntime(proxy)
 	if err != nil {
 		return err
@@ -252,6 +252,12 @@ func Setup(ctx context.Context, lrns []int, revoke bool, proxy string) error {
 		err = enableEtcdAuth(ctx, ec)
 		if err != nil {
 			return err
+		}
+
+		if ghToken != "" {
+			if err := st.PutGitHubToken(ctx, ghToken); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
The neco-updater process sometimes aborts due to the API rate limit exceeded error in the bootstrap test. (That occurs in certain bare-metal servers). This PR set a gh token for neco-worker in the neco setup command to avoid the error using the GitHub PAT located in the neco repository(github-token file).