### PR TITLE
Update Cilium bpf-map-dynamic-size-ratio to 0.005

### DIFF
--- a/cilium/pre/kustomization.yaml
+++ b/cilium/pre/kustomization.yaml
@@ -33,12 +33,3 @@ patches:
     patch: |-
       - op: remove
         path: /spec/ttlSecondsAfterFinished
-  - target:
-      group: apps
-      version: v1
-      kind: DaemonSet
-      name: cilium
-    patch: |-
-      - op: replace
-        path: /spec/updateStrategy/rollingUpdate/maxUnavailable
-        value: 1

--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -787,9 +787,7 @@ spec:
     matchLabels:
       k8s-app: cilium
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 2
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       annotations:

--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -114,7 +114,7 @@ data:
   monitor-aggregation-flags: all
   # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
-  bpf-map-dynamic-size-ratio: "0.0025"
+  bpf-map-dynamic-size-ratio: "0.005"
   enable-host-legacy-routing: "true"
   # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
@@ -796,7 +796,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7"
+        cilium.io/cilium-configmap-checksum: "fe121f30b675abe564f63cbaa4ba558cb513e07282fe8a60e2db39519b4da8d5"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1204,7 +1204,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7"
+        cilium.io/cilium-configmap-checksum: "fe121f30b675abe564f63cbaa4ba558cb513e07282fe8a60e2db39519b4da8d5"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -98,4 +98,7 @@ socketLB:
   enabled: true
   hostNamespaceOnly: true
 tunnel: "disabled"
+updateStrategy:
+  rollingUpdate: null
+  type: OnDelete
 upgradeCompatibility: "1.12"

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -5,6 +5,7 @@ bgp:
 bpf:
   hostLegacyRouting: true
   policyMapMax: 65536
+  mapDynamicSizeRatio: 0.005
 cgroup:
   autoMount:
     enabled: false

--- a/cilium/prod/kustomization.yaml
+++ b/cilium/prod/kustomization.yaml
@@ -33,12 +33,3 @@ patches:
     patch: |-
       - op: remove
         path: /spec/ttlSecondsAfterFinished
-  - target:
-      group: apps
-      version: v1
-      kind: DaemonSet
-      name: cilium
-    patch: |-
-      - op: replace
-        path: /spec/updateStrategy/rollingUpdate/maxUnavailable
-        value: 1

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -784,9 +784,7 @@ spec:
     matchLabels:
       k8s-app: cilium
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 2
-    type: RollingUpdate
+    type: OnDelete
   template:
     metadata:
       annotations:

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -114,7 +114,7 @@ data:
   monitor-aggregation-flags: all
   # Specifies the ratio (0.0-1.0] of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
-  bpf-map-dynamic-size-ratio: "0.0025"
+  bpf-map-dynamic-size-ratio: "0.005"
   enable-host-legacy-routing: "true"
   # bpf-policy-map-max specifies the maximum number of entries in endpoint
   # policy map (per endpoint)
@@ -793,7 +793,7 @@ spec:
         prometheus.io/port: "9962"
         prometheus.io/scrape: "true"
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a"
+        cilium.io/cilium-configmap-checksum: "604113879d707e36938fe8078247de69dce6703aec1aa91904ab4f2a9b6f321b"
         # Set app AppArmor's profile to "unconfined". The value of this annotation
         # can be modified as long users know which profiles they have available
         # in AppArmor.
@@ -1201,7 +1201,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a"
+        cilium.io/cilium-configmap-checksum: "604113879d707e36938fe8078247de69dce6703aec1aa91904ab4f2a9b6f321b"
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -88,4 +88,7 @@ socketLB:
   enabled: true
   hostNamespaceOnly: true
 tunnel: "disabled"
+updateStrategy:
+  rollingUpdate: null
+  type: OnDelete
 upgradeCompatibility: "1.12"

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -5,6 +5,7 @@ bgp:
 bpf:
   hostLegacyRouting: true
   policyMapMax: 65536
+  mapDynamicSizeRatio: 0.005
 cgroup:
   autoMount:
     enabled: false

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -1354,9 +1354,7 @@ spec:
               name: hubble-server-certs
               optional: true
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 2
-    type: RollingUpdate
+    type: OnDelete
 ---
 apiVersion: batch/v1
 kind: Job

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -528,7 +528,7 @@ data:
   bpf-lb-mode: dsr
   bpf-lb-sock: "true"
   bpf-lb-sock-hostns-only: "true"
-  bpf-map-dynamic-size-ratio: "0.0025"
+  bpf-map-dynamic-size-ratio: "0.005"
   bpf-policy-map-max: "65536"
   bpf-root: /sys/fs/bpf
   cgroup-root: /sys/fs/cgroup
@@ -730,7 +730,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7
+        cilium.io/cilium-configmap-checksum: fe121f30b675abe564f63cbaa4ba558cb513e07282fe8a60e2db39519b4da8d5
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -1001,7 +1001,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 497b978fead720b12575f287cf56eb73c58cccdc3258804c312ea4323a3460a7
+        cilium.io/cilium-configmap-checksum: fe121f30b675abe564f63cbaa4ba558cb513e07282fe8a60e2db39519b4da8d5
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -1355,7 +1355,7 @@ spec:
               optional: true
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 2
     type: RollingUpdate
 ---
 apiVersion: batch/v1

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -1338,9 +1338,7 @@ spec:
               name: hubble-server-certs
               optional: true
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 2
-    type: RollingUpdate
+    type: OnDelete
 ---
 apiVersion: batch/v1
 kind: Job

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -1339,7 +1339,7 @@ spec:
               optional: true
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 2
     type: RollingUpdate
 ---
 apiVersion: batch/v1

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -521,7 +521,7 @@ data:
   bpf-lb-mode: dsr
   bpf-lb-sock: "true"
   bpf-lb-sock-hostns-only: "true"
-  bpf-map-dynamic-size-ratio: "0.0025"
+  bpf-map-dynamic-size-ratio: "0.005"
   bpf-policy-map-max: "65536"
   bpf-root: /sys/fs/bpf
   cgroup-root: /sys/fs/cgroup
@@ -720,7 +720,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a
+        cilium.io/cilium-configmap-checksum: 604113879d707e36938fe8078247de69dce6703aec1aa91904ab4f2a9b6f321b
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:
@@ -985,7 +985,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 9544eae4b75b0368f5622be10d33372dda03ed6d2df589ee96ac9290afe7f63a
+        cilium.io/cilium-configmap-checksum: 604113879d707e36938fe8078247de69dce6703aec1aa91904ab4f2a9b6f321b
         container.apparmor.security.beta.kubernetes.io/cilium-agent: unconfined
         container.apparmor.security.beta.kubernetes.io/clean-cilium-state: unconfined
         prometheus.io/port: "9962"


### PR DESCRIPTION
This PR:
- changes `updateStrategy` of cilium-agent to `OnDelete`
- increases `bpf-map-dynamic-size-ratio` from `0.0025` to `0.005`

Signed-off-by: Tomoki Sugiura <tomoki-sugiura@cybozu.co.jp>
Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
