### PR TITLE
Remove ttlSecondsAfterFinished from hubble-generate-certs Job

### DIFF
--- a/cilium/pre/kustomization.yaml
+++ b/cilium/pre/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - bgp_config.yaml
   - upstream.yaml
-patchesJson6902:
+patches:
   - target:
       group: apps
       version: v1
@@ -25,3 +25,11 @@ patchesJson6902:
         path: /metadata/annotations
         value:
           cke.cybozu.com/rank: "2500"
+  - target:
+      group: batch
+      version: v1
+      kind: Job
+      name: hubble-generate-certs-52f7318499
+    patch: |-
+      - op: remove
+        path: /spec/ttlSecondsAfterFinished

--- a/cilium/prod/kustomization.yaml
+++ b/cilium/prod/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - bgp_config.yaml
   - upstream.yaml
-patchesJson6902:
+patches:
   - target:
       group: apps
       version: v1
@@ -25,3 +25,11 @@ patchesJson6902:
         path: /metadata/annotations
         value:
           cke.cybozu.com/rank: "2500"
+  - target:
+      group: batch
+      version: v1
+      kind: Job
+      name: hubble-generate-certs-52f7318499
+    patch: |-
+      - op: remove
+        path: /spec/ttlSecondsAfterFinished

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -1377,4 +1377,3 @@ spec:
       restartPolicy: OnFailure
       serviceAccount: hubble-generate-certs
       serviceAccountName: hubble-generate-certs
-  ttlSecondsAfterFinished: 1800

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -1376,4 +1376,3 @@ spec:
       restartPolicy: OnFailure
       serviceAccount: hubble-generate-certs
       serviceAccountName: hubble-generate-certs
-  ttlSecondsAfterFinished: 1800


### PR DESCRIPTION
`ttlSecondsAfterFinished` causes the job to be deleted in 30 minutes; CKE will recreate the job.