### PR TITLE
Ignore Cilium related images

### DIFF
--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,0 +1,9 @@
+images:
+- repository: quay.io/cybozu/cilium
+  versions: ["1.13.7.1"]
+- repository: quay.io/cybozu/cilium-operator-generic
+  versions: ["1.13.7.1"]
+- repository: quay.io/cybozu/hubble-relay
+  versions: ["1.13.7.1"]
+- repository: quay.io/cybozu/cilium-certgen
+  versions: ["0.1.9.1"]


### PR DESCRIPTION
This pr prevents `generate_artifacts` from updating cilium accidentally.

Signed-off-by: terasihma <tomoya-terashima@cybozu.co.jp>