### PR TITLE
Enable node_exporter network_route collector

### DIFF
--- a/ignitions/common/systemd/node-exporter.service
+++ b/ignitions/common/systemd/node-exporter.service
@@ -6,7 +6,7 @@ After=setup-node-exporter.service
 [Service]
 Type=simple
 Restart=always
-ExecStart=/opt/sbin/node_exporter --collector.textfile.directory=/var/lib/textfile-collector --no-collector.ipvs
+ExecStart=/opt/sbin/node_exporter --collector.textfile.directory=/var/lib/textfile-collector --collector.network_route --no-collector.ipvs
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This pr enables node_exporter's network_route collector.
Please see below for details.

- https://github.com/prometheus/node_exporter/pull/1811
- https://grafana.com/docs/agent/latest/static/configuration/integrations/node-exporter-config/

Signed-off-by: terasihma <tomoya-terashima@cybozu.co.jp>