### PR TITLE
Remove time display

### DIFF
--- a/dctest/suites_test.go
+++ b/dctest/suites_test.go
@@ -1,10 +1,8 @@
 package dctest
 
 import (
-	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,13 +31,6 @@ var _ = BeforeSuite(func() {
 // This must be the only top-level test container.
 // Other tests and test containers must be listed in this.
 var _ = Describe("Neco", func() {
-	BeforeEach(func() {
-		fmt.Printf("START: %s\n", time.Now().Format(time.RFC3339))
-	})
-	AfterEach(func() {
-		fmt.Printf("END: %s\n", time.Now().Format(time.RFC3339))
-	})
-
 	switch testSuite {
 	case "bootstrap":
 		bootstrapSuite()


### PR DESCRIPTION
This PR removes the time display of dctest test.

Now Ginkgo displays the execution time of `By`. So start time and end time of each test is unnecessary.
(The time was not displayed at Ginkgo v1.)

```
Neco setup should complete updates
/home/actions/go/src/github.com/cybozu-go/neco/dctest/setup_test.go:137
START: 2024-06-05T00:09:17Z                                        // Remove
  STEP: Waiting for request to complete @ 06/05/24 00:09:17.51     // Ginkgo displays the execution time of "By".
  STEP: Installing sshd_config and sudoers @ 06/05/24 00:09:43.499
END: 2024-06-05T00:09:43Z                                          // Remove
• [26.030 seconds]
```