### PR TITLE
Fix cpu-governor.service to set performance governor for existing CPU

### DIFF
--- a/ignitions/roles/cs/systemd/cpu-governor.service
+++ b/ignitions/roles/cs/systemd/cpu-governor.service
@@ -4,7 +4,7 @@ Description=Set CPU governor to performance
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/sh -c '/usr/bin/echo "performance" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor'
+ExecStart=/bin/sh -c 'for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do if [ -e "$f" ]; then echo "performance" > "$f"; fi; done'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If we set SysProfile to `PerfOptimized`, there are no files in `/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor`.
In such situation, we want to skip cpu-governor.service.
