### PR TITLE
Update CKE to 1.27.4 to introduce repair queue

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,7 +1,7 @@
 # tool versions used for both local bin and deb/zip packages
 
 ## These should be updated when Kubernetes is updated
-CKE_VERSION = 1.27.3
+CKE_VERSION = 1.27.4
 CONTAINERD_VERSION = 1.7.10
 NERDCTL_VERSION = 1.7.1
 CRITOOLS_VERSION = 1.28.0

--- a/debian/usr/sbin/check-machine-state
+++ b/debian/usr/sbin/check-machine-state
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 IP_ADDRESS STATE [STATE]..." 1>&2
+    exit 2
+fi
+IP_ADDRESS=$1
+shift
+
+JSON=$(sabactl machines get --ipv4 ${IP_ADDRESS} || sabactl machines get --ipv6 ${IP_ADDRESS})
+STATE=$(echo ${JSON} | jq -r '.[].status.state')
+
+for expected in $*; do
+    if [ ${STATE} = ${expected} ]; then
+        exit 0
+    fi
+done
+exit 1

--- a/debian/usr/sbin/retire-machine
+++ b/debian/usr/sbin/retire-machine
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 IP_ADDRESS" 1>&2
+    exit 2
+fi
+IP_ADDRESS=$1
+
+JSON=$(sabactl machines get --ipv4 ${IP_ADDRESS} || sabactl machines get --ipv6 ${IP_ADDRESS})
+SERIAL=$(echo ${JSON} | jq -r '.[].spec.serial')
+sabactl machines set-state ${SERIAL} retiring

--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -31,6 +31,49 @@ reboot:
   command_interval: 60
   evict_retries: 30
   evict_interval: 10
+repair:
+  repair_procedures:
+  - machine_types: ["iDRAC"]
+    repair_operations:
+    - operation: unhealthy
+      repair_steps:
+      - repair_command: ["sh", "-c", "timeout 30 neco bmc repair dell reset-idrac $1 || ckecli ssh $1 -- docker exec setup-hw racadm racreset soft", "reset-idrac"]
+        command_timeout_seconds: 60
+        command_retries: 2
+        command_interval: 30
+        watch_second: 600
+      - repair_command: ["neco", "bmc", "repair", "dell", "discharge"]
+        command_timeout_seconds: 30
+        command_retries: 2
+        command_interval: 30
+        need_drain: true
+        watch_second: 1500
+      health_check_command: ["sh", "-c", "check-machine-state $1 healthy retired", "check-machine-state"]
+      command_timeout_seconds: 10
+    - operation: unreachable
+      repair_steps:
+      - repair_command: ["sh", "-c", "timeout 30 neco bmc repair dell reset-idrac $1 || ckecli ssh $1 -- docker exec setup-hw racadm racreset soft", "reset-idrac"]
+        command_timeout_seconds: 60
+        command_retries: 2
+        command_interval: 30
+        watch_second: 600
+      - repair_command: ["neco", "bmc", "repair", "dell", "discharge"]
+        command_timeout_seconds: 30
+        command_retries: 2
+        command_interval: 30
+        need_drain: false
+        watch_second: 1500
+      - repair_command: ["retire-machine"]
+        command_timeout_seconds: 30
+        command_retries: 2
+        command_interval: 30
+        watch_second: 600
+      health_check_command: ["sh", "-c", "check-machine-state $1 healthy retired", "check-machine-state"]
+      command_timeout_seconds: 10
+  max_concurrent_repairs: 1
+  evict_retries: 30
+  evict_interval: 10
+  eviction_timeout_seconds: 1800
 options:
   kube-api:
     audit_log_enabled: true

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.21.1
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f
 
 require (
-	github.com/cybozu-go/cke v1.27.3
+	github.com/cybozu-go/cke v1.27.4
 	github.com/cybozu-go/etcdutil v1.6.6
 	github.com/cybozu-go/log v1.7.0
 	github.com/cybozu-go/netutil v1.4.6

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cybozu-go/cke v1.27.3 h1:TN6+IaaHWpdI9qjdNO7KW+TlOlcOG6Zj7KOZa5O+/as=
-github.com/cybozu-go/cke v1.27.3/go.mod h1:4lFn8dAguY5JUy9C+6Zqqlc28dhq0wyr0K5z/xOqAgM=
+github.com/cybozu-go/cke v1.27.4 h1:QcSnGpjm68XZS35pIi6w9rbEMPiRj4Bp1vWiACweyZg=
+github.com/cybozu-go/cke v1.27.4/go.mod h1:4lFn8dAguY5JUy9C+6Zqqlc28dhq0wyr0K5z/xOqAgM=
 github.com/cybozu-go/etcdutil v1.6.6 h1:bxemXwRuefUnU7Y+ZeJNXbZZTn84Wo31shVK68xF7UE=
 github.com/cybozu-go/etcdutil v1.6.6/go.mod h1:eQtqaaNMohxH6Vimzl+/413Ufd3KwBoD6/oKduedErE=
 github.com/cybozu-go/log v1.7.0 h1:wPTkNDWcnSLLAv1ejFSn07qvYG8ng6U6Gygv04dYW1w=

--- a/progs/cke/conf.go
+++ b/progs/cke/conf.go
@@ -62,6 +62,17 @@ func GenerateCKETemplate(ctx context.Context, st storage.Storage, name string, c
 				},
 			}
 		}
+		if r, ok := tmpl["repair"].(map[string]interface{}); ok {
+			r["protected_namespaces"] = map[string]interface{}{
+				"matchExpressions": []interface{}{
+					map[string]interface{}{
+						"key":      "development",
+						"operator": "NotIn",
+						"values":   []string{"true"},
+					},
+				},
+			}
+		}
 	}
 
 	weights, err := st.GetCKEWeight(ctx)


### PR DESCRIPTION
This PR updates CKE to 1.27.4.
This PR also updates the cluster yaml for the repair queue,
which is introduced in CKE 1.27.4.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>