### PR TITLE
Add InstallDebianPackage and installDebianPackage's parameter to give Env values for systemd-run

### DIFF
--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -39,7 +39,7 @@ func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest
 		if err != nil {
 			return err
 		}
-		err = InstallDebianPackage(ctx, o.proxyClient, o.ghClient, &deb, false)
+		err = InstallDebianPackage(ctx, o.proxyClient, o.ghClient, &deb, false, nil)
 		if err != nil {
 			return err
 		}

--- a/worker/operator.go
+++ b/worker/operator.go
@@ -113,12 +113,12 @@ func (o *operator) UpdateNeco(ctx context.Context, req *neco.UpdateRequest) erro
 		return err
 	}
 	if env == neco.TestEnv {
-		return installLocalPackage(ctx, deb)
+		return installLocalPackage(ctx, deb, map[string]string{"HOME": "/home/cybozu"})
 	}
 	if env == neco.DevEnv {
 		deb.Release = "test-" + req.Version
 	}
-	return InstallDebianPackage(ctx, o.proxyClient, o.ghClient, deb, true)
+	return InstallDebianPackage(ctx, o.proxyClient, o.ghClient, deb, true, map[string]string{"HOME": "/home/cybozu"})
 }
 
 func (o *operator) FinalStep() int {


### PR DESCRIPTION
This PR added the parameter(named `envValues`) for `InstallDebianPackage()` and `installDebianPackage()` to set environment values.

Given values in `envValues` will be extracted like following and will be executed.
When `envValues` is given as `map[string]string{"HOME": "/home/cybozu"}`,  these values are extracted like following.

```console
systemd-run -p Environment=HOME=/home/cybozu ...
```

ref: https://github.com/cybozu-go/neco/pull/2506/files#diff-38861c4365e417f67e3b1020fb2297e10cd135406e2913894c4ed32c7f5d2aa4R116

Signed-off-by: terasihma <tomoya-terashima@cybozu.co.jp>