### PR TITLE
Add cilium api-rate-limit config

### DIFF
--- a/cilium/pre/kustomization.yaml
+++ b/cilium/pre/kustomization.yaml
@@ -33,3 +33,9 @@ patches:
     patch: |-
       - op: remove
         path: /spec/ttlSecondsAfterFinished
+configMapGenerator:
+- name: cilium-config
+  namespace: kube-system
+  behavior: merge
+  literals:
+  - api-rate-limit=endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2

--- a/cilium/prod/kustomization.yaml
+++ b/cilium/prod/kustomization.yaml
@@ -33,3 +33,9 @@ patches:
     patch: |-
       - op: remove
         path: /spec/ttlSecondsAfterFinished
+configMapGenerator:
+- name: cilium-config
+  namespace: kube-system
+  behavior: merge
+  literals:
+  - api-rate-limit=endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -513,6 +513,7 @@ metadata:
 apiVersion: v1
 data:
   agent-not-ready-taint-key: node.cilium.io/agent-not-ready
+  api-rate-limit: endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -506,6 +506,7 @@ metadata:
 apiVersion: v1
 data:
   agent-not-ready-taint-key: node.cilium.io/agent-not-ready
+  api-rate-limit: endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"


### PR DESCRIPTION
This PR adds cilium's api-rate-limit config.

note: Cilium doesn't support api-rate-limit helm value at 1.13 (it's supported from 1.15).