### PR TITLE
Disable the image pull progress timeout

### DIFF
--- a/ignitions/common/files/etc/k8s-containerd/config.toml
+++ b/ignitions/common/files/etc/k8s-containerd/config.toml
@@ -49,6 +49,7 @@ oom_score = -999
     startup_delay = "100ms"
   [plugins."io.containerd.grpc.v1.cri"]
     disable_tcp_service = true
+    image_pull_progress_timeout = "0s"
     stream_server_address = "127.0.0.1"
     stream_server_port = "10010"
     stream_idle_timeout = "4h0m0s"


### PR DESCRIPTION
Change the containerd configuration so that a timeout does not occur when pulling an image.
Set `image_pull_progress_timeout` to `0s` to prevent timeouts.
>A zero value means there is no timeout.
https://github.com/containerd/containerd/blob/v1.7.13/pkg/cri/config/config.go#L374