### PR TITLE
Update Cilium endpoint-create API rate limit in stages

### DIFF
--- a/cilium/pre/kustomization.yaml
+++ b/cilium/pre/kustomization.yaml
@@ -38,4 +38,4 @@ configMapGenerator:
   namespace: kube-system
   behavior: merge
   literals:
-  - api-rate-limit=endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2
+  - api-rate-limit=endpoint-create=auto-adjust:true,log:true,estimated-processing-duration:5s,max-parallel-requests:16

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -529,7 +529,7 @@ metadata:
 apiVersion: v1
 data:
   agent-not-ready-taint-key: node.cilium.io/agent-not-ready
-  api-rate-limit: endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2
+  api-rate-limit: endpoint-create=auto-adjust:true,log:true,estimated-processing-duration:5s,max-parallel-requests:16
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"


### PR DESCRIPTION
This PR updates Cilium's endpoint-create API rate limit in stages.
Details are below.

- Remove `mean-over` because it is the same as the default value.
  - https://github.com/cilium/cilium/blob/24d61daa20b1e1e1074ad73e4a9b6fea5374b95b/pkg/rate/api_limiter.go#L27
- Change `max-parallel-requests` to 16
- Remove `min-parallel-requests`(default 0).
- Change `estimated-processing-duration` to 5s
  - This means Cilium will raise `rate-limit` unless Pod creation time exceeds this value.
- Enables log
  - `rate` subsystem will output logs

Default values of endpoint-create API rate limit are here:
https://github.com/cilium/cilium/blob/c1044d67cab67eca42517a5f385ccb06b4d49219/daemon/cmd/api_limits.go#L23-L32