### PR TITLE
Bump Argo CD version to 2.11.7 from 2.10.2

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -12,7 +12,7 @@ STERN_VERSION = 1.30.0
 
 
 ## These should be updated regularly
-ARGOCD_VERSION = 2.10.2
+ARGOCD_VERSION = 2.11.7
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L10
 KUSTOMIZE_VERSION = 5.2.1

--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -7,6 +7,8 @@ images:
   versions: ["1.14.13.1", "1.14.13.2"]
 - repository: ghcr.io/cybozu/cilium-certgen
   versions: ["0.1.14.1"]
+- repository: ghcr.io/cybozu/etcd
+  versions: ["3.5.15.1"]
 osImage:
 - channel: stable
   versions: ["3975.2.0"]


### PR DESCRIPTION
Ref. https://github.com/cybozu-private/neco-apps/pull/5287