### PR TITLE
Upgrade Cilium to 1.12.8

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -15,9 +15,9 @@ var CurrentArtifacts = ArtifactSet{
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.13.2", Private: true},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "5.7.0.2", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.13.0.1", Private: false},
-		{Name: "cilium", Repository: "quay.io/cybozu/cilium", Tag: "1.12.4.2", Private: false},
-		{Name: "cilium-operator-generic", Repository: "quay.io/cybozu/cilium-operator-generic", Tag: "1.12.4.2", Private: false},
-		{Name: "hubble-relay", Repository: "quay.io/cybozu/hubble-relay", Tag: "1.12.4.1", Private: false},
+		{Name: "cilium", Repository: "quay.io/cybozu/cilium", Tag: "1.12.8.4", Private: false},
+		{Name: "cilium-operator-generic", Repository: "quay.io/cybozu/cilium-operator-generic", Tag: "1.12.8.1", Private: false},
+		{Name: "hubble-relay", Repository: "quay.io/cybozu/hubble-relay", Tag: "1.12.8.1", Private: false},
 		{Name: "cilium-certgen", Repository: "quay.io/cybozu/cilium-certgen", Tag: "0.1.8.1", Private: false},
 	},
 	Debs: []DebianPackage{

--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,9 +1,3 @@
 images:
 - repository: quay.io/cybozu/squid
-  versions: ["5.8.0.1"]
-- repository: quay.io/cybozu/cilium
-  versions: ["1.12.8.2","1.12.8.1"]
-- repository: quay.io/cybozu/cilium-operator-generic
-  versions: ["1.12.8.1"]
-- repository: quay.io/cybozu/hubble-relay
-  versions: ["1.12.8.1"]
+  versions: ["5.8.0.1","5.8.0.2"]

--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -48,6 +48,7 @@ data:
   identity-allocation-mode: crd
   cilium-endpoint-gc-interval: "5m0s"
   nodes-gc-interval: "5m0s"
+  skip-cnp-status-startup-clean: "false"
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
   # To include or exclude matched resources from cilium identity evaluation
@@ -201,6 +202,7 @@ data:
   enable-svc-source-range-check: "true"
   enable-l2-neigh-discovery: "true"
   arping-refresh-period: "30s"
+  cni-uninstall: "true"
   # Disable health checking, when chaining mode is not set to portmap or none
   enable-endpoint-health-checking: "false"
   enable-health-checking: "true"
@@ -746,7 +748,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776"
+        cilium.io/cilium-configmap-checksum: "4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -757,7 +759,7 @@ spec:
     spec:
       containers:
       - name: cilium-agent
-        image: "quay.io/cybozu/cilium:1.12.4.2"
+        image: "quay.io/cybozu/cilium:1.12.8.4"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -865,11 +867,8 @@ spec:
           protocol: TCP
         securityContext:
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            level: s0
+            type: spc_t
           capabilities:
             add:
               # Use to set socket permission
@@ -923,8 +922,6 @@ spec:
           mountPath: /sys/fs/cgroup
         - name: cilium-run
           mountPath: /var/run/cilium
-        - name: cni-path
-          mountPath: /host/opt/cni/bin
         - name: etc-cni-netd
           mountPath: /host/etc/cni/net.d
         - name: clustermesh-secrets
@@ -950,7 +947,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "quay.io/cybozu/cilium:1.12.4.2"
+        image: "quay.io/cybozu/cilium:1.12.8.4"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -966,7 +963,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "quay.io/cybozu/cilium:1.12.4.2"
+        image: "quay.io/cybozu/cilium:1.12.8.4"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -990,11 +987,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            level: s0
+            type: spc_t
           capabilities:
             # Most of the capabilities here are the same ones used in the
             # cilium-agent's container because this container can be used to
@@ -1031,10 +1025,32 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi # wait-for-kube-proxy
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: "quay.io/cybozu/cilium:1.12.8.4"
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: "cilium"
       serviceAccountName: "cilium"
+      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 1
       hostNetwork: true
       affinity:
@@ -1147,7 +1163,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776"
+        cilium.io/cilium-configmap-checksum: "4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -1156,7 +1172,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: "quay.io/cybozu/cilium-operator-generic:1.12.4.2"
+        image: "quay.io/cybozu/cilium-operator-generic:1.12.8.1"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1215,6 +1231,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: "cilium-operator"
       serviceAccountName: "cilium-operator"
+      automountServiceAccountToken: true
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.
       affinity:
@@ -1264,7 +1281,7 @@ spec:
     spec:
       containers:
         - name: hubble-relay
-          image: "quay.io/cybozu/hubble-relay:1.12.4.1"
+          image: "quay.io/cybozu/hubble-relay:1.12.8.1"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -1339,7 +1356,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hubble-generate-certs-6458353616
+  name: hubble-generate-certs-5d5d11e923
   namespace: kube-system
   labels:
     k8s-app: hubble-generate-certs
@@ -1372,6 +1389,7 @@ spec:
       hostNetwork: true
       serviceAccount: "hubble-generate-certs"
       serviceAccountName: "hubble-generate-certs"
+      automountServiceAccountToken: true
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 1800
 ---
@@ -1416,5 +1434,6 @@ spec:
           hostNetwork: true
           serviceAccount: "hubble-generate-certs"
           serviceAccountName: "hubble-generate-certs"
+          automountServiceAccountToken: true
           restartPolicy: OnFailure
       ttlSecondsAfterFinished: 1800

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -48,6 +48,7 @@ data:
   identity-allocation-mode: crd
   cilium-endpoint-gc-interval: "5m0s"
   nodes-gc-interval: "5m0s"
+  skip-cnp-status-startup-clean: "false"
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
   # To include or exclude matched resources from cilium identity evaluation
@@ -201,6 +202,7 @@ data:
   enable-svc-source-range-check: "true"
   enable-l2-neigh-discovery: "true"
   arping-refresh-period: "30s"
+  cni-uninstall: "true"
   # Disable health checking, when chaining mode is not set to portmap or none
   enable-endpoint-health-checking: "false"
   enable-health-checking: "true"
@@ -746,7 +748,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776"
+        cilium.io/cilium-configmap-checksum: "4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -757,7 +759,7 @@ spec:
     spec:
       containers:
       - name: cilium-agent
-        image: "quay.io/cybozu/cilium:1.12.4.2"
+        image: "quay.io/cybozu/cilium:1.12.8.4"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -865,11 +867,8 @@ spec:
           protocol: TCP
         securityContext:
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            level: s0
+            type: spc_t
           capabilities:
             add:
               # Use to set socket permission
@@ -923,8 +922,6 @@ spec:
           mountPath: /sys/fs/cgroup
         - name: cilium-run
           mountPath: /var/run/cilium
-        - name: cni-path
-          mountPath: /host/opt/cni/bin
         - name: etc-cni-netd
           mountPath: /host/etc/cni/net.d
         - name: clustermesh-secrets
@@ -950,7 +947,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "quay.io/cybozu/cilium:1.12.4.2"
+        image: "quay.io/cybozu/cilium:1.12.8.4"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -966,7 +963,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "quay.io/cybozu/cilium:1.12.4.2"
+        image: "quay.io/cybozu/cilium:1.12.8.4"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -990,11 +987,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           seLinuxOptions:
-            level: 's0'
-            # Running with spc_t since we have removed the privileged mode.
-            # Users can change it to a different type as long as they have the
-            # type available on the system.
-            type: 'spc_t'
+            level: s0
+            type: spc_t
           capabilities:
             # Most of the capabilities here are the same ones used in the
             # cilium-agent's container because this container can be used to
@@ -1031,10 +1025,32 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi # wait-for-kube-proxy
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: "quay.io/cybozu/cilium:1.12.8.4"
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+          capabilities:
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: "cilium"
       serviceAccountName: "cilium"
+      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 1
       hostNetwork: true
       affinity:
@@ -1147,7 +1163,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776"
+        cilium.io/cilium-configmap-checksum: "4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -1156,7 +1172,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: "quay.io/cybozu/cilium-operator-generic:1.12.4.2"
+        image: "quay.io/cybozu/cilium-operator-generic:1.12.8.1"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic
@@ -1215,6 +1231,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: "cilium-operator"
       serviceAccountName: "cilium-operator"
+      automountServiceAccountToken: true
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.
       affinity:
@@ -1264,7 +1281,7 @@ spec:
     spec:
       containers:
         - name: hubble-relay
-          image: "quay.io/cybozu/hubble-relay:1.12.4.1"
+          image: "quay.io/cybozu/hubble-relay:1.12.8.1"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -1339,7 +1356,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hubble-generate-certs-6458353616
+  name: hubble-generate-certs-5d5d11e923
   namespace: kube-system
   labels:
     k8s-app: hubble-generate-certs
@@ -1372,6 +1389,7 @@ spec:
       hostNetwork: true
       serviceAccount: "hubble-generate-certs"
       serviceAccountName: "hubble-generate-certs"
+      automountServiceAccountToken: true
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 1800
 ---
@@ -1416,5 +1434,6 @@ spec:
           hostNetwork: true
           serviceAccount: "hubble-generate-certs"
           serviceAccountName: "hubble-generate-certs"
+          automountServiceAccountToken: true
           restartPolicy: OnFailure
       ttlSecondsAfterFinished: 1800

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -470,6 +470,7 @@ data:
   cluster-pool-ipv4-cidr: 10.0.0.0/8
   cluster-pool-ipv4-mask-size: "24"
   cni-chaining-mode: generic-veth
+  cni-uninstall: "true"
   custom-cni-conf: "true"
   debug: "false"
   devices: eth+ eno1+ eno2+
@@ -536,6 +537,7 @@ data:
   remove-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
   sidecar-istio-proxy-image: cilium/istio_proxy
+  skip-cnp-status-startup-clean: "false"
   synchronize-k8s-nodes: "true"
   tofqdns-dns-reject-response-code: refused
   tofqdns-enable-dns-compression: "true"
@@ -664,7 +666,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776
+        cilium.io/cilium-configmap-checksum: 4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -678,6 +680,7 @@ spec:
               matchLabels:
                 io.cilium/app: operator
             topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -705,7 +708,7 @@ spec:
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: "16443"
-        image: quay.io/cybozu/cilium-operator-generic:1.12.4.2
+        image: quay.io/cybozu/cilium-operator-generic:1.12.8.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -787,7 +790,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cybozu/hubble-relay:1.12.4.1
+        image: quay.io/cybozu/hubble-relay:1.12.8.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:
@@ -862,6 +865,7 @@ spec:
           labels:
             k8s-app: hubble-generate-certs
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --cilium-namespace=kube-system
@@ -915,7 +919,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776
+        cilium.io/cilium-configmap-checksum: 4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"
@@ -930,6 +934,7 @@ spec:
               matchLabels:
                 k8s-app: cilium
             topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -964,7 +969,7 @@ spec:
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: "16443"
-        image: quay.io/cybozu/cilium:1.12.4.2
+        image: quay.io/cybozu/cilium:1.12.8.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -1071,8 +1076,6 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
-        - mountPath: /host/opt/cni/bin
-          name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
         - mountPath: /var/lib/cilium/clustermesh
@@ -1100,7 +1103,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cybozu/cilium:1.12.4.2
+        image: quay.io/cybozu/cilium:1.12.8.4
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -1129,7 +1132,7 @@ spec:
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: "16443"
-        image: quay.io/cybozu/cilium:1.12.4.2
+        image: quay.io/cybozu/cilium:1.12.8.4
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -1157,6 +1160,26 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
+      - command:
+        - /install-plugin.sh
+        image: quay.io/cybozu/cilium:1.12.8.4
+        imagePullPolicy: IfNotPresent
+        name: install-cni-binaries
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1237,7 +1260,7 @@ kind: Job
 metadata:
   labels:
     k8s-app: hubble-generate-certs
-  name: hubble-generate-certs-6458353616
+  name: hubble-generate-certs-5d5d11e923
   namespace: kube-system
 spec:
   template:
@@ -1245,6 +1268,7 @@ spec:
       labels:
         k8s-app: hubble-generate-certs
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --cilium-namespace=kube-system

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -470,6 +470,7 @@ data:
   cluster-pool-ipv4-cidr: 10.0.0.0/8
   cluster-pool-ipv4-mask-size: "24"
   cni-chaining-mode: generic-veth
+  cni-uninstall: "true"
   custom-cni-conf: "true"
   debug: "false"
   devices: eth+ eno1+ eno2+
@@ -536,6 +537,7 @@ data:
   remove-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
   sidecar-istio-proxy-image: cilium/istio_proxy
+  skip-cnp-status-startup-clean: "false"
   synchronize-k8s-nodes: "true"
   tofqdns-dns-reject-response-code: refused
   tofqdns-enable-dns-compression: "true"
@@ -664,7 +666,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776
+        cilium.io/cilium-configmap-checksum: 4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -678,6 +680,7 @@ spec:
               matchLabels:
                 io.cilium/app: operator
             topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -705,7 +708,7 @@ spec:
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: "16443"
-        image: quay.io/cybozu/cilium-operator-generic:1.12.4.2
+        image: quay.io/cybozu/cilium-operator-generic:1.12.8.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -787,7 +790,7 @@ spec:
         - serve
         command:
         - hubble-relay
-        image: quay.io/cybozu/hubble-relay:1.12.4.1
+        image: quay.io/cybozu/hubble-relay:1.12.8.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:
@@ -862,6 +865,7 @@ spec:
           labels:
             k8s-app: hubble-generate-certs
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --cilium-namespace=kube-system
@@ -915,7 +919,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 6782953c836676cff457c41bd94e8e062246c3fcdf23e29ee9b6033ee959a776
+        cilium.io/cilium-configmap-checksum: 4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"
@@ -930,6 +934,7 @@ spec:
               matchLabels:
                 k8s-app: cilium
             topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: true
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -964,7 +969,7 @@ spec:
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: "16443"
-        image: quay.io/cybozu/cilium:1.12.4.2
+        image: quay.io/cybozu/cilium:1.12.8.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -1071,8 +1076,6 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
-        - mountPath: /host/opt/cni/bin
-          name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
         - mountPath: /var/lib/cilium/clustermesh
@@ -1100,7 +1103,7 @@ spec:
         - /bin/bash
         - -c
         - --
-        image: quay.io/cybozu/cilium:1.12.4.2
+        image: quay.io/cybozu/cilium:1.12.8.4
         imagePullPolicy: IfNotPresent
         name: mount-bpf-fs
         securityContext:
@@ -1129,7 +1132,7 @@ spec:
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
           value: "16443"
-        image: quay.io/cybozu/cilium:1.12.4.2
+        image: quay.io/cybozu/cilium:1.12.8.4
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -1157,6 +1160,26 @@ spec:
           name: cilium-cgroup
         - mountPath: /var/run/cilium
           name: cilium-run
+      - command:
+        - /install-plugin.sh
+        image: quay.io/cybozu/cilium:1.12.8.4
+        imagePullPolicy: IfNotPresent
+        name: install-cni-binaries
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          seLinuxOptions:
+            level: s0
+            type: spc_t
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-path
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1237,7 +1260,7 @@ kind: Job
 metadata:
   labels:
     k8s-app: hubble-generate-certs
-  name: hubble-generate-certs-6458353616
+  name: hubble-generate-certs-5d5d11e923
   namespace: kube-system
 spec:
   template:
@@ -1245,6 +1268,7 @@ spec:
       labels:
         k8s-app: hubble-generate-certs
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --cilium-namespace=kube-system


### PR DESCRIPTION
We can't upgrade cilium and squid at the same time. Let's upgrade squid separately

- Fail to start squid pod because cilium hasn't started yet
- Fail to pull new cilium image because squid hasn't started yet
  - Communication through the node port svc(squid svc) fail because cilium can't update the bpf map 