### PR TITLE
Update cilium endpoint-create API rate-limit config in prod

### DIFF
--- a/cilium/prod/kustomization.yaml
+++ b/cilium/prod/kustomization.yaml
@@ -38,4 +38,5 @@ configMapGenerator:
   namespace: kube-system
   behavior: merge
   literals:
-  - api-rate-limit=endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2
+  - api-rate-limit=endpoint-create=auto-adjust:true,log:true,estimated-processing-duration:5s,max-parallel-requests:16
+

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -529,7 +529,7 @@ metadata:
 apiVersion: v1
 data:
   agent-not-ready-taint-key: node.cilium.io/agent-not-ready
-  api-rate-limit: endpoint-create=auto-adjust:true,mean-over:10,max-parallel-requests:4,min-parallel-requests:2
+  api-rate-limit: endpoint-create=auto-adjust:true,log:true,estimated-processing-duration:5s,max-parallel-requests:16
   arping-refresh-period: 30s
   auto-direct-node-routes: "false"
   bgp-announce-lb-ip: "true"


### PR DESCRIPTION
This is a follow-up PR for https://github.com/cybozu-go/neco/pull/2682 .
This PR updates Cilium endpoint-create API's rate-limit config in prod.