### PR TITLE
container image asset names should include container registry name

### DIFF
--- a/progs/sabakan/upload.go
+++ b/progs/sabakan/upload.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cybozu-go/log"
@@ -31,7 +32,9 @@ const (
 const retryCount = 40
 
 func imageAssetName(img neco.ContainerImage) string {
-	return fmt.Sprintf("cybozu-%s-%s.img", img.Name, img.Tag)
+	// container image asset names should include registry name
+	// because the images themselves contain registry name info.
+	return fmt.Sprintf("cybozu-%s-%s-%s.img", img.Name, strings.ReplaceAll(img.Repository, "/", "-"), img.Tag)
 }
 
 // UploadContents upload contents to sabakan


### PR DESCRIPTION
The container image files include their image names. i.e. they include registry name (like "ghcr.io") and username (like "cybozu").
On the other hand, the container image asset names does not include them.

As the result, Neco boot servers and worker nodes may get unexpected image files: an worker node want to get a image from a certain container registry (e.g. `ghcr.io/cybozu/xxx:n.n.n`) but it actually get a image from another container registry (e.g. `quay.io/cybozu/xxx:n.n.n`).

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>