### PR TITLE
Add new network I/F settings

### DIFF
--- a/ignitions/common/files/opt/sbin/neco-wait-dhcp-online
+++ b/ignitions/common/files/opt/sbin/neco-wait-dhcp-online
@@ -2,7 +2,7 @@
 
 wait_for_address() {
     for i in $(seq 500); do
-        ip -o -4 address | grep -w "eth0\|eth1\|eno1\|eno2\|eno12399\|eno12409" >/dev/null
+        ip -o -4 address | grep -w "eth0\|eth1\|eno1\|eno2\|eno12399\|eno12399np0\|eno12409\|eno12409np1" >/dev/null
         [ "$?" -eq 0 ] && return
         sleep 1
     done

--- a/ignitions/common/files/opt/sbin/setup-local-network
+++ b/ignitions/common/files/opt/sbin/setup-local-network
@@ -24,7 +24,7 @@ fi
 
 cat >/etc/systemd/network/01-eth0.network <<EOF
 [Match]
-Name=eth0 eno1 eno12399
+Name=eth0 eno1 eno12399 eno12399np0
 
 [Network]
 LLDP=true
@@ -40,7 +40,7 @@ EOF
 
 cat >/etc/systemd/network/01-eth1.network <<EOF
 [Match]
-Name=eth1 eno2 eno12409
+Name=eth1 eno2 eno12409 eno12409np1
 
 [Network]
 LLDP=true
@@ -89,6 +89,6 @@ wait_network() {
     done
 }
 
-wait_network eth0 "{{ index .Spec.IPv4 1 }}/{{ (index .Info.Network.IPv4 1).MaskBits }}" eth0 eno1 eno12399
-wait_network eth1 "{{ index .Spec.IPv4 2 }}/{{ (index .Info.Network.IPv4 2).MaskBits }}" eth1 eno2 eno12409
+wait_network eth0 "{{ index .Spec.IPv4 1 }}/{{ (index .Info.Network.IPv4 1).MaskBits }}" eth0 eno1 eno12399 eno12399np0
+wait_network eth1 "{{ index .Spec.IPv4 2 }}/{{ (index .Info.Network.IPv4 2).MaskBits }}" eth1 eno2 eno12409 eno12409np1
 wait_network node0 "{{ index .Spec.IPv4 0 }}/32" node0

--- a/ignitions/common/networkd/01-eth0.network
+++ b/ignitions/common/networkd/01-eth0.network
@@ -1,5 +1,5 @@
 [Match]
-Name=eth0 eno1 eno12399
+Name=eth0 eno1 eno12399 eno12399np0
 
 [Network]
 DHCP=yes

--- a/ignitions/common/networkd/01-eth1.network
+++ b/ignitions/common/networkd/01-eth1.network
@@ -1,5 +1,5 @@
 [Match]
-Name=eth1 eno2 eno12409
+Name=eth1 eno2 eno12409 eno12409np1
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
From [Flatcar Linux 3975](https://www.flatcar.org/releases#release-3975.2.0),  the port numbers are added to the network device names of our actual machines.
To accommodate this change, update the initialization scripts.