### PR TITLE
Use docker credentials when pulling container images

### DIFF
--- a/image.go
+++ b/image.go
@@ -35,11 +35,7 @@ func (f ImageFetcher) GetTarball(ctx context.Context, img ContainerImage, w io.W
 		return err
 	}
 
-	auth := f.auth
-	if auth == nil || !img.Private {
-		auth = authn.Anonymous
-	}
-	rimg, err := remote.Image(ref, remote.WithAuth(auth), remote.WithContext(ctx), remote.WithJobs(1), remote.WithTransport(f.transport))
+	rimg, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx), remote.WithJobs(1), remote.WithTransport(f.transport))
 	if err != nil {
 		return fmt.Errorf("failed to create remote image for %s: %w", img.Name, err)
 	}


### PR DESCRIPTION
In the current implementation, when pulling container images from neco, the credentials managed by either docker or neco are used.

When pulling container images, docker credentials will be used.
https://github.com/cybozu-go/neco/blob/b13aacd3b261ac6ba648a3d2e19a46839d928f6d/docker.go#L44-L47

When pulling a container image to tarball it, the credentials stored in neco will be used.
https://github.com/cybozu-go/neco/blob/b13aacd3b261ac6ba648a3d2e19a46839d928f6d/image.go#L42

I would like to be able to manage credentials in one of the two, because if I manage credentials in both, there is a possibility that credential update omissions may occur.
This PR will change to use docker credentials when pulling container images to tarball them.

I plan to remove the functions that manage credentials for pulling container images when they are no longer used.