### PR TITLE
Expand cs memory for dctest

### DIFF
--- a/dctest/menu-ss.yml
+++ b/dctest/menu-ss.yml
@@ -48,7 +48,7 @@ kind: Node
 type: cs
 spec:
   cpu: 12
-  memory: 20G
+  memory: 32G
   disk-count: 6
   disk-size: 100G
   tpm: true


### PR DESCRIPTION
The issue of not being able to increase cpu resources is under investigation.
Memory only seems to be OK, so I increased it.

Signed-off-by: kouki <kouworld0123@gmail.com>