### PR TITLE
Increase maxPods in kubelet to 150

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -194,6 +194,7 @@ options:
       containerLogMaxSize: 10Mi
       containerLogMaxFiles: 10
       cpuManagerPolicy: static
+      maxPods: 150
       topologyManagerPolicy: best-effort
       systemReserved:
         cpu: "1"


### PR DESCRIPTION
In some environments (CI and stage1), the number of pods per node is insufficient.

ref. https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration