### PR TITLE
dctest: try to recover when update request is aborted

### DIFF
--- a/dctest/join_remove_test.go
+++ b/dctest/join_remove_test.go
@@ -168,7 +168,7 @@ func testJoinRemove() {
 		execSafeAt(bootServers[0], "sudo", "env", "VAULT_TOKEN="+token, "neco", "leave", "3")
 
 		By("Waiting for the request to complete")
-		waitRequestComplete("members: [0 1 2]", true)
+		waitRequestCompleteWithRecover("members: [0 1 2]", 3)
 
 		By("Waiting boot-3 gets removed from etcd")
 		Eventually(func() error {

--- a/dctest/setup_test.go
+++ b/dctest/setup_test.go
@@ -137,7 +137,7 @@ WantedBy=multi-user.target`
 
 	It("should complete updates", func() {
 		By("Waiting for request to complete")
-		waitRequestComplete("")
+		waitRequestCompleteWithRecover("", 3)
 
 		By("Installing sshd_config and sudoers")
 		for _, h := range bootServers {


### PR DESCRIPTION
This PR fixes the flaky test in `setup_test.go`.

Stopping Vault in neco update process sometimes fails as follows.
I think neco recover will solve the problem, so when aborted, it will call neco recover.

```
Neco setup should complete updates
/tmp/release/dctest/setup_test.go:138
  STEP: Waiting for request to complete @ 09/04/24 15:25:12.455
  [FAILED] in [It] - /tmp/release/dctest/setup_test.go:140 @ 09/04/24 15:35:14.457
• [FAILED] [602.002 seconds]
Neco setup [It] should complete updates
/tmp/release/dctest/setup_test.go:138

  [FAILED] Timed out after 600.001s.
  Expected success, but got an error:
      <*errors.errorString | 0xc000174070>: 
      request is not completed: Boot servers: [0 1 2]
      Update process
          status: aborted
         version: 2024.08.28-31066
         members: [0 1 2]
         started: 2024-09-04T15:25:09Z
      
      Boot server 0
          step: 4
          condition: aborted
          message: other boot server failed to update: 1
      
      Boot server 1
          step: 3
          condition: aborted
          message: exit status 1
      
      Boot server 2
          step: 4
          condition: aborted
          message: other boot server failed to update: 1
      
      {
          s: "request is not completed: Boot servers: [0 1 2]\nUpdate process\n    status: aborted\n   version: 2024.08.28-31066\n   members: [0 1 2]\n   started: 2024-09-04T15:25:09Z\n\nBoot server 0\n    step: 4\n    condition: aborted\n    message: other boot server failed to update: 1\n\nBoot server 1\n    step: 3\n    condition: aborted\n    message: exit status 1\n\nBoot server 2\n    step: 4\n    condition: aborted\n    message: other boot server failed to update: 1\n",
      }
  In [It] at: /tmp/release/dctest/setup_test.go:140 @ 09/04/24 15:35:14.457
```