### PR TITLE
Remove fwupd and popularity-contest from the list to purge

### DIFF
--- a/installer/setup/packages.go
+++ b/installer/setup/packages.go
@@ -31,9 +31,11 @@ func purgePackages() error {
 
 	// cloud-init depends on netplan.io, so it can be purged
 	// only from non-virtual machines.
+	// The fwupd and popularity-contest packages are not included in the cloud image, but are included in the iso image.
+	// Therefore, it is necessary to purge them in a non-vm environment.
 	err := exec.Command("systemd-detect-virt", "-v", "-q").Run()
 	if err != nil {
-		args = append(args, "netplan.io")
+		args = append(args, "netplan.io", "fwupd", "popularity-contest")
 	}
 
 	return runCmd("apt-get", args...)

--- a/installer/setup/packages.go
+++ b/installer/setup/packages.go
@@ -10,10 +10,10 @@ var (
 	purgeList = []string{
 		"apport",
 		"apport-symptoms",
-		"fwupd",
+		//"fwupd",
 		"nano",
 		//"netplan.io",
-		"popularity-contest",
+		//"popularity-contest",
 		"unattended-upgrades",
 		"update-manager-core",
 		"ubuntu-release-upgrader-core",


### PR DESCRIPTION
The latest ubuntu cloud image does not include the `fwupd` and `popularity-contest` packages, so trying to purge these packages will result in an error.
Since `fwupd` and `popularity-contest` are still included in the iso image, I changed it to purge those packages in non-vm environments.