### PR TITLE
Add nsdump and clusterdump commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OP_MAC_ZIP = neco-operation-cli-mac_$(VERSION)_amd64.zip
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker
-OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt jsonnet-lint kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq tempo-cli flamegraph.pl stackcollapse-perf.pl necoperf-cli necoip cmctl
+OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt jsonnet-lint kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq tempo-cli flamegraph.pl stackcollapse-perf.pl necoperf-cli necoip nsdump cmctl
 OPDEB_DOCNAMES = argocd hubble jsonnet kubectl kubeseal kustomize logcli stern teleport moco accurate alertmanager yq tempo flamegraph necoperf cmctl
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OP_MAC_ZIP = neco-operation-cli-mac_$(VERSION)_amd64.zip
 DEBBUILD_FLAGS = -Znone
 BIN_PKGS = ./pkg/neco
 SBIN_PKGS = ./pkg/neco-updater ./pkg/neco-worker
-OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt jsonnet-lint kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq tempo-cli flamegraph.pl stackcollapse-perf.pl necoperf-cli necoip nsdump cmctl
+OPDEB_BINNAMES = argocd hubble jsonnet jsonnetfmt jsonnet-lint kubectl kubeseal kustomize logcli stern tsh kubectl-moco kubectl-accurate amtool yq tempo-cli flamegraph.pl stackcollapse-perf.pl necoperf-cli necoip nsdump clusterdump cmctl
 OPDEB_DOCNAMES = argocd hubble jsonnet kubectl kubeseal kustomize logcli stern teleport moco accurate alertmanager yq tempo flamegraph necoperf cmctl
 
 .PHONY: all

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -67,7 +67,7 @@ all:
 	$(CURDIR)/bin/neco-download-dir-cache.sh write
 
 .PHONY: download-all
-download-all: node_exporter containerd nerdctl crictl runc argocd kubectl kubeseal stern kustomize jsonnet teleport cke moco logcli yq kubectl-neat accurate alertmanager cilium-cli hubble tempo helm flamegraph necoperf necoip nsdump cmctl
+download-all: node_exporter containerd nerdctl crictl runc argocd kubectl kubeseal stern kustomize jsonnet teleport cke moco logcli yq kubectl-neat accurate alertmanager cilium-cli hubble tempo helm flamegraph necoperf necoip nsdump clusterdump cmctl
 	# all binaries in BINDIR and SBINDIR must have executable bits
 	test -z "$$(find $(BINDIR) $(SBINDIR) -type f -a \( \! -perm -111 \) | tee /dev/stderr)"
 	mkdir -p $(DOWNLOADDIR)
@@ -567,6 +567,11 @@ necoip:
 nsdump:
 	mkdir -p $(BINDIR)
 	cp $(CURDIR)/bin/nsdump $(BINDIR)/nsdump
+
+.PHONY: clusterdump
+clusterdump:
+	mkdir -p $(BINDIR)
+	cp $(CURDIR)/bin/clusterdump $(BINDIR)/clusterdump
 
 $(CMCTL_DOWNLOAD):
 	mkdir -p $(CMCTL_DLDIR)/linux_amd64 $(CMCTL_DLDIR)/windows_amd64 $(CMCTL_DLDIR)/darwin_amd64

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -67,7 +67,7 @@ all:
 	$(CURDIR)/bin/neco-download-dir-cache.sh write
 
 .PHONY: download-all
-download-all: node_exporter containerd nerdctl crictl runc argocd kubectl kubeseal stern kustomize jsonnet teleport cke moco logcli yq kubectl-neat accurate alertmanager cilium-cli hubble tempo helm flamegraph necoperf necoip cmctl
+download-all: node_exporter containerd nerdctl crictl runc argocd kubectl kubeseal stern kustomize jsonnet teleport cke moco logcli yq kubectl-neat accurate alertmanager cilium-cli hubble tempo helm flamegraph necoperf necoip nsdump cmctl
 	# all binaries in BINDIR and SBINDIR must have executable bits
 	test -z "$$(find $(BINDIR) $(SBINDIR) -type f -a \( \! -perm -111 \) | tee /dev/stderr)"
 	mkdir -p $(DOWNLOADDIR)
@@ -562,6 +562,11 @@ necoperf: $(NECOPERF_DOWNLOAD)
 necoip:
 	mkdir -p $(BINDIR)
 	cp $(CURDIR)/bin/necoip $(BINDIR)/necoip
+
+.PHONY: nsdump
+nsdump:
+	mkdir -p $(BINDIR)
+	cp $(CURDIR)/bin/nsdump $(BINDIR)/nsdump
 
 $(CMCTL_DOWNLOAD):
 	mkdir -p $(CMCTL_DLDIR)/linux_amd64 $(CMCTL_DLDIR)/windows_amd64 $(CMCTL_DLDIR)/darwin_amd64

--- a/bin/clusterdump
+++ b/bin/clusterdump
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+set -o pipefail
+
+kubectl get $(kubectl api-resources --namespaced=false -o name | paste -sd,) -o json 2>/dev/null | jq -S 'reduce .items[] as $i ({}; . * {($i.kind): {($i.metadata.name): 1}}) | with_entries(.value=(.value | keys))'

--- a/bin/nsdump
+++ b/bin/nsdump
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+set -o pipefail
+
+if [ $# -eq 0 ]; then
+        echo 'nsdump <NAMESPACE>'
+        exit
+fi
+
+kubectl get -n "$1" $(kubectl api-resources --namespaced -o name | paste -sd,) -o json 2>/dev/null | jq -S 'reduce .items[] as $i ({}; . * {($i.kind): {($i.metadata.name): 1}}) | with_entries(.value=(.value | keys))'


### PR DESCRIPTION
This PR adds the following commands:
- `nsdump <NAMESPACE>`: show all the namespace-scoped resource names in JSON
- `clusterdump`: show all the cluster-scoped resource names in JSON

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>