### PR TITLE
Add "neco bmc repair" subcommand

### DIFF
--- a/dctest/machines_test.go
+++ b/dctest/machines_test.go
@@ -10,13 +10,26 @@ import (
 // testMachines tests machine control functions.
 func testMachines() {
 	It("should put BMC/IPMI settings", func() {
+		// test set/get functions
 		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "bmc-user", "/mnt/bmc-user.json")
-		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-user", "cybozu")
+
+		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-user", "cybozu1")
 		ipmiUser := execSafeAt(bootServers[0], "neco", "bmc", "config", "get", "ipmi-user")
-		Expect(string(ipmiUser)).To(Equal("cybozu\n"))
-		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-password", "cybozu")
+		Expect(string(ipmiUser)).To(Equal("cybozu1\n"))
+		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-password", "cybozu2")
 		ipmiPassword := execSafeAt(bootServers[0], "neco", "bmc", "config", "get", "ipmi-password")
-		Expect(string(ipmiPassword)).To(Equal("cybozu\n"))
+		Expect(string(ipmiPassword)).To(Equal("cybozu2\n"))
+
+		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "repair-user", "cybozu3")
+		repairUser := execSafeAt(bootServers[0], "neco", "bmc", "config", "get", "repair-user")
+		Expect(string(repairUser)).To(Equal("cybozu3\n"))
+		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "repair-password", "cybozu4")
+		repairPassword := execSafeAt(bootServers[0], "neco", "bmc", "config", "get", "repair-password")
+		Expect(string(repairPassword)).To(Equal("cybozu4\n"))
+
+		// finally set user/password hard-coded in underlying virtual BMCs
+		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-user", "cybozu")
+		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-password", "cybozu")
 	})
 
 	It("should setup boot server hardware", func() {

--- a/docs/neco.md
+++ b/docs/neco.md
@@ -167,10 +167,22 @@ Synopsis
     - `bmc-user`: Register [`bmc-user.json`](https://github.com/cybozu-go/setup-hw/blob/master/README.md#etcnecobmc-userjson)
     - `ipmi-user`: Register IPMI username for power management.
     - `ipmi-password`: Register IPMI password for power management.
+    - `repair-user`: Register BMC username for repair operations.
+    - `repair-password`: Register BMC password for repair operations.
 
 * `neco bmc config get KEY`
 
     Get the `VALUE` for `KEY`.
+
+* `neco bmc repair BMC_TYPE BMC_specific_command...`
+
+    Try to repair an unhealthy/unreachable machine by invoking BMC functions remotely.
+
+    * Dell iDRAC:
+        * `neco bmc repair dell reset-idrac SERIAL_OR_IP`
+            Reset the iDRAC of a machine having `SERIAL` or `IP` address.
+        * `neco bmc repair dell discharge SERIAL_OR_IP`
+            Simulate power-disconnection and discharge of a machine having `SERIAL` or `IP` address. This implies reboot of the machine.
 
 * `neco bmc setup-hw`
 

--- a/pkg/neco/cmd/bmc_config_get.go
+++ b/pkg/neco/cmd/bmc_config_get.go
@@ -10,9 +10,11 @@ var bmcConfigGetCmd = &cobra.Command{
 	Long: `Show the current BMC configuration value.
 
 Possible keys are:
-    bmc-user      - bmc-user.json contents.
-    ipmi-user     - IPMI username for power management.
-    ipmi-password - IPMI password for power management.
+    bmc-user        - bmc-user.json contents.
+    ipmi-user       - IPMI username for power management.
+    ipmi-password   - IPMI password for power management.
+    repair-user     - BMC username for repair operations.
+    repair-password - BMC password for repair operations.
 `,
 }
 

--- a/pkg/neco/cmd/bmc_config_get_repairpassword.go
+++ b/pkg/neco/cmd/bmc_config_get_repairpassword.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/neco/storage"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var bmcConfigGetRepairPasswordCmd = &cobra.Command{
+	Use:   "repair-password",
+	Short: "show the current BMC password for repair operations",
+	Long:  `Show the current BMC password for repair operations.`,
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		etcd, err := neco.EtcdClient()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		defer etcd.Close()
+		st := storage.NewStorage(etcd)
+		well.Go(func(ctx context.Context) error {
+			data, err := st.GetBMCRepairPassword(ctx)
+			if err != nil {
+				return err
+			}
+			fmt.Println(data)
+			return nil
+		})
+		well.Stop()
+		err = well.Wait()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+func init() {
+	bmcConfigGetCmd.AddCommand(bmcConfigGetRepairPasswordCmd)
+}

--- a/pkg/neco/cmd/bmc_config_get_repairuser.go
+++ b/pkg/neco/cmd/bmc_config_get_repairuser.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/neco/storage"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var bmcConfigGetRepairUserCmd = &cobra.Command{
+	Use:   "repair-user",
+	Short: "show the current BMC username for repair operations",
+	Long:  `show the current BMC username for repair operations.`,
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		etcd, err := neco.EtcdClient()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		defer etcd.Close()
+		st := storage.NewStorage(etcd)
+		well.Go(func(ctx context.Context) error {
+			data, err := st.GetBMCRepairUser(ctx)
+			if err != nil {
+				return err
+			}
+			fmt.Println(data)
+			return nil
+		})
+		well.Stop()
+		err = well.Wait()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+func init() {
+	bmcConfigGetCmd.AddCommand(bmcConfigGetRepairUserCmd)
+}

--- a/pkg/neco/cmd/bmc_config_set.go
+++ b/pkg/neco/cmd/bmc_config_set.go
@@ -10,9 +10,11 @@ var bmcConfigSetCmd = &cobra.Command{
 	Long: `Store a BMC configuration.
 
 Possible keys are:
-    bmc-user      - bmc-user.json contents.
-    ipmi-user     - IPMI username for power management.
-    ipmi-password - IPMI password for power management.
+    bmc-user        - bmc-user.json contents.
+    ipmi-user       - IPMI username for power management.
+    ipmi-password   - IPMI password for power management.
+    repair-user     - BMC username for repair operations.
+    repair-password - BMC password for repair operations.
 `,
 }
 

--- a/pkg/neco/cmd/bmc_config_set_repairpassword.go
+++ b/pkg/neco/cmd/bmc_config_set_repairpassword.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/neco/storage"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var bmcConfigSetRepairPasswordCmd = &cobra.Command{
+	Use:   "repair-password PASSWORD",
+	Short: "store BMC password for repair operations",
+	Long:  `Store BMC password for repair operations.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		etcd, err := neco.EtcdClient()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		defer etcd.Close()
+		st := storage.NewStorage(etcd)
+		well.Go(func(ctx context.Context) error {
+			return st.PutBMCRepairPassword(ctx, args[0])
+		})
+		well.Stop()
+		err = well.Wait()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+func init() {
+	bmcConfigSetCmd.AddCommand(bmcConfigSetRepairPasswordCmd)
+}

--- a/pkg/neco/cmd/bmc_config_set_repairuser.go
+++ b/pkg/neco/cmd/bmc_config_set_repairuser.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/neco/storage"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var bmcConfigSetRepairUserCmd = &cobra.Command{
+	Use:   "repair-user USERNAME",
+	Short: "store BMC username for repair operations.",
+	Long:  `Store BMC username for repair operations.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		etcd, err := neco.EtcdClient()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+		defer etcd.Close()
+		st := storage.NewStorage(etcd)
+		well.Go(func(ctx context.Context) error {
+			return st.PutBMCRepairUser(ctx, args[0])
+		})
+		well.Stop()
+		err = well.Wait()
+		if err != nil {
+			log.ErrorExit(err)
+		}
+	},
+}
+
+func init() {
+	bmcConfigSetCmd.AddCommand(bmcConfigSetRepairUserCmd)
+}

--- a/pkg/neco/cmd/bmc_repair.go
+++ b/pkg/neco/cmd/bmc_repair.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cybozu-go/neco"
+	"github.com/cybozu-go/neco/storage"
+	"github.com/cybozu-go/sabakan/v2"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+)
+
+var bmcRepairCmd = &cobra.Command{
+	Use:   "repair BMC_TYPE BMC_specific_command...",
+	Short: "repair a machine via BMC",
+	Long:  `Try to repair an unhealthy/unreachable machine by invoking BMC functions remotely.`,
+}
+
+func init() {
+	bmcCmd.AddCommand(bmcRepairCmd)
+}
+
+func getBMCWithType(ctx context.Context, id, bmcType string) (*sabakan.MachineBMC, error) {
+	machine, err := lookupMachine(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup serial or IP address %q: %w", id, err)
+	}
+
+	if machine.Spec.BMC.Type != bmcType {
+		return nil, fmt.Errorf("not a machine with %q-type BMC: %q", bmcType, id)
+	}
+
+	return &machine.Spec.BMC, nil
+}
+
+func dialToBMCByRepairUser(ctx context.Context, bmc *sabakan.MachineBMC) (*ssh.Client, error) {
+	var address string
+	switch {
+	case len(bmc.IPv6) > 0:
+		address = bmc.IPv6
+	case len(bmc.IPv4) > 0:
+		address = bmc.IPv4
+	default:
+		return nil, errors.New("BMC IP address not set")
+	}
+
+	etcd, err := neco.EtcdClient()
+	if err != nil {
+		return nil, err
+	}
+	defer etcd.Close()
+
+	st := storage.NewStorage(etcd)
+	user, err := st.GetBMCRepairUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	password, err := st.GetBMCRepairPassword(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+			ssh.KeyboardInteractive(func(name, instruction string, questions []string, echos []bool) (answers []string, err error) {
+				ret := make([]string, len(questions))
+				for i := range questions {
+					ret[i] = password
+				}
+				return ret, nil
+			}),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // acceptable for local network
+	}
+
+	return ssh.Dial("tcp", address+":22", config)
+}
+
+func sshSessionOutput(client *ssh.Client, cmd string) ([]byte, error) {
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	session.Stderr = os.Stderr
+	return session.Output(cmd)
+}

--- a/pkg/neco/cmd/bmc_repair_dell.go
+++ b/pkg/neco/cmd/bmc_repair_dell.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var bmcRepairDellCmd = &cobra.Command{
+	Use:   "dell",
+	Short: "repair a Dell machine via BMC",
+	Long:  `Try to repair a Dell machine by invoking BMC functions remotely.`,
+}
+
+func init() {
+	bmcRepairCmd.AddCommand(bmcRepairDellCmd)
+}

--- a/pkg/neco/cmd/bmc_repair_dell_discharge.go
+++ b/pkg/neco/cmd/bmc_repair_dell_discharge.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+var bmcRepairDellDischargeCmd = &cobra.Command{
+	Use:   "discharge SERIAL_OR_IP",
+	Short: "discharge a machine",
+	Long: `Simulate power-disconnection and discharge of a machine having "SERIAL" or "IP" address.
+This implies reboot of the machine.`,
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		ctx := context.Background()
+		bmc, err := getBMCWithType(ctx, args[0], "iDRAC")
+		if err != nil {
+			return err
+		}
+
+		client, err := dialToBMCByRepairUser(ctx, bmc)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		output, err := sshSessionOutput(client, "racadm set BIOS.MiscSettings.PowerCycleRequest FullPowerCycle")
+		if err != nil {
+			return err
+		}
+
+		re := regexp.MustCompile(`(?s).*\[Key=(.*)#MiscSettings\].*`)
+		if !re.Match(output) {
+			return errors.New("FQDD of BIOS setup not found")
+		}
+		fqdd := re.ReplaceAllString(string(output), "$1")
+
+		_, err = sshSessionOutput(client, "racadm jobqueue create "+fqdd)
+		if err != nil {
+			return err
+		}
+
+		_, err = sshSessionOutput(client, "racadm serveraction hardreset")
+		return err
+	},
+}
+
+func init() {
+	bmcRepairDellCmd.AddCommand(bmcRepairDellDischargeCmd)
+}

--- a/pkg/neco/cmd/bmc_repair_dell_resetidrac.go
+++ b/pkg/neco/cmd/bmc_repair_dell_resetidrac.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+var bmcRepairDellResetIdracCmd = &cobra.Command{
+	Use:   "reset-idrac SERIAL_OR_IP",
+	Short: "reset an iDRAC",
+	Long:  `Reset the iDRAC of a machine having "SERIAL" or "IP" address.`,
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		ctx := context.Background()
+		bmc, err := getBMCWithType(ctx, args[0], "iDRAC")
+		if err != nil {
+			return err
+		}
+
+		client, err := dialToBMCByRepairUser(ctx, bmc)
+		if err != nil {
+			return err
+		}
+		defer client.Close()
+
+		_, err = sshSessionOutput(client, "racadm racreset soft")
+		return err
+	},
+}
+
+func init() {
+	bmcRepairDellCmd.AddCommand(bmcRepairDellResetIdracCmd)
+}

--- a/storage/bmc.go
+++ b/storage/bmc.go
@@ -31,3 +31,23 @@ func (s Storage) PutBMCIPMIPassword(ctx context.Context, value string) error {
 func (s Storage) GetBMCIPMIPassword(ctx context.Context) (string, error) {
 	return s.get(ctx, KeyBMCIPMIPassword)
 }
+
+// PutBMCRepairUser stores BMC username for repair operations.
+func (s Storage) PutBMCRepairUser(ctx context.Context, username string) error {
+	return s.put(ctx, KeyBMCRepairUser, username)
+}
+
+// GetBMCRepairUser returns BMC username for repair operations.
+func (s Storage) GetBMCRepairUser(ctx context.Context) (string, error) {
+	return s.get(ctx, KeyBMCRepairUser)
+}
+
+// PutBMCRepairPassword stores BMC password for repair operations.
+func (s Storage) PutBMCRepairPassword(ctx context.Context, password string) error {
+	return s.put(ctx, KeyBMCRepairPassword, password)
+}
+
+// GetBMCRepairPassword returns BMC password for repair operations.
+func (s Storage) GetBMCRepairPassword(ctx context.Context) (string, error) {
+	return s.get(ctx, KeyBMCRepairPassword)
+}

--- a/storage/keys.go
+++ b/storage/keys.go
@@ -46,6 +46,8 @@ const (
 	KeyBMCBMCUser               = "bmc/bmc-user"
 	KeyBMCIPMIUser              = "bmc/ipmi-user"
 	KeyBMCIPMIPassword          = "bmc/ipmi-password"
+	KeyBMCRepairUser            = "bmc/repair-user"
+	KeyBMCRepairPassword        = "bmc/repair-password"
 	KeyTeleportAuthToken        = "teleport/auth-token"
 	KeyCKEWeight                = "cke/weight"
 )


### PR DESCRIPTION
This PR adds `neco bmc repair` subcommand and its descendants.
This PR also adds configurations of the user and password for those subcommands.
Please see the diff of `docs/neco.md` first.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>