### PR TITLE
Configure CKE to retry reboot command

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -27,6 +27,7 @@ reboot:
   max_concurrent_reboots: 1
   eviction_timeout_seconds: 1800
   command_timeout_seconds: 30
+  command_retries: 5
 options:
   kube-api:
     audit_log_enabled: true


### PR DESCRIPTION
CKE 1.25.1 introduces a configuration parameter `.reboot.command_retries`
for the reboot queue.
This commit specifies the parameter to issue the reboot command for
6 times.
This may suspend CKE's reconciliation for up to 180 seconds.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>