### PR TITLE
dctest: Fixed wrong use of StopTrying

### DIFF
--- a/dctest/run_test.go
+++ b/dctest/run_test.go
@@ -183,7 +183,7 @@ func execRetryAt(host string, handler retryHandler, args ...string) []byte {
 		if err != nil {
 			msg := fmt.Sprintf("stdout: %s, stderr: %s, err: %v", string(stdout), string(stderr), err)
 			if !handler(string(stdout), string(stderr), err) {
-				StopTrying("retry skipped. " + msg).Wrap(err)
+				StopTrying("retry skipped. " + msg).Wrap(err).Now()
 			}
 			fmt.Printf("retrying... %v", args)
 			g.Expect(err).NotTo(BeNil(), "retry failed. "+msg)


### PR DESCRIPTION
This PR fixed wrong use of `StopTrying()`.
In this case, we may need to call `StopTrying().Now()`.

https://pkg.go.dev/github.com/onsi/gomega#pkg-variables