### PR TITLE
sabakan-state-setter: Add config for monitoring Prometheus alerts

### DIFF
--- a/etc/sabakan-state-setter.yml
+++ b/etc/sabakan-state-setter.yml
@@ -115,3 +115,15 @@ machine-types:
           label-prefix:
             device: Disk.Direct.
         minimum-healthy-count: 2
+alert-monitor:
+  alertmanager-endpoint: http://vmalertmanager-vmalertmanager-largeset.monitoring.svc:9093/api/v2/
+  trigger-alerts:
+    - name: FailedToConnectBMC
+      serial-label: serial
+      state: unhealthy
+    - name: NodeNetworkDown
+      address-label: address
+      state: unhealthy
+    - name: NodeDiskMissing
+      address-label: address
+      state: unhealthy


### PR DESCRIPTION
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
See-also: https://github.com/cybozu-private/neco-tasks/issues/473
