### PR TITLE
update argocd to ver 2.6.8

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -12,7 +12,7 @@ STERN_VERSION = 1.23.0
 
 
 ## These should be updated regularly
-ARGOCD_VERSION = 2.6.7
+ARGOCD_VERSION = 2.6.8
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L10
 KUSTOMIZE_VERSION = 4.5.7


### PR DESCRIPTION
Update Argo CD to 2.6.8 from 2.6.7