### PR TITLE
Downgrade OS image to 3602.2.0

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -6,12 +6,12 @@ package neco
 var CurrentArtifacts = ArtifactSet{
 	Images: []ContainerImage{
 		{Name: "coil", Repository: "ghcr.io/cybozu-go/coil", Tag: "2.4.0", Private: false},
-		{Name: "bird", Repository: "quay.io/cybozu/bird", Tag: "2.13.1.1", Private: false},
+		{Name: "bird", Repository: "quay.io/cybozu/bird", Tag: "2.14.0.1", Private: false},
 		{Name: "chrony", Repository: "quay.io/cybozu/chrony", Tag: "4.3.0.3", Private: false},
 		{Name: "etcd", Repository: "quay.io/cybozu/etcd", Tag: "3.5.10.1", Private: false},
 		{Name: "promtail", Repository: "quay.io/cybozu/promtail", Tag: "2.9.2.1", Private: false},
 		{Name: "sabakan", Repository: "quay.io/cybozu/sabakan", Tag: "2.13.2", Private: false},
-		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.10.1.3", Private: false},
+		{Name: "serf", Repository: "quay.io/cybozu/serf", Tag: "0.10.1.4", Private: false},
 		{Name: "setup-hw", Repository: "quay.io/cybozu/setup-hw", Tag: "1.15.0", Private: true},
 		{Name: "squid", Repository: "quay.io/cybozu/squid", Tag: "5.8.0.2", Private: false},
 		{Name: "vault", Repository: "quay.io/cybozu/vault", Tag: "1.14.3.1", Private: false},
@@ -23,5 +23,5 @@ var CurrentArtifacts = ArtifactSet{
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.4.3"},
 	},
-	OSImage: OSImage{Channel: "stable", Version: "3602.2.1"},
+	OSImage: OSImage{Channel: "stable", Version: "3602.2.0"},
 }

--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,5 +1,8 @@
 images:
 - repository: quay.io/cybozu/squid
-  versions: ["6.3.0.1", "6.4.0.1"]
+  versions: ["6.3.0.1", "6.4.0.1", "6.5.0.1"]
 - repository: ghcr.io/cybozu-go/coil
   versions: ["2.5.0"]
+osImage:
+- channel: stable
+  versions: ["3602.2.1"]


### PR DESCRIPTION
- Downgrade the OS image to `3602.2.0` to investigate network failure.
- Ignore the Squid `6.5.0.1` image to prevent failure when prod release.
  - Cilium `1.13.7.2` will be included in the next prod release.