### PR TITLE
Add optional internet-cn LoadBalancer config

### DIFF
--- a/cilium/pre/bgp_config.yaml
+++ b/cilium/pre/bgp_config.yaml
@@ -27,3 +27,10 @@ data:
       addresses:
       - {{ .lbAddressInternet }}
       auto-assign: false
+    {{ if .lbAddressInternetCN }}
+    - name: internet-cn
+      protocol: bgp
+      addresses:
+      - {{ .lbAddressInternetCN }}
+      auto-assign: false
+    {{ end }}

--- a/dctest/contents_test.go
+++ b/dctest/contents_test.go
@@ -44,6 +44,9 @@ func testInitData() {
 		By("setting LB address block for internet")
 		execSafeAt(bootServers[0], "neco", "config", "set", "lb-address-block-internet", lbAddressBlockInternet)
 
+		By("setting LB address block for internet-cn")
+		execSafeAt(bootServers[0], "neco", "config", "set", "lb-address-block-internet-cn", lbAddressBlockInternetCN)
+
 		By("initialize data for sabakan and CKE")
 		cs, err := getMachinesSpecifiedRole("cs")
 		Expect(err).NotTo(HaveOccurred())

--- a/dctest/run_test.go
+++ b/dctest/run_test.go
@@ -24,11 +24,12 @@ const (
 	// DefaultRunTimeout is the timeout value for Agent.Run().
 	DefaultRunTimeout = 10 * time.Minute
 
-	proxy                  = "http://10.0.49.3:3128"
-	externalIPBlock        = "172.19.0.16/28"
-	lbAddressBlockDefault  = "10.72.32.0/20"
-	lbAddressBlockBastion  = "10.72.48.48/28"
-	lbAddressBlockInternet = "172.19.0.16/28"
+	proxy                    = "http://10.0.49.3:3128"
+	externalIPBlock          = "172.19.0.16/28"
+	lbAddressBlockDefault    = "10.72.32.0/20"
+	lbAddressBlockBastion    = "10.72.48.48/28"
+	lbAddressBlockInternet   = "172.19.0.16/28"
+	lbAddressBlockInternetCN = "172.19.0.248/29"
 )
 
 var (

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -498,6 +498,13 @@ data:
       addresses:
       - {{ .lbAddressInternet }}
       auto-assign: false
+    {{ if .lbAddressInternetCN }}
+    - name: internet-cn
+      protocol: bgp
+      addresses:
+      - {{ .lbAddressInternetCN }}
+      auto-assign: false
+    {{ end }}
 kind: ConfigMap
 metadata:
   name: bgp-config

--- a/pkg/neco/cmd/config_get.go
+++ b/pkg/neco/cmd/config_get.go
@@ -19,18 +19,19 @@ var configGetCmd = &cobra.Command{
 	Long: `Show the current configuration value.
 
 Possible keys are:
-    env                       - "staging" or "prod".  Default is "staging".
-    slack                     - Slack WebHook URL.
-    proxy                     - HTTP proxy server URL to access Internet for boot servers.
-    quay-username             - Username to authenticate to quay.io.
-    check-update-interval     - Polling interval for checking new neco release.
-    worker-timeout            - Timeout value to wait for workers.
-    github-token              - GitHub personal access token for checking GitHub release.
-    node-proxy                - HTTP proxy server URL to access Internet for worker nodes.
-    external-ip-address-block - IP address block to be assigned to Nodes by LoadBalancer controllers.
-    lb-address-block-default  - LoadBalancer address block for default.
-    lb-address-block-bastion  - LoadBalancer address block for bastion.
-    lb-address-block-internet - LoadBalancer address block for internet.`,
+    env                          - "staging" or "prod".  Default is "staging".
+    slack                        - Slack WebHook URL.
+    proxy                        - HTTP proxy server URL to access Internet for boot servers.
+    quay-username                - Username to authenticate to quay.io.
+    check-update-interval        - Polling interval for checking new neco release.
+    worker-timeout               - Timeout value to wait for workers.
+    github-token                 - GitHub personal access token for checking GitHub release.
+    node-proxy                   - HTTP proxy server URL to access Internet for worker nodes.
+    external-ip-address-block    - IP address block to be assigned to Nodes by LoadBalancer controllers.
+    lb-address-block-default     - LoadBalancer address block for default.
+    lb-address-block-bastion     - LoadBalancer address block for bastion.
+    lb-address-block-internet    - LoadBalancer address block for internet.
+    lb-address-block-internet-cn - LoadBalancer address block for internet-cn.`,
 
 	Args: cobra.ExactArgs(1),
 	ValidArgs: []string{
@@ -122,6 +123,12 @@ Possible keys are:
 				fmt.Println(ipBlock)
 			case "lb-address-block-internet":
 				ipBlock, err := st.GetLBAddressBlockInternet(ctx)
+				if err != nil {
+					return err
+				}
+				fmt.Println(ipBlock)
+			case "lb-address-block-internet-cn":
+				ipBlock, err := st.GetLBAddressBlockInternetCN(ctx)
 				if err != nil {
 					return err
 				}

--- a/pkg/neco/cmd/config_set.go
+++ b/pkg/neco/cmd/config_set.go
@@ -23,19 +23,20 @@ var configSetCmd = &cobra.Command{
 	Long: `Store a configuration value to etcd.
 
 Possible keys are:
-    env                       - "staging" or "prod".
-    slack                     - Slack WebHook URL.
-    proxy                     - HTTP proxy server URL to access Internet for boot servers.
-    quay-username             - Username to authenticate to quay.io from QUAY_USER.  This does not take VALUE.
-    quay-password             - Password to authenticate to quay.io from QUAY_PASSWORD.  This does not take VALUE.
-    check-update-interval     - Polling interval for checking new neco release.
-    worker-timeout            - Timeout value to wait for workers.
-    github-token              - GitHub personal access token for checking GitHub release.
-    node-proxy                - HTTP proxy server URL to access Internet for worker nodes.
-    external-ip-address-block - IP address block to be assigned to Nodes by LoadBalancer controllers.
-	lb-address-block-default  - LoadBalancer address block for default.
-	lb-address-block-bastion  - LoadBalancer address block for bastion.
-	lb-address-block-internet - LoadBalancer address block for internet.`,
+    env                          - "staging" or "prod".
+    slack                        - Slack WebHook URL.
+    proxy                        - HTTP proxy server URL to access Internet for boot servers.
+    quay-username                - Username to authenticate to quay.io from QUAY_USER.  This does not take VALUE.
+    quay-password                - Password to authenticate to quay.io from QUAY_PASSWORD.  This does not take VALUE.
+    check-update-interval        - Polling interval for checking new neco release.
+    worker-timeout               - Timeout value to wait for workers.
+    github-token                 - GitHub personal access token for checking GitHub release.
+    node-proxy                   - HTTP proxy server URL to access Internet for worker nodes.
+    external-ip-address-block    - IP address block to be assigned to Nodes by LoadBalancer controllers.
+	lb-address-block-default     - LoadBalancer address block for default.
+	lb-address-block-bastion     - LoadBalancer address block for bastion.
+	lb-address-block-internet    - LoadBalancer address block for internet.
+	lb-address-block-internet-cn - LoadBalancer address block for internet-cn.`,
 
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
@@ -175,6 +176,16 @@ Possible keys are:
 					return errors.New("not IPv4 addr: " + value)
 				}
 				return st.PutLBAddressBlockInternet(ctx, block.String())
+			case "lb-address-block-internet-cn":
+				value = args[1]
+				ip, block, err := net.ParseCIDR(value)
+				if err != nil {
+					return err
+				}
+				if ip.To4() == nil {
+					return errors.New("not IPv4 addr: " + value)
+				}
+				return st.PutLBAddressBlockInternetCN(ctx, block.String())
 			}
 			return errors.New("unknown key: " + key)
 		})

--- a/progs/cke/resource.go
+++ b/progs/cke/resource.go
@@ -40,6 +40,11 @@ func UpdateResources(ctx context.Context, st storage.Storage) error {
 	if err != nil {
 		return err
 	}
+	lbAddr, err = st.GetLBAddressBlockInternetCN(ctx)
+	templateParams, err = setLBAddress("lbAddressInternetCN", lbAddr, templateParams, err)
+	if err != nil {
+		return err
+	}
 
 	env, err := st.GetEnvConfig(ctx)
 	if err != nil {

--- a/storage/config.go
+++ b/storage/config.go
@@ -174,3 +174,13 @@ func (s Storage) PutLBAddressBlockInternet(ctx context.Context, ipBlock string) 
 func (s Storage) GetLBAddressBlockInternet(ctx context.Context) (string, error) {
 	return s.get(ctx, KeyLBAddressBlockInternet)
 }
+
+// PutLBAddressBlockInternetCN stores LB address block for internet-cn to storage.
+func (s Storage) PutLBAddressBlockInternetCN(ctx context.Context, ipBlock string) error {
+	return s.put(ctx, KeyLBAddressBlockInternetCN, ipBlock)
+}
+
+// GetLBAddressBlockInternetCN returns LB address block for internet-cn from storage.
+func (s Storage) GetLBAddressBlockInternetCN(ctx context.Context) (string, error) {
+	return s.get(ctx, KeyLBAddressBlockInternetCN)
+}

--- a/storage/keys.go
+++ b/storage/keys.go
@@ -37,6 +37,7 @@ const (
 	KeyLBAddressBlockDefault    = "config/lb-address-block-default"
 	KeyLBAddressBlockBastion    = "config/lb-address-block-bastion"
 	KeyLBAddressBlockInternet   = "config/lb-address-block-internet"
+	KeyLBAddressBlockInternetCN = "config/lb-address-block-internet-cn"
 	KeyVaultUnsealKey           = "vault-unseal-key"
 	KeyVaultRootToken           = "vault-root-token"
 	KeyFinishPrefix             = "finish/"


### PR DESCRIPTION
This PR adds a new LB address block named `internet-cn`.
It renders the ConfigMap for MetalLB on dctest:

- without `neco config set lb-address-block-internet-cn`:

```
peers:
- peer-address: 127.0.0.1
  peer-asn: 64699
  my-asn: 64698
  node-selectors:
  - match-labels:
      cke.cybozu.com/role: cs
address-pools:
- name: default
  protocol: bgp
  addresses:
  - 10.72.32.0/20
- name: bastion
  protocol: bgp
  addresses:
  - 10.72.48.48/28
  auto-assign: false
- name: internet
  protocol: bgp
  addresses:
  - 172.19.0.16/28
  auto-assign: false
```

- with `neco config set lb-address-block-internet-cn`:

```
peers:
- peer-address: 127.0.0.1
  peer-asn: 64699
  my-asn: 64698
  node-selectors:
  - match-labels:
      cke.cybozu.com/role: cs
address-pools:
- name: default
  protocol: bgp
  addresses:
  - 10.72.32.0/20
- name: bastion
  protocol: bgp
  addresses:
  - 10.72.48.48/28
  auto-assign: false
- name: internet
  protocol: bgp
  addresses:
  - 172.19.0.16/28
  auto-assign: false

- name: internet-cn
  protocol: bgp
  addresses:
  - 172.19.0.248/29
  auto-assign: false
```

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>