### PR TITLE
Bump Argo CD version from 2.11.7 to 2.13.2 and its dependencies

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -12,10 +12,10 @@ STERN_VERSION = 1.31.0
 
 
 ## These should be updated regularly
-ARGOCD_VERSION = 2.11.7
+ARGOCD_VERSION = 2.13.2
 # Follow Argo CD installed kustomize version
 # https://github.com/cybozu/neco-containers/blob/main/argocd/Dockerfile#L10
-KUSTOMIZE_VERSION = 5.2.1
+KUSTOMIZE_VERSION = 5.4.3
 # Follow Argo CD installed google/go-jsonnet version
 # https://github.com/argoproj/argo-cd/blob/v${ARGOCD_VERSION}/go.mod
 JSONNET_VERSION = 0.20.0

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -266,7 +266,7 @@ kustomize: $(KUSTOMIZE_DOWNLOAD)
 	$(CP) $(KUSTOMIZE_DLDIR)/LICENSE $(DOCDIR)/$@/LICENSE
 	$(CP) $(KUSTOMIZE_DLDIR)/README.md $(DOCDIR)/$@/README.md
 	unzip -o $(KUSTOMIZE_DLDIR)/windows_amd64/kustomize.zip -d $(KUSTOMIZE_DLDIR)/windows_amd64
-	$(CP) $(KUSTOMIZE_DLDIR)/windows_amd64/kustomize $(WINDOWS_BINDIR)/kustomize.exe
+	$(CP) $(KUSTOMIZE_DLDIR)/windows_amd64/kustomize.exe $(WINDOWS_BINDIR)/kustomize.exe
 	$(CP) $(KUSTOMIZE_DLDIR)/LICENSE $(WINDOWS_DOCDIR)/$@/LICENSE
 	$(CP) $(KUSTOMIZE_DLDIR)/README.md $(WINDOWS_DOCDIR)/$@/README.md
 	$(CP) $(KUSTOMIZE_DLDIR)/darwin_amd64/kustomize $(MAC_BINDIR)/kustomize


### PR DESCRIPTION
- `JSONNET_VERSION` remains 0.20.0, no change required.
  https://github.com/argoproj/argo-cd/blob/dc43124058130db9a747d141d86d7c2f4aac7bf9/go.mod#L47
- kustomize 5.4.3 for windows binary has `.exe` extension.
  https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.4.3