### PR TITLE
Set timeout to FW update commands

### DIFF
--- a/pkg/neco/cmd/isoreboot.go
+++ b/pkg/neco/cmd/isoreboot.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -20,14 +21,16 @@ If some nodes are already powered off, this command does not do anything to thos
 }
 
 var isoRebootGetOpts sabakanMachinesGetOpts
+var isoRebootTimeoutOption time.Duration
 
 func isoRebootRun(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
-	uploadAssetsAndRunCommandOnWorkers(ctx, &isoRebootGetOpts, args, []string{"docker", "exec", "setup-hw", "setup-isoreboot"}, true)
+	uploadAssetsAndRunCommandOnWorkers(ctx, &isoRebootGetOpts, args, []string{"docker", "exec", "setup-hw", "setup-isoreboot"}, isoRebootTimeoutOption, true)
 }
 
 func init() {
 	rootCmd.AddCommand(isoRebootCmd)
 	addSabakanMachinesGetOpts(isoRebootCmd, &isoRebootGetOpts)
+	isoRebootCmd.Flags().DurationVar(&isoRebootTimeoutOption, "timeout", 30*time.Second, "timeout")
 }


### PR DESCRIPTION
part of https://github.com/cybozu-private/neco-tasks/issues/397

This PR set the default timeaout and timeout option to `neco isoreboot` and `neco apply-firmware`.

Sometimes SSH to the worker machines hangs and the command stops.
To prevent this, I set a timeout to child command execution.

According to the execution log of past runs, execution time of `isoreboot`'s child command was about 12~13 seconds; `apply-firmware`'s child command was about 70 seconds, on worker nodes.
So I set the default timeout as follows:

- isoreboot: 30sec
- apply-firmware: 5min