### PR TITLE
Use "apt-get download" to show deb filename

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -21,7 +21,7 @@ LOCALDS_IMG = build/seed.img
 ifeq ($(shell lsb_release --release --short),$(UBUNTU_RELEASE))
 # usage: get-deb-filename PACKAGE
 define get-deb-filename
-$(shell apt-get install --print-uris --reinstall $1 | tail -1 | awk '{print $$2}')
+$(shell apt-get download --print-uris $1 | awk '{print $$2}')
 endef
 CHRONY_DEB = build/$(call get-deb-filename,chrony)
 BIRD2_DEB = build/$(call get-deb-filename,bird2)


### PR DESCRIPTION
"apt-get install --print-uris --reinstall" does not show the filename
of the deb archive if the archive is already cached.
"apt-get download --print-uris" always shows the filename.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>