### PR TITLE
Fix to use the old commit hash of neco-containers in make update-cilium target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ update-cilium: helm
 	rm -rf /tmp/work-cilium
 	mkdir -p /tmp/work-cilium
 	curl -sSfL https://github.com/cilium/cilium/archive/$(shell echo $(CILIUM_TAG) | cut -d \. -f 1,2,3).tar.gz | tar -C /tmp/work-cilium -xzf - --strip-components=1
-	curl -sSfL -o /tmp/work-cilium/18449.patch https://raw.githubusercontent.com/cybozu/neco-containers/main/cilium/18449.patch
+	curl -sSfL -o /tmp/work-cilium/18449.patch https://raw.githubusercontent.com/cybozu/neco-containers/bafee04577033ed384add6152b016c04d2ffd55d/cilium/18449.patch
 	cd /tmp/work-cilium; patch -p1 --no-backup-if-mismatch < /tmp/work-cilium/18449.patch
 	$(HELM) template /tmp/work-cilium/install/kubernetes/cilium/ \
 		--namespace=kube-system \

--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,0 +1,9 @@
+images:
+- repository: quay.io/cybozu/cilium
+  versions: ["1.13.7.1"]
+- repository: quay.io/cybozu/cilium-operator-generic
+  versions: ["1.13.7.1"]
+- repository: quay.io/cybozu/hubble-relay
+  versions: ["1.13.7.1"]
+- repository: quay.io/cybozu/cilium-certgen
+  versions: ["0.1.9.1"]


### PR DESCRIPTION
This pr fixes CI failures by using removed file: `github.com/cybozu/neco-containers/cilium/18449.patch`.
To avoid this, I changed to use the old commit hash of neco-containers.

https://github.com/cybozu/neco-containers/blob/bafee04577033ed384add6152b016c04d2ffd55d/cilium/18449.patch

Also, this creates `artifacts_ignore.yaml` to ignore newer cilium related images.

Signed-off-by: terasihma <tomoya-terashima@cybozu.co.jp>