### PR TITLE
Disable iscsiuio.service

### DIFF
--- a/docs/ignition.md
+++ b/docs/ignition.md
@@ -211,6 +211,8 @@ Following services are masked:
 * `systemd-timesyncd.service`: ditto.
 * `rkt-metadata.service`: we do not use this.
 * `rkt-metadata.socket`: ditto.
+* `iscsiuio.service`: we do not use this.
+* `iscsiuio.socket`: ditto.
 
 Serf tags
 ---------

--- a/ignition-template/settings.json
+++ b/ignition-template/settings.json
@@ -185,6 +185,14 @@
           "mask": true
         },
         {
+          "name": "iscsiuio.service",
+          "mask": true
+        },
+        {
+          "name": "iscsiuio.socket",
+          "mask": true
+        },
+        {
           "name": "docker.service",
           "enabled": true
         },

--- a/ignition-template/settings.json
+++ b/ignition-template/settings.json
@@ -144,6 +144,7 @@
         "/opt/sbin/chrony-wait",
         "/opt/sbin/disable-nic-offload",
         "/opt/sbin/neco-wait-dhcp-online",
+        "/opt/sbin/reset-iscsiuio",
         "/opt/sbin/setup-bmc-user",
         "/opt/sbin/setup-containerd",
         "/opt/sbin/setup-hw",
@@ -362,6 +363,10 @@
         },
         {
           "name": "setup-seccomp-profile.service",
+          "enabled": true
+        },
+        {
+          "name": "reset-iscsiuio.service",
           "enabled": true
         }
       ],

--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -32,6 +32,7 @@ files:
   - /opt/sbin/chrony-wait
   - /opt/sbin/disable-nic-offload
   - /opt/sbin/neco-wait-dhcp-online
+  - /opt/sbin/reset-iscsiuio
   - /opt/sbin/setup-bmc-user
   - /opt/sbin/setup-containerd
   - /opt/sbin/setup-hw
@@ -143,6 +144,8 @@ systemd:
     name: remove-kubelet-state.service
   - enabled: true
     name: setup-seccomp-profile.service
+  - enabled: true
+    name: reset-iscsiuio.service
 networkd:
   - 01-eth0.network
   - 01-eth1.network

--- a/ignitions/common/common.yml
+++ b/ignitions/common/common.yml
@@ -57,6 +57,10 @@ systemd:
     name: systemd-timesyncd.service
   - mask: true
     name: tcsd.service
+  - mask: true
+    name: iscsiuio.service
+  - mask: true
+    name: iscsiuio.socket
   - enabled: true
     name: docker.service
   - enabled: true

--- a/ignitions/common/files/opt/sbin/reset-iscsiuio
+++ b/ignitions/common/files/opt/sbin/reset-iscsiuio
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+if systemctl list-units --state=masked --no-legend --plain --full | fgrep iscsiuio.service; then
+    if [ "$(systemctl is-active iscsiuio.service)" = "failed" ]; then
+        echo 'iscsiuio.service is masked but failed. Resetting...'
+        systemctl reset-failed iscsiuio.service
+    fi
+fi

--- a/ignitions/common/systemd/reset-iscsiuio.service
+++ b/ignitions/common/systemd/reset-iscsiuio.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reset unused iSCSI UserSpace I/O service
+Before=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/sbin/reset-iscsiuio
+RemainAfterExit=yes
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR:
- masks `iscsiuio.service` because it is not used
- resets failure status of `iscsiuio.service` when masked, because it causes CI instability.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>