### PR TITLE
Use token to download a debian package

### DIFF
--- a/artifacts_ignore.yaml
+++ b/artifacts_ignore.yaml
@@ -13,4 +13,4 @@ images:
   versions: ["1.0.7"]
 osImage:
 - channel: stable
-  versions: ["4081.2.0"]
+  versions: ["4081.2.0","4081.2.1"]

--- a/worker/etcdpasswd.go
+++ b/worker/etcdpasswd.go
@@ -39,7 +39,11 @@ func (o *operator) UpdateEtcdpasswd(ctx context.Context, req *neco.UpdateRequest
 		if err != nil {
 			return err
 		}
-		err = InstallDebianPackage(ctx, o.proxyClient, o.ghClient, &deb, false, nil)
+		token, err := o.storage.GetGitHubToken(ctx)
+		if err != nil {
+			return err
+		}
+		err = InstallDebianPackage(ctx, o.proxyClient, token, o.ghClient, &deb, false, nil)
 		if err != nil {
 			return err
 		}

--- a/worker/operator.go
+++ b/worker/operator.go
@@ -108,7 +108,11 @@ func (o *operator) UpdateNeco(ctx context.Context, req *neco.UpdateRequest) erro
 	if env == neco.DevEnv {
 		deb.Release = "test-" + req.Version
 	}
-	return InstallDebianPackage(ctx, o.proxyClient, o.ghClient, deb, true, map[string]string{"HOME": "/home/cybozu"})
+	token, err := o.storage.GetGitHubToken(ctx)
+	if err != nil {
+		return err
+	}
+	return InstallDebianPackage(ctx, o.proxyClient, token, o.ghClient, deb, true, map[string]string{"HOME": "/home/cybozu"})
 }
 
 func (o *operator) FinalStep() int {


### PR DESCRIPTION
- Set bearer token in header.
- Change download url from `browser_download_url` to `url`. Because `browser_download_url` cannot be used with token.

ref. https://github.com/cybozu-private/neco-tasks/issues/529