### PR TITLE
Disable hubble metrics

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -220,19 +220,6 @@ data:
   enable-hubble: "true"
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path: "/var/run/cilium/hubble.sock"
-  # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
-  # field is not set.
-  hubble-metrics-server: ":9965"
-  # A space separated list of metrics to enable. See [0] for available metrics.
-  #
-  # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md
-  hubble-metrics:
-    dns
-    drop:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip
-    tcp
-    flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip
-    icmp
-    http
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: ":4244"
   hubble-disable-tls: "false"
@@ -691,28 +678,6 @@ spec:
     port: 443
     targetPort: 4245
 ---
-# Source: cilium/templates/hubble/metrics-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: hubble-metrics
-  namespace: kube-system
-  labels:
-    k8s-app: hubble
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9965"
-spec:
-  clusterIP: None
-  type: ClusterIP
-  ports:
-  - name: hubble-metrics
-    port: 9965
-    protocol: TCP
-    targetPort: hubble-metrics
-  selector:
-    k8s-app: cilium
----
 # Source: cilium/templates/hubble/peer-service.yaml
 apiVersion: v1
 kind: Service
@@ -753,7 +718,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "22795da6a7477223260d64cf0ef5c29e95c4d202e2fddcf894e9e80ebeca96ad"
+        cilium.io/cilium-configmap-checksum: "0b98692a8135484d3cdc0c9b00165864810bc7f547440e32cfe14040eba34c10"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -865,10 +830,6 @@ spec:
         - name: envoy-metrics
           containerPort: 9964
           hostPort: 9964
-          protocol: TCP
-        - name: hubble-metrics
-          containerPort: 9965
-          hostPort: 9965
           protocol: TCP
         securityContext:
           seLinuxOptions:
@@ -1168,7 +1129,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "22795da6a7477223260d64cf0ef5c29e95c4d202e2fddcf894e9e80ebeca96ad"
+        cilium.io/cilium-configmap-checksum: "0b98692a8135484d3cdc0c9b00165864810bc7f547440e32cfe14040eba34c10"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -37,14 +37,6 @@ hubble:
   tls:
     auto:
       method: "cronJob"
-  metrics:
-    enabled:
-      - "dns"
-      - "drop:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip"
-      - "tcp"
-      - "flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip"
-      - "icmp"
-      - "http"
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -215,19 +215,6 @@ data:
   enable-hubble: "true"
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path: "/var/run/cilium/hubble.sock"
-  # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
-  # field is not set.
-  hubble-metrics-server: ":9965"
-  # A space separated list of metrics to enable. See [0] for available metrics.
-  #
-  # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md
-  hubble-metrics:
-    dns
-    drop:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip
-    tcp
-    flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip
-    icmp
-    http
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: ":4244"
   hubble-disable-tls: "false"
@@ -686,28 +673,6 @@ spec:
     port: 443
     targetPort: 4245
 ---
-# Source: cilium/templates/hubble/metrics-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: hubble-metrics
-  namespace: kube-system
-  labels:
-    k8s-app: hubble
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9965"
-spec:
-  clusterIP: None
-  type: ClusterIP
-  ports:
-  - name: hubble-metrics
-    port: 9965
-    protocol: TCP
-    targetPort: hubble-metrics
-  selector:
-    k8s-app: cilium
----
 # Source: cilium/templates/hubble/peer-service.yaml
 apiVersion: v1
 kind: Service
@@ -748,7 +713,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449"
+        cilium.io/cilium-configmap-checksum: "65aff468d3e584347030d5fecca8490c99558a232bef606e1e2fd11726d4037e"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -860,10 +825,6 @@ spec:
         - name: envoy-metrics
           containerPort: 9964
           hostPort: 9964
-          protocol: TCP
-        - name: hubble-metrics
-          containerPort: 9965
-          hostPort: 9965
           protocol: TCP
         securityContext:
           seLinuxOptions:
@@ -1163,7 +1124,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449"
+        cilium.io/cilium-configmap-checksum: "65aff468d3e584347030d5fecca8490c99558a232bef606e1e2fd11726d4037e"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -37,14 +37,6 @@ hubble:
   tls:
     auto:
       method: "cronJob"
-  metrics:
-    enabled:
-      - "dns"
-      - "drop:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip"
-      - "tcp"
-      - "flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip"
-      - "icmp"
-      - "http"
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -508,9 +508,6 @@ data:
   enable-xt-socket-fallback: "true"
   hubble-disable-tls: "false"
   hubble-listen-address: :4244
-  hubble-metrics: dns drop:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip
-    tcp flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip icmp http
-  hubble-metrics-server: :9965
   hubble-socket-path: /var/run/cilium/hubble.sock
   hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
   hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
@@ -594,27 +591,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "9965"
-    prometheus.io/scrape: "true"
-  labels:
-    k8s-app: hubble
-  name: hubble-metrics
-  namespace: kube-system
-spec:
-  clusterIP: None
-  ports:
-  - name: hubble-metrics
-    port: 9965
-    protocol: TCP
-    targetPort: hubble-metrics
-  selector:
-    k8s-app: cilium
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
   labels:
     k8s-app: cilium
   name: hubble-peer
@@ -667,7 +643,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 22795da6a7477223260d64cf0ef5c29e95c4d202e2fddcf894e9e80ebeca96ad
+        cilium.io/cilium-configmap-checksum: 0b98692a8135484d3cdc0c9b00165864810bc7f547440e32cfe14040eba34c10
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -920,7 +896,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 22795da6a7477223260d64cf0ef5c29e95c4d202e2fddcf894e9e80ebeca96ad
+        cilium.io/cilium-configmap-checksum: 0b98692a8135484d3cdc0c9b00165864810bc7f547440e32cfe14040eba34c10
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"
@@ -1010,10 +986,6 @@ spec:
         - containerPort: 9964
           hostPort: 9964
           name: envoy-metrics
-          protocol: TCP
-        - containerPort: 9965
-          hostPort: 9965
-          name: hubble-metrics
           protocol: TCP
         readinessProbe:
           failureThreshold: 3

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -508,9 +508,6 @@ data:
   enable-xt-socket-fallback: "true"
   hubble-disable-tls: "false"
   hubble-listen-address: :4244
-  hubble-metrics: dns drop:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip
-    tcp flow:destinationContext=pod|dns|ip;sourceContext=pod|dns|ip icmp http
-  hubble-metrics-server: :9965
   hubble-socket-path: /var/run/cilium/hubble.sock
   hubble-tls-cert-file: /var/lib/cilium/tls/hubble/server.crt
   hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/client-ca.crt
@@ -593,27 +590,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "9965"
-    prometheus.io/scrape: "true"
-  labels:
-    k8s-app: hubble
-  name: hubble-metrics
-  namespace: kube-system
-spec:
-  clusterIP: None
-  ports:
-  - name: hubble-metrics
-    port: 9965
-    protocol: TCP
-    targetPort: hubble-metrics
-  selector:
-    k8s-app: cilium
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
   labels:
     k8s-app: cilium
   name: hubble-peer
@@ -666,7 +642,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449
+        cilium.io/cilium-configmap-checksum: 65aff468d3e584347030d5fecca8490c99558a232bef606e1e2fd11726d4037e
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -919,7 +895,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 4e1abf0cfb0def3954391477f8ccf2b6ed26880390e3248de85b67aea9a1b449
+        cilium.io/cilium-configmap-checksum: 65aff468d3e584347030d5fecca8490c99558a232bef606e1e2fd11726d4037e
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"
@@ -1009,10 +985,6 @@ spec:
         - containerPort: 9964
           hostPort: 9964
           name: envoy-metrics
-          protocol: TCP
-        - containerPort: 9965
-          hostPort: 9965
-          name: hubble-metrics
           protocol: TCP
         readinessProbe:
           failureThreshold: 3


### PR DESCRIPTION
We've remove the scrape config for the hubble metrics. So let's disable the hubble metrics for now.