### PR TITLE
Fix CI instability

### DIFF
--- a/dctest/Makefile
+++ b/dctest/Makefile
@@ -110,6 +110,12 @@ run-placemat-inside-container: $(PLACEMAT_DEPS)
 	$(SUDO) cp $(OUTPUT)/bird*.conf /etc/bird
 	$(SUDO) cp $(OUTPUT)/squid.conf /etc/squid
 	$(SUDO) sh -c "$(PLACEMAT) $(abspath $(OUTPUT)/cluster.yml) > /var/log/placemat.log  2>&1" &
+	for i in $$(seq 60); do \
+		if ! pgrep --exact placemat2 > /dev/null; then \
+			break; \
+		fi; \
+		sleep 1; \
+	done
 	@echo 'Placemat is running.  To kill it, do "make stop-placemat-inside-container".'
 
 .PHONY: stop-placemat-inside-container

--- a/dctest/machines_test.go
+++ b/dctest/machines_test.go
@@ -2,16 +2,21 @@ package dctest
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+func handleBMCRetry(stdout, stderr string, err error) bool {
+	return strings.Contains(stderr, "missing HTTP content-type")
+}
+
 // testMachines tests machine control functions.
 func testMachines() {
 	It("should put BMC/IPMI settings", func() {
 		// test set/get functions
-		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "bmc-user", "/mnt/bmc-user.json")
+		execRetryAt(bootServers[0], handleBMCRetry, "neco", "bmc", "config", "set", "bmc-user", "/mnt/bmc-user.json")
 
 		execSafeAt(bootServers[0], "neco", "bmc", "config", "set", "ipmi-user", "cybozu1")
 		ipmiUser := execSafeAt(bootServers[0], "neco", "bmc", "config", "get", "ipmi-user")


### PR DESCRIPTION
This PR fixes three flaky behaviors to improve CI stability.

- test: retry neco bmc config set bmc-user
  Previously, `neco bmc config set bmc-user` sometimes fails because it fails to send packets and receives a message with `"missing HTTP content-type"`.
  This PR implements `execRetryAt` and `handleBMCRetry` to see if it is caused by connection error.

- neco-worker: wait changing systemd service state until transient state ends
  neco-worker was not deterministic at stopping systemd service, because `systemd` rejects `systemd stop <service_name>` with message `"Job for <service_name> canceled."` when it is already changing its state, especially when it is in `activating` or `deactivating` state.

- test: wait placemat
  In minor cases PID of `placemat2` is not observed and CI fails. This fix waits until `pgrep --exact placemat2` succeeds.