### PR TITLE
Revert "Relax CI workflow to allow release without upgrade test"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,6 @@ workflows:
               ignore:
                 - release
                 - main
-                - relax-ci-workflow
 
   manual-reboot:
     jobs:
@@ -455,14 +454,13 @@ workflows:
       - dctest-functions-release:
           requires:
             - generate-artifacts
-      - hold:
-          type: approval
+      - dctest-upgrade-release:
           requires:
             - generate-artifacts
       - update-release:
           requires:
             - dctest-functions-release
-            - hold
+            - dctest-upgrade-release
 
   # For updating `artifact_release.go` regularly, run the same job as `main` workflow.
   daily:


### PR DESCRIPTION
This reverts commit 34a6e3d7ec6a1283222bdfe27d1faa0a6f6118da.