### PR TITLE
Fix time parse format

### DIFF
--- a/pkg/generate-sabakan-machines/cmd/root.go
+++ b/pkg/generate-sabakan-machines/cmd/root.go
@@ -80,7 +80,7 @@ Example:
 				return err
 			}
 
-			supportDate, err := time.Parse("2006/1/02", supportDateString)
+			supportDate, err := time.Parse("2006/1/2", supportDateString)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
`generate-sabakan-machines` fails when the date of `supportDateString` is one digit.

```
$ cat <<EOF > input.csv
環境,論理ラック番号,物理ラック番号,シリアル番号,機種,role,サポート開始日
env,1,mydc rack1,serial,model,boot,2024/5/9
EOF
$ go install ./pkg/generate-sabakan-machines
$ generate-sabakan-machines --machine-type-boot=r6525-boot-1 --machine-type-cs=r6525-cs-1 --machine-type-ss=r7525-ss-1 input.csv
Error: parsing time "2024/5/9" as "2006/1/02": cannot parse "9" as "02"
```