### PR TITLE
add help to nsdump, clusterdump, and necoip commands

### DIFF
--- a/bin/clusterdump
+++ b/bin/clusterdump
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 set -o pipefail
 
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+        echo '* clusterdump'
+        echo '# clusterdump shows all the cluster-scoped resources in a JSON format.'
+        echo '# to see implementation: cat $(which clusterdump)'
+        exit
+fi
+
 # The following line returns a non-zero code if it cannot access API server
 KINDS=$(kubectl api-resources --namespaced=false -o name | paste -sd,)
 

--- a/bin/necoip
+++ b/bin/necoip
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 set -o pipefail
 
-if [ $# -eq 0 ]; then
-        echo 'necoip <IPADDR>'
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+        echo '* necoip <IPADDR>'
+        echo '# necoip shows the detail of an IP, how it is used in the cluster.'
+        echo '# to see implementation: cat $(which necoip)'
         exit
 fi
 

--- a/bin/nsdump
+++ b/bin/nsdump
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 set -o pipefail
 
-if [ $# -eq 0 ]; then
-        echo 'nsdump <NAMESPACE>'
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+        echo '* nsdump <NAMESPACE>'
+        echo '# nsdump shows all the resources in a namespace in a JSON format.'
+        echo '# show implementation: cat $(which nsdump)'
         exit
 fi
 


### PR DESCRIPTION
This PR supports `-h` and `--help` options for `nsdump`, `clusterdump`, and `necoip`.