### PR TITLE
Add fwupd to the list to purge

### DIFF
--- a/installer/setup/packages.go
+++ b/installer/setup/packages.go
@@ -10,7 +10,7 @@ var (
 	purgeList = []string{
 		"apport",
 		"apport-symptoms",
-		//"fwupd",
+		"fwupd",
 		"nano",
 		//"netplan.io",
 		//"popularity-contest",
@@ -31,11 +31,11 @@ func purgePackages() error {
 
 	// cloud-init depends on netplan.io, so it can be purged
 	// only from non-virtual machines.
-	// The fwupd and popularity-contest packages are not included in the cloud image, but are included in the iso image.
+	// The popularity-contest package is not included in the cloud image, but is included in the iso image.
 	// Therefore, it is necessary to purge them in a non-vm environment.
 	err := exec.Command("systemd-detect-virt", "-v", "-q").Run()
 	if err != nil {
-		args = append(args, "netplan.io", "fwupd", "popularity-contest")
+		args = append(args, "netplan.io", "popularity-contest")
 	}
 
 	return runCmd("apt-get", args...)


### PR DESCRIPTION
The https://github.com/cybozu-go/neco/pull/2474  PR said that I needed to remove popularity-contest and fwupd, but in fact I only needed to remove popularity-contest.
Add fwupd again to the list to purge.