### PR TITLE
Fix no-output termination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ commands:
           command: |
             if [ -f .skip ]; then exit 0; fi
             ./bin/run-dctest.sh bootstrap "<<parameters.tag>>" "<<parameters.datacenter>>"
-          no_output_timeout: 20m
+          no_output_timeout: 22m
 
   setup-tools:
     description: "setup tools"
@@ -242,7 +242,7 @@ jobs:
       - run:
           name: Run dctest functions
           command: ./bin/run-dctest-suite.sh functions
-          no_output_timeout: 20m
+          no_output_timeout: 22m
       - run:
           name: Set the instance lifetime and the state label
           command: |
@@ -271,7 +271,7 @@ jobs:
       - run:
           name: Run dctest reboot-worker
           command: ./bin/run-dctest-suite.sh reboot-worker
-          no_output_timeout: 51m
+          no_output_timeout: 52m
       - run:
           name: Set the instance lifetime and the state label
           command: |
@@ -300,7 +300,7 @@ jobs:
       - run:
           name: Run dctest upgrade
           command: ./bin/run-dctest-suite.sh upgrade
-          no_output_timeout: 20m
+          no_output_timeout: 22m
       - run:
           name: Set the instance lifetime
           command: |
@@ -345,7 +345,7 @@ jobs:
           command: |
             if [ -f .skip ]; then exit 0; fi
             ./bin/run-dctest-suite.sh functions
-          no_output_timeout: 20m
+          no_output_timeout: 22m
       - run:
           name: Set the instance lifetime
           command: |
@@ -383,7 +383,7 @@ jobs:
       - run:
           name: Run dctest upgrade release
           command: ./bin/run-dctest-suite.sh upgrade
-          no_output_timeout: 20m
+          no_output_timeout: 22m
       - run:
           name: Set the instance lifetime
           command: |

--- a/dctest/upgrade_test.go
+++ b/dctest/upgrade_test.go
@@ -249,7 +249,7 @@ func testUpgrade() {
 					return errors.New("cke uses unknown container image")
 				}
 				return nil
-			}, 19*time.Minute).Should(Succeed())
+			}, 20*time.Minute).Should(Succeed())
 		}
 	})
 


### PR DESCRIPTION
CircleCI terminates test programs when they run without output longer than a certain limit (default: 10m).
On the other hand, some Ginkgo jobs should wait for some time to see completion of slow work.

Therefore, we need to tell CircleCI to avoid terminating jobs longer than the period set to Ginkgo jobs.
This PR clarifies the division of responsibility:
- Ginkgo jobs can use round number
- CircleCI should wait for an extra time (set to 2m)

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
