### PR TITLE
Extend lifetimes of docker containers and images

### DIFF
--- a/debian/lib/systemd/system/docker-prune.service
+++ b/debian/lib/systemd/system/docker-prune.service
@@ -6,5 +6,5 @@ ConditionPathExists=/usr/bin/docker
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker container prune -f --filter "until=72h"
-ExecStart=/usr/bin/docker image prune -a -f --filter "until=72h"
+ExecStart=/usr/bin/docker container prune -f --filter "until=168h"
+ExecStart=/usr/bin/docker image prune -a -f --filter "until=168h"

--- a/ignitions/common/systemd/docker-prune.service
+++ b/ignitions/common/systemd/docker-prune.service
@@ -5,5 +5,5 @@ Wants=network-online.target docker.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker container prune -f --filter "until=72h"
-ExecStart=/usr/bin/docker image prune -a -f --filter "until=72h"
+ExecStart=/usr/bin/docker container prune -f --filter "until=168h"
+ExecStart=/usr/bin/docker image prune -a -f --filter "until=168h"


### PR DESCRIPTION
This commit extends the lifetimes of docker containers and images
from 3 days to 7 days.
This will save containers/images from deletion even if the server
is inactive for several days.

Note that we cannot use the notation of "7d" nor "1w" because
Docker employs Go duration strings.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>