### PR TITLE
Revert "Audit creation of cilium.io resources"

### DIFF
--- a/etc/cke-template.yml
+++ b/etc/cke-template.yml
@@ -113,10 +113,6 @@ options:
             - group: ""
               resources: ["events"]
         - level: RequestResponse
-          verbs: ["create"]
-          resources:
-            - group: "cilium.io"
-        - level: RequestResponse
           userGroups:
             - system:serviceaccounts:teleport
         - level: None


### PR DESCRIPTION
Revert commit 8f311b4ef48c5cb2b44b09382c3e9101698116fd due to the massive volume of metrics.