### PR TITLE
Add ignore rules to security labels

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -54,7 +54,7 @@ data:
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
   # To include or exclude matched resources from cilium identity evaluation
-  labels: "k8s:!controller-uid k8s:!job-name k8s:!node"
+  labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -796,7 +796,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "d8c88277233c725e9a0b12d6afe95754f59dab2247847aa2bb61677c545716ba"
+        cilium.io/cilium-configmap-checksum: "7b38b833ebea074979cfae83a926de659b99104fdf0c0df61a0343af5430fa16"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1204,7 +1204,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "d8c88277233c725e9a0b12d6afe95754f59dab2247847aa2bb61677c545716ba"
+        cilium.io/cilium-configmap-checksum: "7b38b833ebea074979cfae83a926de659b99104fdf0c0df61a0343af5430fa16"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -40,7 +40,7 @@ hubble:
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"
-labels: "k8s:!controller-uid k8s:!job-name k8s:!node"
+labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
 loadBalancer:
   # We can't enable XDP Acceleration because rolling restart Cilium with XDP enabled disrupts in-cluster connectivity
   acceleration: disabled

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -54,7 +54,7 @@ data:
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
   # To include or exclude matched resources from cilium identity evaluation
-  labels: "k8s:!controller-uid k8s:!job-name k8s:!node"
+  labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -793,7 +793,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "8e9c9baedbea00df309272cc06f76842588a97cec233d9c6f56a3e73ab1fb579"
+        cilium.io/cilium-configmap-checksum: "66cd4e5efcd38c57a3c3a941e8efad6d35dcf172b4ac9ccbd2c20b444b729143"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1201,7 +1201,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "8e9c9baedbea00df309272cc06f76842588a97cec233d9c6f56a3e73ab1fb579"
+        cilium.io/cilium-configmap-checksum: "66cd4e5efcd38c57a3c3a941e8efad6d35dcf172b4ac9ccbd2c20b444b729143"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -40,7 +40,7 @@ hubble:
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"
-labels: "k8s:!controller-uid k8s:!job-name k8s:!node"
+labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
 loadBalancer:
   # We can't enable XDP Acceleration because rolling restart Cilium with XDP enabled disrupts in-cluster connectivity
   acceleration: disabled

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -583,7 +583,8 @@ data:
   ipam: cluster-pool
   kube-proxy-replacement: partial
   kube-proxy-replacement-healthz-bind-address: ""
-  labels: k8s:!controller-uid k8s:!job-name k8s:!node
+  labels: k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid
+    k8s:!batch.kubernetes.io/job-name
   metrics: +cilium_bpf_map_pressure
   monitor-aggregation: medium
   monitor-aggregation-flags: all
@@ -721,7 +722,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: d8c88277233c725e9a0b12d6afe95754f59dab2247847aa2bb61677c545716ba
+        cilium.io/cilium-configmap-checksum: 7b38b833ebea074979cfae83a926de659b99104fdf0c0df61a0343af5430fa16
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -986,7 +987,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: d8c88277233c725e9a0b12d6afe95754f59dab2247847aa2bb61677c545716ba
+        cilium.io/cilium-configmap-checksum: 7b38b833ebea074979cfae83a926de659b99104fdf0c0df61a0343af5430fa16
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -583,7 +583,8 @@ data:
   ipam: cluster-pool
   kube-proxy-replacement: partial
   kube-proxy-replacement-healthz-bind-address: ""
-  labels: k8s:!controller-uid k8s:!job-name k8s:!node
+  labels: k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid
+    k8s:!batch.kubernetes.io/job-name
   metrics: +cilium_bpf_map_pressure
   monitor-aggregation: medium
   monitor-aggregation-flags: all
@@ -718,7 +719,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 8e9c9baedbea00df309272cc06f76842588a97cec233d9c6f56a3e73ab1fb579
+        cilium.io/cilium-configmap-checksum: 66cd4e5efcd38c57a3c3a941e8efad6d35dcf172b4ac9ccbd2c20b444b729143
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -983,7 +984,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 8e9c9baedbea00df309272cc06f76842588a97cec233d9c6f56a3e73ab1fb579
+        cilium.io/cilium-configmap-checksum: 66cd4e5efcd38c57a3c3a941e8efad6d35dcf172b4ac9ccbd2c20b444b729143
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"


### PR DESCRIPTION
Kubernetes 1.27 changes high-cardinality label names for job pods.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>