### PR TITLE
Disable endpoint-manager's gc in cilium-agent

### DIFF
--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -847,6 +847,7 @@ spec:
         - cilium-agent
         args:
         - --config-dir=/tmp/cilium/config-map
+        - --endpoint-gc-interval=0
         startupProbe:
           httpGet:
             host: "127.0.0.1"

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -20,6 +20,8 @@ enableIPv4Masquerade: false
 enableIdentityMark: false
 externalIPs:
   enabled: true
+extraArgs:
+  - "--endpoint-gc-interval=0"
 extraConfig:
   bpf-ct-timeout-regular-any: 1h0m0s
   bpf-ct-timeout-service-any: 1h0m0s

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -844,6 +844,7 @@ spec:
         - cilium-agent
         args:
         - --config-dir=/tmp/cilium/config-map
+        - --endpoint-gc-interval=0
         startupProbe:
           httpGet:
             host: "127.0.0.1"

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -20,6 +20,8 @@ enableIPv4Masquerade: false
 enableIdentityMark: false
 externalIPs:
   enabled: true
+extraArgs:
+  - "--endpoint-gc-interval=0"
 extraConfig:
   bpf-ct-timeout-regular-any: 1h0m0s
   bpf-ct-timeout-service-any: 1h0m0s

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -1075,6 +1075,7 @@ spec:
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
+        - --endpoint-gc-interval=0
         command:
         - cilium-agent
         env:

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -1066,6 +1066,7 @@ spec:
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
+        - --endpoint-gc-interval=0
         command:
         - cilium-agent
         env:


### PR DESCRIPTION
"endpoint-manager" which is a subsystem in cilium-agents has GC system.
This GC sometimes removes healthy CEP.
(I think this is due to poor coordination with Coil, but the root cause is not currently known.)

It was implemented as a way to deal with the bug with dockershim.
However, dockershim is not used in Neco and as far as I looked up I cannot find the CEP that has to be garbage collected.

This PR disables endpoint-manager's GC and avoid deleting healthy CEP.