### PR TITLE
Refine BIRD configuration parameters

### DIFF
--- a/ignitions/common/files/etc/bird/bird.conf
+++ b/ignitions/common/files/etc/bird/bird.conf
@@ -8,8 +8,8 @@ protocol direct singles {
 }
 protocol bfd {
     interface "*" {
-       min rx interval 300 ms;
-       min tx interval 300 ms;
+       min rx interval 400 ms;
+       min tx interval 400 ms;
     };
 }
 protocol kernel {
@@ -49,6 +49,7 @@ template bgp tor {
     local as {{ add 64600 .Spec.Rack }};
     direct;
     bfd;
+    error wait time 3,300;
     ipv4 {
         # Accept routes regardless of its NEXT_HOP.
         igp table dummytab;

--- a/installer/setup/templates.go
+++ b/installer/setup/templates.go
@@ -14,8 +14,8 @@ protocol direct singles {
 }
 protocol bfd {
     interface "*" {
-       min rx interval 300 ms;
-       min tx interval 300 ms;
+       min rx interval 400 ms;
+       min tx interval 400 ms;
     };
 }
 protocol kernel {
@@ -37,6 +37,7 @@ template bgp tor {
     local as {{ .ASN }};
     direct;
     bfd;
+    error wait time 3,300;
 
     ipv4 {
         # Accept routes regardless of its NEXT_HOP.


### PR DESCRIPTION
This commit updates the BIRD configuration to extend the BFD TX/RX intervals
from 300 ms to 400 ms.
The multiplier is set to 5 in default.
This combination means that a link is not declared as down if the link
failure is shorter than 2 sec.
In other words, the detection of the link failure is delayed by 2 sec.

This commit also shorten the minimum delay between a protocol failure
and automatic restart for the BGP protocols from 60 sec (default) to
3 sec.
This will speed up the recovery from a failure.

See https://bird.network.cz/?get_doc&v=20&f=bird-6.html#ss6.2 for the BFD parameters.
See https://bird.network.cz/?get_doc&v=20&f=bird-6.html#ss6.3 for the BGP parameters.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>