### PR TITLE
Add necoip command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OP_MAC_ZIP = neco-operation-cli-mac_$(VERSION)_amd64.zip
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker
-OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt jsonnet-lint kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq tempo-cli flamegraph.pl stackcollapse-perf.pl necoperf-cli
+OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt jsonnet-lint kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq tempo-cli flamegraph.pl stackcollapse-perf.pl necoperf-cli necoip
 OPDEB_DOCNAMES = argocd hubble jsonnet kubectl kubeseal kustomize logcli stern teleport moco accurate alertmanager yq tempo flamegraph necoperf
 
 .PHONY: all

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -65,7 +65,7 @@ all:
 	$(CURDIR)/bin/neco-download-dir-cache.sh write
 
 .PHONY: download-all
-download-all: node_exporter containerd nerdctl crictl runc argocd kubectl kubeseal stern kustomize jsonnet teleport cke moco logcli yq kubectl-neat accurate alertmanager cilium-cli hubble tempo helm flamegraph necoperf
+download-all: node_exporter containerd nerdctl crictl runc argocd kubectl kubeseal stern kustomize jsonnet teleport cke moco logcli yq kubectl-neat accurate alertmanager cilium-cli hubble tempo helm flamegraph necoperf necoip
 	# all binaries in BINDIR and SBINDIR must have executable bits
 	test -z "$$(find $(BINDIR) $(SBINDIR) -type f -a \( \! -perm -111 \) | tee /dev/stderr)"
 	mkdir -p $(DOWNLOADDIR)
@@ -555,6 +555,11 @@ necoperf: $(NECOPERF_DOWNLOAD)
 	mkdir -p $(BINDIR) $(DOCDIR)/$@/
 	tar xvf $(NECOPERF_DLDIR)/necoperf_linux_amd64.tar.gz -C $(BINDIR) necoperf-cli
 	tar xvf $(NECOPERF_DLDIR)/necoperf_linux_amd64.tar.gz -C $(DOCDIR)/$@/ LICENSE
+
+.PHONY: necoip
+necoip:
+	mkdir -p $(BINDIR)
+	cp $(CURDIR)/bin/necoip $(BINDIR)/necoip
 
 .PHONY: clean
 clean:

--- a/bin/necoip
+++ b/bin/necoip
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+set -o pipefail
+
+if [ $# -eq 0 ]; then
+        echo 'necoip <IPADDR>'
+        exit
+fi
+
+if ! echo $1 | grep -E '([0-9]{1,3}[.]){3}[0-9]{1,3}' > /dev/null; then
+        echo "Input is not a valid IP"
+        exit
+fi
+
+NODE_JSON=$(kubectl get node $1 -o json 2>/dev/null || true)
+if [ ! -z "${NODE_JSON}" ]; then
+        echo "$1 is a Node"
+        exit
+fi
+
+SVC_JSON=$(kubectl get svc -Ao json)
+SVC_CLUSTER_IP=$(echo $SVC_JSON | jq ".items[] | select(.spec.clusterIP == \"$1\")")
+if [ ! -z "${SVC_CLUSTER_IP}" ]; then
+        SVC_NAMESPACE=$(echo ${SVC_CLUSTER_IP} | jq -r '.metadata.namespace')
+        SVC_NAME=$(echo ${SVC_CLUSTER_IP} | jq -r '.metadata.name')
+        echo "$1 is a Service (ClusterIP): ${SVC_NAMESPACE}/${SVC_NAME}"
+        exit
+fi
+
+SVC_LOAD_BALANCER=$(echo $SVC_JSON | jq ".items[] | select(.status.loadBalancer.ingress[0].ip == \"$1\")")
+if [ ! -z "${SVC_LOAD_BALANCER}" ]; then
+        SVC_NAMESPACE=$(echo ${SVC_LOAD_BALANCER} | jq -r '.metadata.namespace')
+        SVC_NAME=$(echo ${SVC_LOAD_BALANCER} | jq -r '.metadata.name')
+        echo "$1 is a Service (LoadBalancer): ${SVC_NAMESPACE}/${SVC_NAME}"
+        exit
+fi
+
+POD_JSON=$(kubectl get po -Ao json | jq ".items[] | select(.status.podIP == \"$1\")")
+if [ ! -z "${POD_JSON}" ]; then
+        POD_NAMESPACE=$(echo ${POD_JSON} | jq -r '.metadata.namespace')
+        POD_NAME=$(echo ${POD_JSON} | jq -r '.metadata.name')
+        echo "$1 is a Pod: ${POD_NAMESPACE}/${POD_NAME}"
+        exit
+fi
+
+for p in $(kubectl get addresspools -o json | jq -c '.items[]'); do
+        POOL_NAME=$(echo $p | jq -r '.metadata.name')
+        for s in $(echo $p | jq -r '.spec.subnets[].ipv4'); do
+                TEST=$(python3 -c "from ipaddress import *; print(ip_address(\"$1\") in ip_network(\"$s\"))")
+                if [ "${TEST}" = "True" ]; then
+                        echo "$1 is an AddressPool IP: ${POOL_NAME}"
+                        exit
+                fi
+        done
+done
+
+echo "$1 is unknown (maybe a bug in this script)"

--- a/bin/necoip
+++ b/bin/necoip
@@ -6,7 +6,7 @@ if [ $# -eq 0 ]; then
         exit
 fi
 
-if ! echo $1 | grep -E '([0-9]{1,3}[.]){3}[0-9]{1,3}' > /dev/null; then
+if ! echo $1 | grep -E '^([0-9]{1,3}[.]){3}[0-9]{1,3}$' > /dev/null; then
         echo "Input is not a valid IP"
         exit
 fi


### PR DESCRIPTION
This PR adds `necoip` command, that helps us to find where the IP address comes from.
It will be installed on boot servers and Teleport nodes.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>