### PR TITLE
fix neco-rebooter

### DIFF
--- a/pkg/neco-rebooter/metrics.go
+++ b/pkg/neco-rebooter/metrics.go
@@ -139,6 +139,14 @@ func (c *collector) updateProcessingGroup(ch chan<- prometheus.Metric, ctx conte
 		slog.Error("failed to get processing group", "err", err)
 		return
 	}
+	entries, err := c.storage.GetRebootListEntries(ctx)
+	if err != nil {
+		slog.Error("failed to get reboot list", "err", err)
+		return
+	}
+	if len(entries) == 0 {
+		return
+	}
 	ch <- prometheus.MustNewConstMetric(c.processingGroup, prometheus.GaugeValue, 1, group)
 }
 

--- a/pkg/neco-rebooter/metrics_test.go
+++ b/pkg/neco-rebooter/metrics_test.go
@@ -108,4 +108,23 @@ func TestMetrics(t *testing.T) {
 			t.Errorf("number of %s is expected to 1 %s, but got %d", metrics, tc.expect, strings.Count(metrics, tc.expect))
 		}
 	}
+
+	// Remove all entries
+	entries, err := c.necoStorage.GetRebootListEntries(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		err = c.necoStorage.RemoveRebootListEntry(context.Background(), c.leaderKey, entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	req = httptest.NewRequest("GET", "/metrics", nil)
+	rec = httptest.NewRecorder()
+	ts.Config.Handler.ServeHTTP(rec, req)
+	metrics = rec.Body.String()
+	if strings.Contains(metrics, "neco_rebooter_processing_group") {
+		t.Errorf("unexpected metrics: %s", metrics)
+	}
 }

--- a/pkg/neco-rebooter/utils.go
+++ b/pkg/neco-rebooter/utils.go
@@ -31,6 +31,14 @@ func findRebootQueueEntryFromRebootListEntry(rebootQueueEntries []*cke.RebootQue
 	}
 	return nil
 }
+func findRebootListEntryFromRebootQueueEntry(rebootListEntries []*neco.RebootListEntry, rebootQueueEntry cke.RebootQueueEntry) *neco.RebootListEntry {
+	for _, entry := range rebootListEntries {
+		if entry.Node == rebootQueueEntry.Node {
+			return entry
+		}
+	}
+	return nil
+}
 
 func getAllGroups(rebootListEntries []*neco.RebootListEntry) []string {
 	groups := make([]string, 0)


### PR DESCRIPTION
fix neco-rebooter to 
- manage orphaned cke reboot queue entry
- hide processing group metrics when number of the reboot list entry is 0