### PR TITLE
Expand k8s-containerd lvm for qemu

### DIFF
--- a/dctest/menu.yml
+++ b/dctest/menu.yml
@@ -48,7 +48,7 @@ type: cs
 spec:
   cpu: 8
   memory: 16G
-  disk-count: 2
+  disk-count: 3
   tpm: true
 ---
 kind: Node

--- a/ignitions/common/files/opt/sbin/setup-var
+++ b/ignitions/common/files/opt/sbin/setup-var
@@ -4,7 +4,7 @@ VG=vg1
 LVLIST="k8s-containerd docker kubelet systemd coredump"
 
 # these values are for qemu (dctest env). see below for real machines.
-CONTAINERD_SIZE=40g
+CONTAINERD_SIZE=50g
 DOCKER_SIZE=10g
 KUBELET_SIZE=40g
 SYSTEMD_SIZE=1g


### PR DESCRIPTION
When migrating the image registry for rook from quay.io to ghcr.io, it is necessary to save both the old and the new image on the volume.

related to: https://github.com/cybozu-private/neco-apps/pull/4499, https://github.com/cybozu-private/csa-apps/issues/2487