### PR TITLE
dctest: try to recover forever

### DIFF
--- a/dctest/join_remove_test.go
+++ b/dctest/join_remove_test.go
@@ -168,7 +168,7 @@ func testJoinRemove() {
 		execSafeAt(bootServers[0], "sudo", "env", "VAULT_TOKEN="+token, "neco", "leave", "3")
 
 		By("Waiting for the request to complete")
-		waitRequestCompleteWithRecover("members: [0 1 2]", 3)
+		waitRequestComplete("members: [0 1 2]", true)
 
 		By("Waiting boot-3 gets removed from etcd")
 		Eventually(func() error {

--- a/dctest/setup_test.go
+++ b/dctest/setup_test.go
@@ -137,7 +137,7 @@ WantedBy=multi-user.target`
 
 	It("should complete updates", func() {
 		By("Waiting for request to complete")
-		waitRequestCompleteWithRecover("", 3)
+		waitRequestComplete("", true)
 
 		By("Installing sshd_config and sudoers")
 		for _, h := range bootServers {


### PR DESCRIPTION
https://github.com/cybozu-go/neco/pull/2670 was ineffective. I will try to correct it.

When limiting the number of recoveries, The `Eventually` may terminate before the rerun completes. (as follows)
So I try to repeat `neco recover` forever.

https://github.com/cybozu-private/neco-apps/actions/runs/10822616854/job/30031096472
```
Neco setup should complete updates
/home/actions/go/src/github.com/cybozu-go/neco/dctest/setup_test.go:138
  STEP: Waiting for request to complete @ 09/12/24 04:44:43.666
Boot servers: [0 1 2]
Update process
    status: aborted
   version: 9999.12.31-99999
   members: [0 1 2]
   started: 2024-09-12T04:44:41Z

Boot server 0
    step: 4
    condition: aborted
    message: other boot server failed to update: 2

Boot server 1
    step: 3
    condition: running

Boot server 2
    step: 3
    condition: aborted
    message: exit status 1

update request is aborted, try to recover...
Boot servers: [0 1 2]
Update process
    status: aborted
   version: 9999.12.31-99999
   members: [0 1 2]
   started: 2024-09-12T04:44:41Z

Boot server 0
    step: 4
    condition: aborted
    message: other boot server failed to update: 2

Boot server 1
    step: 4
    condition: aborted
    message: other boot server failed to update: 2

Boot server 2
    step: 3
    condition: aborted
    message: exit status 1

update request is aborted, try to recover...
Boot servers: [0 1 2]
Update process
    status: aborted
   version: 9999.12.31-99999
   members: [0 1 2]
   started: 2024-09-12T04:44:41Z

Boot server 0
    step: 4
    condition: aborted
    message: other boot server failed to update: 2

Boot server 1
    step: 4
    condition: aborted
    message: other boot server failed to update: 2

Boot server 2
    step: 3
    condition: aborted
    message: exit status 1

update request is aborted, try to recover...
```