### PR TITLE
Ignore Cilium 1.12.10

### DIFF
--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,0 +1,7 @@
+images:
+- repository: quay.io/cybozu/cilium
+  versions: ["1.12.10.1"]
+- repository: quay.io/cybozu/cilium-operator-generic
+  versions: ["1.12.10.1"]
+- repository: quay.io/cybozu/hubble-relay
+  versions: ["1.12.10.1"]


### PR DESCRIPTION
Hold off on Cilium updates until squid 5.8.0 is released, since we can't upgrade Cilium and squid at the same time
https://github.com/cybozu-go/neco/pull/2301
