### PR TITLE
reset failed status of systemd-networkd-wait-online.service

### DIFF
--- a/dctest/init_test.go
+++ b/dctest/init_test.go
@@ -12,6 +12,14 @@ import (
 
 // testInit test initialization steps
 func testInit() {
+	It("should reset failed status of systemd-networkd-wait-online.service", func() {
+		// systemd-networkd-wait-online.service may fail due to timeout on dctest env
+		// Frankly speaking, it is not a problem because the test program can already connect to boot servers.
+		for _, host := range bootServers {
+			execSafeAt(host, "sudo", "systemctl", "reset-failed", "systemd-networkd-wait-online.service")
+		}
+	})
+
 	It("should create a Vault admin user", func() {
 		// wait for vault leader election
 		time.Sleep(10 * time.Second)


### PR DESCRIPTION
Since yesterday, systemd-networkd-wait-online.service fails due to timeout during neco-apps bootstrap. (The reason is still unknown)
The failure itself doesn't seem a problem because the test code can already connect to boot servers.
Because neco-apps has a alert rule that checks all systemd services are OK, I decide to reset the failed status instead of ignoring the failed status during the test.

note: it may or may not be a temporary resolution.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>