### PR TITLE
Flatcar OS 3975.2.1

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -24,5 +24,5 @@ var CurrentArtifacts = ArtifactSet{
 	Debs: []DebianPackage{
 		{Name: "etcdpasswd", Owner: "cybozu-go", Repository: "etcdpasswd", Release: "v1.4.8"},
 	},
-	OSImage: OSImage{Channel: "stable", Version: "3815.2.5"},
+	OSImage: OSImage{Channel: "stable", Version: "3975.2.1"},
 }

--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -1,6 +1,3 @@
 images:
 - repository: ghcr.io/cybozu/etcd
   versions: ["3.5.15.1"]
-osImage:
-- channel: stable
-  versions: ["3975.2.0","3975.2.1"]

--- a/ignitions/common/files/etc/fstab
+++ b/ignitions/common/files/etc/fstab
@@ -1,7 +1,7 @@
-/dev/vg1/k8s-containerd /var/lib/k8s-containerd   ext4  x-systemd.device-timeout=600 0 0
-/dev/vg1/docker         /var/lib/docker           ext4  x-systemd.device-timeout=600 0 0
-/dev/vg1/kubelet        /var/lib/kubelet          ext4  x-systemd.device-timeout=600 0 0
-/dev/vg1/systemd        /var/lib/systemd          ext4  x-systemd.device-timeout=600 0 0
-/dev/vg1/coredump       /var/lib/systemd/coredump ext4  x-systemd.device-timeout=600 0 0
-none                    /var/lib/rook             tmpfs defaults                     0 0
-/var/lib/kubelet/varlog /var/log                  none  bind                         0 0
+/dev/vg1/k8s-containerd /var/lib/k8s-containerd   ext4  x-systemd.requires=setup-var.service,x-systemd.device-timeout=600 0 0
+/dev/vg1/docker         /var/lib/docker           ext4  x-systemd.requires=setup-var.service,x-systemd.device-timeout=600 0 0
+/dev/vg1/kubelet        /var/lib/kubelet          ext4  x-systemd.requires=setup-var.service,x-systemd.device-timeout=600 0 0
+/dev/vg1/systemd        /var/lib/systemd          ext4  x-systemd.requires=setup-var.service,x-systemd.device-timeout=600 0 0
+/dev/vg1/coredump       /var/lib/systemd/coredump ext4  x-systemd.requires=setup-var.service,x-systemd.device-timeout=600 0 0
+none                    /var/lib/rook             tmpfs defaults                                                          0 0
+/var/lib/kubelet/varlog /var/log                  none  bind                                                              0 0


### PR DESCRIPTION
This PR updates Flatcar OS to 3975.2.1 and adds dependencies to `/etc/fstab`.

With Flatcar OS 3975.2.1, the order of `setup-var.service` and volume mounting is often reversed, and the CI(neco's bootstrap) became too unstable. (It almost always fails.)
To prevent this, I set `x-systemd.requires` to `/etc/fstab` and stabilize the order.