### PR TITLE
Change to white identity list

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -54,7 +54,7 @@ data:
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
   # To include or exclude matched resources from cilium identity evaluation
-  labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
+  labels: " k8s:app k8s:io\\.cilium\\.k8s\\.namespace\\.labels\\.team k8s:io\\.kubernetes\\.pod\\.namespace k8s:k8s-app io\\.cilium\\.k8s\\.policy cybozu\\.io/family app\\.cybozu\\.io neco\\.cybozu\\.io\\/registry identity\\.neco\\.cybozu\\.io "
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -796,7 +796,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "5698d98e67f50ae0a856ec7f9b5cc53704ba7e99387489ddef2605e2742bfb72"
+        cilium.io/cilium-configmap-checksum: "497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1204,7 +1204,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "5698d98e67f50ae0a856ec7f9b5cc53704ba7e99387489ddef2605e2742bfb72"
+        cilium.io/cilium-configmap-checksum: "497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -40,7 +40,17 @@ hubble:
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"
-labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
+labels: "
+  k8s:app
+  k8s:io\\.cilium\\.k8s\\.namespace\\.labels\\.team
+  k8s:io\\.kubernetes\\.pod\\.namespace
+  k8s:k8s-app 
+  io\\.cilium\\.k8s\\.policy
+  cybozu\\.io/family
+  app\\.cybozu\\.io
+  neco\\.cybozu\\.io\\/registry
+  identity\\.neco\\.cybozu\\.io
+  "
 loadBalancer:
   # We can't enable XDP Acceleration because rolling restart Cilium with XDP enabled disrupts in-cluster connectivity
   acceleration: disabled

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -54,7 +54,7 @@ data:
   # Disable the usage of CiliumEndpoint CRD
   disable-endpoint-crd: "false"
   # To include or exclude matched resources from cilium identity evaluation
-  labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
+  labels: " k8s:app k8s:io\\.cilium\\.k8s\\.namespace\\.labels\\.team k8s:io\\.kubernetes\\.pod\\.namespace k8s:k8s-app io\\.cilium\\.k8s\\.policy cybozu\\.io/family app\\.cybozu\\.io neco\\.cybozu\\.io\\/registry identity\\.neco\\.cybozu\\.io "
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -793,7 +793,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "b7deb098ebc5ec3b1aba9362866fa0f1dfd1a8c50607cdf65647de7555d05334"
+        cilium.io/cilium-configmap-checksum: "9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1201,7 +1201,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "b7deb098ebc5ec3b1aba9362866fa0f1dfd1a8c50607cdf65647de7555d05334"
+        cilium.io/cilium-configmap-checksum: "9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -40,7 +40,17 @@ hubble:
 k8sServiceHost: 127.0.0.1
 k8sServicePort: 16443
 kubeProxyReplacement: "partial"
-labels: "k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid k8s:!batch.kubernetes.io/job-name"
+labels: "
+  k8s:app
+  k8s:io\\.cilium\\.k8s\\.namespace\\.labels\\.team
+  k8s:io\\.kubernetes\\.pod\\.namespace
+  k8s:k8s-app 
+  io\\.cilium\\.k8s\\.policy
+  cybozu\\.io/family
+  app\\.cybozu\\.io
+  neco\\.cybozu\\.io\\/registry
+  identity\\.neco\\.cybozu\\.io
+  "
 loadBalancer:
   # We can't enable XDP Acceleration because rolling restart Cilium with XDP enabled disrupts in-cluster connectivity
   acceleration: disabled

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -583,8 +583,9 @@ data:
   ipam: cluster-pool
   kube-proxy-replacement: partial
   kube-proxy-replacement-healthz-bind-address: ""
-  labels: k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid
-    k8s:!batch.kubernetes.io/job-name
+  labels: ' k8s:app k8s:io\.cilium\.k8s\.namespace\.labels\.team k8s:io\.kubernetes\.pod\.namespace
+    k8s:k8s-app io\.cilium\.k8s\.policy cybozu\.io/family app\.cybozu\.io neco\.cybozu\.io\/registry
+    identity\.neco\.cybozu\.io '
   metrics: +cilium_bpf_map_pressure
   monitor-aggregation: medium
   monitor-aggregation-flags: all
@@ -722,7 +723,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 5698d98e67f50ae0a856ec7f9b5cc53704ba7e99387489ddef2605e2742bfb72
+        cilium.io/cilium-configmap-checksum: 497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -987,7 +988,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 5698d98e67f50ae0a856ec7f9b5cc53704ba7e99387489ddef2605e2742bfb72
+        cilium.io/cilium-configmap-checksum: 497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -583,8 +583,9 @@ data:
   ipam: cluster-pool
   kube-proxy-replacement: partial
   kube-proxy-replacement-healthz-bind-address: ""
-  labels: k8s:!controller-uid k8s:!job-name k8s:!node k8s:!batch.kubernetes.io/controller-uid
-    k8s:!batch.kubernetes.io/job-name
+  labels: ' k8s:app k8s:io\.cilium\.k8s\.namespace\.labels\.team k8s:io\.kubernetes\.pod\.namespace
+    k8s:k8s-app io\.cilium\.k8s\.policy cybozu\.io/family app\.cybozu\.io neco\.cybozu\.io\/registry
+    identity\.neco\.cybozu\.io '
   metrics: +cilium_bpf_map_pressure
   monitor-aggregation: medium
   monitor-aggregation-flags: all
@@ -719,7 +720,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: b7deb098ebc5ec3b1aba9362866fa0f1dfd1a8c50607cdf65647de7555d05334
+        cilium.io/cilium-configmap-checksum: 9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -984,7 +985,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: b7deb098ebc5ec3b1aba9362866fa0f1dfd1a8c50607cdf65647de7555d05334
+        cilium.io/cilium-configmap-checksum: 9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"


### PR DESCRIPTION
This PR changes cilium-config to use white label list instead of black one for identities.

Arrowed label prefixes are below (except for default ones):

```
- k8s:app
- k8s:io.cilium.k8s.namespace.labels.team
- k8s:io.kubernetes.pod.namespace
- k8s:k8s-app 
- io.cilium.k8s.policy
- cybozu.io/family
- app.cybozu.io
- neco.cybozu.io/registry
- identity.neco.cybozu.io
```