### PR TITLE
Update containerd version and modify the configuration

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2,7 +2,7 @@
 
 ## These should be updated when Kubernetes is updated
 CKE_VERSION = 1.28.6
-CONTAINERD_VERSION = 1.7.13
+CONTAINERD_VERSION = 1.7.20
 NERDCTL_VERSION = 1.7.6
 CRITOOLS_VERSION = 1.30.0
 RUNC_VERSION = 1.1.12

--- a/ignitions/common/files/etc/k8s-containerd/config.toml
+++ b/ignitions/common/files/etc/k8s-containerd/config.toml
@@ -50,6 +50,7 @@ oom_score = -999
   [plugins."io.containerd.grpc.v1.cri"]
     disable_tcp_service = true
     image_pull_progress_timeout = "0s"
+    image_pull_with_sync_fs = true
     stream_server_address = "127.0.0.1"
     stream_server_port = "10010"
     stream_idle_timeout = "4h0m0s"

--- a/ignitions/common/files/opt/bin/load-containerd-image
+++ b/ignitions/common/files/opt/bin/load-containerd-image
@@ -9,7 +9,7 @@ img="$1"
 tag="$2"
 filename=/tmp/$(basename "$img")
 
-if /opt/bin/ctr --address=/var/run/k8s-containerd.sock --namespace k8s.io image inspect "$tag" >/dev/null 2>&1; then
+if /opt/bin/ctr --address=/var/run/k8s-containerd.sock --namespace k8s.io images list | grep "$tag" >/dev/null 2>&1; then
     exit 0
 fi
 


### PR DESCRIPTION
- Update containerd to 1.7.20.
- Enable image pull with sync fs in k8s-containerd config to prevent data inconsistencies in the event of an unexpected shutdown.
- Fix load-containerd-image script.