### PR TITLE
update libssl3 package url for installer

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -39,9 +39,9 @@ BIRD2_SHA512 = 21b17a1e52dba90e0f35bb6b0cd8048c355de4c8364951d495e50d6e387ca807c
 LIBSSH_URL = http://archive.ubuntu.com/ubuntu/pool/main/libs/libssh/libssh-gcrypt-4_0.9.6-2build1_amd64.deb
 LIBSSH_DEB = build/$(notdir $(LIBSSH_URL))
 LIBSSH_SHA512 = c0a52a502da59cc644e178b351dc1edfdc44e04ea61184fc858e6d9dbdf161b27f2a30371e721a3ffb9c513ac23706fecc0df1b21259ec1183788049bf64547d
-LIBSSL3_URL = http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.9_amd64.deb
+LIBSSL3_URL = http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl3_3.0.2-0ubuntu1.10_amd64.deb
 LIBSSL3_DEB = build/$(notdir $(LIBSSL3_URL))
-LIBSSL3_SHA512 = c1906da77753689db0d9748d49ef6759b26d1bfaabf18ad40a01a00dd706ce90cea19ce2151b47507cc7d0f7ac227b571fbfe8b3230970866b6537451180d162
+LIBSSL3_SHA512 = 3408b20e644b0594cc85fb65732377c7683193283d980b5ffcb4fd8026f3a850f366005448452a5a0a17bc2ad3f93a36f3e3af92f084b3ec6237502163ee899b
 endif
 DEBS = $(CHRONY_DEB) $(BIRD2_DEB) $(LIBSSH_DEB) $(LIBSSL3_DEB)
 


### PR DESCRIPTION
workaround for the environment which is detected "not 22.04"

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>