### PR TITLE
Revert "Merge pull request #2785 from cybozu-go/cilium-operator-recrete"

### DIFF
--- a/cilium/dctest/upstream.yaml
+++ b/cilium/dctest/upstream.yaml
@@ -1292,7 +1292,10 @@ spec:
   # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
   # podAntiAffinity which prevents deployments of multiple operator replicas on the same node.
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/cilium/dctest/values.yaml
+++ b/cilium/dctest/values.yaml
@@ -76,9 +76,6 @@ nodePort:
   directRoutingDevice: "e+"
   enabled: true
 operator:
-  updateStrategy:
-    rollingUpdate: null
-    type: Recreate
   rollOutPods: true
   prometheus:
     enabled: true

--- a/cilium/pre/upstream.yaml
+++ b/cilium/pre/upstream.yaml
@@ -1294,7 +1294,10 @@ spec:
   # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
   # podAntiAffinity which prevents deployments of multiple operator replicas on the same node.
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/cilium/pre/values.yaml
+++ b/cilium/pre/values.yaml
@@ -78,9 +78,6 @@ nodePort:
   directRoutingDevice: "e+"
   enabled: true
 operator:
-  updateStrategy:
-    type: Recreate
-    rollingUpdate: null
   rollOutPods: true
   prometheus:
     enabled: true

--- a/cilium/prod/upstream.yaml
+++ b/cilium/prod/upstream.yaml
@@ -1291,7 +1291,10 @@ spec:
   # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
   # podAntiAffinity which prevents deployments of multiple operator replicas on the same node.
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/cilium/prod/values.yaml
+++ b/cilium/prod/values.yaml
@@ -75,9 +75,6 @@ nodePort:
   directRoutingDevice: "e+"
   enabled: true
 operator:
-  updateStrategy:
-    rollingUpdate: null
-    type: Recreate
   rollOutPods: true
   prometheus:
     enabled: true

--- a/etc/cilium-dctest.yaml
+++ b/etc/cilium-dctest.yaml
@@ -757,7 +757,10 @@ spec:
       io.cilium/app: operator
       name: cilium-operator
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/etc/cilium-pre.yaml
+++ b/etc/cilium-pre.yaml
@@ -757,7 +757,10 @@ spec:
       io.cilium/app: operator
       name: cilium-operator
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/etc/cilium.yaml
+++ b/etc/cilium.yaml
@@ -754,7 +754,10 @@ spec:
       io.cilium/app: operator
       name: cilium-operator
   strategy:
-    type: Recreate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 50%
+    type: RollingUpdate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
This reverts commit 96d2b10f27ad425845b7eb1df3fdb9a5c0b80986, reversing changes made to 8670e0e13d86e6c33d3d472c9a79c2947f1a056b.